### PR TITLE
Using namespaces in the magefile

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -54,7 +54,7 @@ check the [Magefile](../magefile.go) source code. Below is a list of the most co
 In the root directory:
 
 - `mage All`: Builds all the binaries for local testing.
-- `mage deleteOperator [namespace]`: Deletes the installed add-on in the given `namespace` for the active K8S
+- `mage operator:deleterelease [namespace]`: Deletes the installed add-on in the given `namespace` for the active K8S
   cluster.
 - `mage dockerBuildAll <repository>`: Builds all the images for the `interceptor`, `scaler`, and `operator` modules
   for the specified `repository`.
@@ -72,6 +72,6 @@ In the root directory:
 
 In the operator directory:
 
-- `mage Manifests`: Builds all the manifest files for Kubernetes, it's important to build after every change
+- `mage operator:manifests`: Builds all the manifest files for Kubernetes, it's important to build after every change
   to a Kustomize annotation.
-- `mage All`: Generates the operator.
+- `mage all`: Builds all binaries.


### PR DESCRIPTION
Using `mg.Namespace` to namespace magefile actions for the operator, scaler and interceptor. This leads to commands like `mage interceptor:build` instead of `mage buildInterceptor`. The namespace is built into the type system instead of forcing us to bake in namespaces to the mage targets.

### Checklist

- [ ] Update all documentation
- [ ] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [`docs/`](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
