### PR TITLE
Using proper go versions in dockerfiles

### DIFF
--- a/interceptor/Dockerfile
+++ b/interceptor/Dockerfile
@@ -1,6 +1,6 @@
 # adapted from Athens
 # https://github.com/gomods/athens/blob/main/cmd/proxy/Dockerfile
-ARG GOLANG_VERSION=1.14
+ARG GOLANG_VERSION=1.16
 ARG ALPINE_VERSION=3.11.5
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,6 +1,6 @@
 # adapted from Athens 
 # https://github.com/gomods/athens/blob/main/cmd/proxy/Dockerfile
-ARG GOLANG_VERSION=1.14
+ARG GOLANG_VERSION=1.16
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 

--- a/scaler/Dockerfile
+++ b/scaler/Dockerfile
@@ -1,6 +1,6 @@
 # taken from Athens
 # https://github.com/gomods/athens/blob/main/cmd/proxy/Dockerfile
-ARG GOLANG_VERSION=1.14
+ARG GOLANG_VERSION=1.16
 ARG ALPINE_VERSION=3.11.5
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder


### PR DESCRIPTION
The dockerfiles for scaler, interceptor and operator all defaulted to Go version 1.14. Since we're now using the [`embed`](https://godoc.org/embed) package, which is available in 1.16 and above, we need to change that.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
