### PR TITLE
fix: Push images to GitHub Container Registry, not Docker Hub

### DIFF
--- a/.github/workflows/build_canary.yml
+++ b/.github/workflows/build_canary.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+env:
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+  IMAGE_OPERATOR_NAME: ${{ env.IMAGE_PREFIX }}/http-add-on-operator
+  IMAGE_INTERCEPTOR_NAME: ${{ env.IMAGE_PREFIX }}/http-add-on-interceptor
+  IMAGE_SCALER_NAME: ${{ env.IMAGE_PREFIX }}/http-add-on-scaler
+
 jobs:
   build_operator:
 
@@ -37,7 +43,7 @@ jobs:
         with:
           # Docker repository to tag the image with
           tags: |
-            ${{ github.repository_owner }}/http-add-on-operator:canary,${{ github.repository_owner }}/http-add-on-operator:sha-${{ steps.prep.outputs.sha }}
+            ${{ env.IMAGE_OPERATOR_NAME }}:canary,${{ env.IMAGE_OPERATOR_NAME }}:sha-${{ steps.prep.outputs.sha }}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
@@ -76,7 +82,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          tags: ${{ github.repository_owner }}/http-add-on-interceptor:canary,${{ github.repository_owner }}/http-add-on-interceptor:sha-${{steps.prep.outputs.sha}}
+          tags: ${{ env.IMAGE_INTERCEPTOR_NAME }}:canary,${{ env.IMAGE_INTERCEPTOR_NAME }}:sha-${{steps.prep.outputs.sha}}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
@@ -114,7 +120,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          tags: ${{ github.repository_owner }}/http-add-on-scaler:canary,${{ github.repository_owner }}/http-add-on-scaler:sha-${{steps.prep.outputs.sha}}
+          tags: ${{ env.IMAGE_SCALER_NAME }}:canary,${{ env.IMAGE_SCALER_NAME }}:sha-${{steps.prep.outputs.sha}}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags: [ "v[0-9].[0-9].[0-9]" ]
 
+env:
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+  IMAGE_OPERATOR_NAME: ${{ env.IMAGE_PREFIX }}/http-add-on-operator
+  IMAGE_INTERCEPTOR_NAME: ${{ env.IMAGE_PREFIX }}/http-add-on-interceptor
+  IMAGE_SCALER_NAME: ${{ env.IMAGE_PREFIX }}/http-add-on-scaler
+
 jobs:
   build_operator:
 
@@ -34,7 +40,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          tags: ${{ github.repository_owner }}/http-add-on-operator:latest,${{ github.repository_owner }}/http-add-on-scaler:${GITHUB_REF#refs/tags/}
+          tags: ${{ env.IMAGE_OPERATOR_NAME }}:latest,${{ env.IMAGE_OPERATOR_NAME }}:${GITHUB_REF#refs/tags/}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
@@ -73,7 +79,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          tags: ${{ github.repository_owner }}/http-add-on-interceptor:latest,${{ github.repository_owner }}/http-add-on-scaler:${GITHUB_REF#refs/tags/}
+          tags: ${{ env.IMAGE_INTERCEPTOR_NAME }}:latest,${{ env.IMAGE_INTERCEPTOR_NAME }}:${GITHUB_REF#refs/tags/}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
@@ -111,7 +117,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          tags: ${{ github.repository_owner }}/http-add-on-scaler:latest,${{ github.repository_owner }}/http-add-on-scaler:${GITHUB_REF#refs/tags/}
+          tags: ${{ env.IMAGE_SCALER_NAME }}:latest,${{ env.IMAGE_SCALER_NAME }}:${GITHUB_REF#refs/tags/}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Push images to GitHub Container Registry, not Docker Hub

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [`docs/`](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Followup for https://github.com/kedacore/http-add-on/pull/156