### PR TITLE
Adding additional printer columns to HTTPScaledObjects

### DIFF
--- a/charts/keda-http-operator/crds/httpscaledobjects.http.keda.sh.yaml
+++ b/charts/keda-http-operator/crds/httpscaledobjects.http.keda.sh.yaml
@@ -13,13 +13,36 @@ spec:
     kind: HTTPScaledObject
     listKind: HTTPScaledObjectList
     plural: httpscaledobjects
+    shortNames:
+    - httpso
     singular: httpscaledobject
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.scaleTargetRef.deploymentName
+      name: ScaleTargetDeploymentName
+      type: string
+    - jsonPath: .spec.scaleTargetRef
+      name: ScaleTargetServiceName
+      type: string
+    - jsonPath: .spec.scaleTargetRef
+      name: ScaleTargetPort
+      type: integer
+    - jsonPath: .spec.replicas.min
+      name: MinReplicas
+      type: integer
+    - jsonPath: .spec.replicas.max
+      name: MaxReplicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="HTTPScaledObjectIsReady")].status
+      name: Active
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: HTTPScaledObject is the Schema for the scaledobjects API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/operator/api/v1alpha1/httpscaledobject_types.go
+++ b/operator/api/v1alpha1/httpscaledobject_types.go
@@ -138,6 +138,15 @@ type HTTPScaledObjectStatus struct {
 // HTTPScaledObject is the Schema for the scaledobjects API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:path=httpscaledobjects,scope=Namespaced,shortName=httpso
+// +kubebuilder:printcolumn:name="ScaleTargetDeploymentName",type="string",JSONPath=".spec.scaleTargetRef.deploymentName"
+// +kubebuilder:printcolumn:name="ScaleTargetServiceName",type="string",JSONPath=".spec.scaleTargetRef"
+// +kubebuilder:printcolumn:name="ScaleTargetPort",type="integer",JSONPath=".spec.scaleTargetRef"
+// +kubebuilder:printcolumn:name="MinReplicas",type="integer",JSONPath=".spec.replicas.min"
+// +kubebuilder:printcolumn:name="MaxReplicas",type="integer",JSONPath=".spec.replicas.max"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Active",type="string",JSONPath=".status.conditions[?(@.type==\"HTTPScaledObjectIsReady\")].status"
+
 type HTTPScaledObject struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/operator/config/crd/bases/http.keda.sh_httpscaledobjects.yaml
+++ b/operator/config/crd/bases/http.keda.sh_httpscaledobjects.yaml
@@ -13,13 +13,36 @@ spec:
     kind: HTTPScaledObject
     listKind: HTTPScaledObjectList
     plural: httpscaledobjects
+    shortNames:
+    - httpso
     singular: httpscaledobject
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.scaleTargetRef.deploymentName
+      name: ScaleTargetDeploymentName
+      type: string
+    - jsonPath: .spec.scaleTargetRef
+      name: ScaleTargetServiceName
+      type: string
+    - jsonPath: .spec.scaleTargetRef
+      name: ScaleTargetPort
+      type: integer
+    - jsonPath: .spec.replicas.min
+      name: MinReplicas
+      type: integer
+    - jsonPath: .spec.replicas.max
+      name: MaxReplicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="HTTPScaledObjectIsReady")].status
+      name: Active
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: HTTPScaledObject is the Schema for the scaledobjects API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'


### PR DESCRIPTION
This PR adds additional (custom) columns to the HTTPScaledObject CRD. It uses the `+kubebuilder:printcolumn` comments on the Go struct, which results in `additionalPrinterColumns` on the generated CRD.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #119

cc/ @tomkerkhove 