### PR TITLE
fixing docker push actions

### DIFF
--- a/.github/workflows/build_canary.yml
+++ b/.github/workflows/build_canary.yml
@@ -36,14 +36,15 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          repository: ${{ github.repository_owner }}/http-add-on-operator
-          tags: canary,sha-${{steps.prep.outputs.sha}}
+          tags: |
+            ${{ github.repository_owner }}/http-add-on-operator:canary,${{ github.repository_owner }}/http-add-on-operator:sha-${{ steps.prep.outputs.sha }}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
             sh.keda.http.image.revision=${{github.sha}}
           file: operator/Dockerfile
           context: .
+          push: true
 
   build_interceptor:
 
@@ -75,14 +76,14 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          repository: ${{ github.repository_owner }}/http-add-on-interceptor
-          tags: canary,sha-${{steps.prep.outputs.sha}}
+          tags: ${{ github.repository_owner }}/http-add-on-interceptor:canary,${{ github.repository_owner }}/http-add-on-interceptor:sha-${{steps.prep.outputs.sha}}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
             sh.keda.http.image.revision=${{github.sha}}
           file: interceptor/Dockerfile
           context: .
+          push: true
 
   build_scaler:
     runs-on: ubuntu-20.04
@@ -113,11 +114,11 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          repository: ${{ github.repository_owner }}/http-add-on-scaler
-          tags: canary,sha-${{steps.prep.outputs.sha}}
+          tags: ${{ github.repository_owner }}/http-add-on-scaler:canary,${{ github.repository_owner }}/http-add-on-scaler:sha-${{steps.prep.outputs.sha}}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
             sh.keda.http.image.revision=${{github.sha}}
           file: scaler/Dockerfile
           context: .
+          push: true

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -34,8 +34,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          repository: ${{ github.repository_owner }}/http-add-on-operator
-          tags: latest,${GITHUB_REF#refs/tags/}
+          tags: ${{ github.repository_owner }}/http-add-on-operator:latest,${{ github.repository_owner }}/http-add-on-scaler:${GITHUB_REF#refs/tags/}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
@@ -43,6 +42,7 @@ jobs:
             sh.keda.http.image.release=${{github.ref}}
           file: operator/Dockerfile
           context: .
+          push: true
 
   build_interceptor:
 
@@ -73,8 +73,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          repository: ${{ github.repository_owner }}/http-add-on-interceptor
-          tags: latest,${GITHUB_REF#refs/tags/}
+          tags: ${{ github.repository_owner }}/http-add-on-interceptor:latest,${{ github.repository_owner }}/http-add-on-scaler:${GITHUB_REF#refs/tags/}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
@@ -82,6 +81,7 @@ jobs:
             sh.keda.http.image.release=${{github.ref}}
           file: interceptor/Dockerfile
           context: .
+          push: true
 
   build_scaler:
     runs-on: ubuntu-20.04
@@ -111,8 +111,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          repository: ${{ github.repository_owner }}/http-add-on-scaler
-          tags: latest,${GITHUB_REF#refs/tags/}
+          tags: ${{ github.repository_owner }}/http-add-on-scaler:latest,${{ github.repository_owner }}/http-add-on-scaler:${GITHUB_REF#refs/tags/}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
@@ -120,3 +119,4 @@ jobs:
             sh.keda.http.image.release=${{github.ref}}
           file: scaler/Dockerfile
           context: .
+          push: true


### PR DESCRIPTION
The canary and release push actions were broken. This PR fixes them

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [`docs/`](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
