### PR TITLE
Using latest tag for image names in helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ helm-upgrade-operator:
     --namespace ${NAMESPACE} \
     --create-namespace \
     --set image=${OPERATOR_DOCKER_IMG} \
-	--set externalScalerImage=${SCALER_DOCKER_IMG} \
-	--set interceptorImage=${INTERCEPTOR_DOCKER_IMG}
+	--set images.scaler=${SCALER_DOCKER_IMG} \
+	--set images.interceptor=${INTERCEPTOR_DOCKER_IMG}
 
 .PHONY: helm-delete-operator
 helm-delete-operator:

--- a/charts/keda-http-operator/templates/deployment.yaml
+++ b/charts/keda-http-operator/templates/deployment.yaml
@@ -32,14 +32,14 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
-        image: {{ .Values.image }}
+        image: {{ .Values.images.operator }}
         imagePullPolicy: Always
         name: manager
         env:
         - name: KEDAHTTP_OPERATOR_EXTERNAL_SCALER_IMAGE
-          value: {{ .Values.externalScalerImage }}
+          value: {{ .Values.images.scaler }}
         - name: KEDAHTTP_OPERATOR_INTERCEPTOR_IMAGE
-          value: {{ .Values.interceptorImage }}
+          value: {{ .Values.images.interceptor }}
         # resources:
         #   limits:
         #     cpu: 0.5

--- a/charts/keda-http-operator/values.yaml
+++ b/charts/keda-http-operator/values.yaml
@@ -1,2 +1,4 @@
 version: v0.1.0-v1alpha1
-image: arschles/keda-http-operator
+image: ghcr.io/kedacore/http-add-on-operator
+interceptorImage: ghcr.io/kedacore/http-add-on-interceptor
+externalScalerImage: ghcr.io/kedacore/http-add-on-scaler

--- a/charts/keda-http-operator/values.yaml
+++ b/charts/keda-http-operator/values.yaml
@@ -1,4 +1,5 @@
 version: v0.1.0-v1alpha1
-image: ghcr.io/kedacore/http-add-on-operator:latest
-interceptorImage: ghcr.io/kedacore/http-add-on-interceptor:latest
-externalScalerImage: ghcr.io/kedacore/http-add-on-scaler:latest
+images:
+  operator: ghcr.io/kedacore/http-add-on-operator:latest
+  interceptor: ghcr.io/kedacore/http-add-on-interceptor:latest
+  scaler: ghcr.io/kedacore/http-add-on-scaler:latest

--- a/charts/keda-http-operator/values.yaml
+++ b/charts/keda-http-operator/values.yaml
@@ -1,4 +1,4 @@
 version: v0.1.0-v1alpha1
-image: ghcr.io/kedacore/http-add-on-operator
-interceptorImage: ghcr.io/kedacore/http-add-on-interceptor
-externalScalerImage: ghcr.io/kedacore/http-add-on-scaler
+image: ghcr.io/kedacore/http-add-on-operator:latest
+interceptorImage: ghcr.io/kedacore/http-add-on-interceptor:latest
+externalScalerImage: ghcr.io/kedacore/http-add-on-scaler:latest

--- a/docs/install.md
+++ b/docs/install.md
@@ -56,8 +56,8 @@ helm upgrade kedahttp ./charts/keda-http-operator \
     --namespace ${NAMESPACE} \
     --create-namespace \
     --set image=localhost:32000/keda-http-operator \
-	--set externalScalerImage=localhost:32000/keda-http-scaler \
-	--set interceptorImage=localhost:32000/keda-http-interceptor
+	--set images.scaler=localhost:32000/keda-http-scaler \
+	--set images.interceptor=localhost:32000/keda-http-interceptor
 ```
 
 In the above command, `localhost:32000` is the address of the registry from inside a Microk8s cluster.


### PR DESCRIPTION
Now that images are pushed automatically to GitHub Container registry in #40, we can reference them in the helm chart. The `latest` tag is pushed on each tag release, so we're using that here.

This is approximately the same patch as #45 except specifying `latest` explicitly.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Closes: #45 - this is a replacement

Credit @khaosdoctor for this change. I'm only submitting it because he's out today and we want to get the release done today.
