### PR TITLE
changing default image names in Makefile to GH container registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GIT_TAG?=$(shell git rev-parse --short HEAD)
-SCALER_DOCKER_IMG?=arschles/keda-http-scaler:${GIT_TAG}
-INTERCEPTOR_DOCKER_IMG?=arschles/keda-http-interceptor:${GIT_TAG}
-OPERATOR_DOCKER_IMG?=arschles/keda-http-operator:${GIT_TAG}
+SCALER_DOCKER_IMG?=ghcr.io/kedacore/http-add-on-scaler:sha-${GIT_SHA}
+INTERCEPTOR_DOCKER_IMG?=ghcr.io/kedacore/keda-http-interceptor:sha-${GIT_TAG}
+OPERATOR_DOCKER_IMG?=ghcr.io/kedacore/keda-http-operator:sha-${GIT_TAG}
 NAMESPACE?=kedahttp
 
 #####


### PR DESCRIPTION
The `Makefile` still had `arschles/keda-http-{scaler, operator, interceptor}` image names in it. Now that we've moved the official images to GH container registry, this patch changes the image names to `ghcr.io/kedacore/http-add-on-{scaler, operator, interceptor}` image names

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] (N/A) A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)
