### PR TITLE
using GITHUB_TOKEN for docker images

### DIFF
--- a/.github/workflows/build_canary.yml
+++ b/.github/workflows/build_canary.yml
@@ -67,8 +67,8 @@ jobs:
         with:
           # Username used to log in to a Docker registry. If not set then no login will occur
           username: ${{ github.repository_owner }}
-          # Password or personal access token used to log in to a Docker registry. If not set then no login will occur
-          password: ${{ secrets.GHCR_AUTH_PAT }}
+          # https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/
+          password: ${{ secrets.GITHUB_TOKEN }}
           # Server address of Docker registry. If not set then will default to Docker Hub
           registry: ghcr.io
 


### PR DESCRIPTION
Instead of using a PAT and storing it in the GH actions secrets list, we can now use `GITHUB_TOKEN`. See [this blog post](https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/) for more.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [`docs/`](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #147 
