### PR TITLE
Adding automated link checking to documentation

### DIFF
--- a/.github/workflows/linkinator.yaml
+++ b/.github/workflows/linkinator.yaml
@@ -1,7 +1,9 @@
 name: Check links on all markdown documents
 on:
   push:
-    branches: [ main ]
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   linkinator:

--- a/.github/workflows/linkinator.yaml
+++ b/.github/workflows/linkinator.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   linkinator:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: JustinBeckwith/linkinator-action@v1

--- a/.github/workflows/linkinator.yaml
+++ b/.github/workflows/linkinator.yaml
@@ -1,0 +1,15 @@
+name: Check links on all markdown documents
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  linkinator:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JustinBeckwith/linkinator-action@v1
+        with:
+          paths: "**/*.md"
+          markdown: true
+          retry: true


### PR DESCRIPTION
This PR adds a GitHub action that automatically checks all links in all Markdown documents in the repository when a PR (targeting the main branch) is opened.

Thanks to @bnb for this code. I took most of it from https://github.com/nodejs/community-committee/pull/658/files

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

