### PR TITLE
fix: Don't use env. in environment definitions

### DIFF
--- a/.github/workflows/build_canary.yml
+++ b/.github/workflows/build_canary.yml
@@ -6,10 +6,9 @@ on:
   workflow_dispatch:
 
 env:
-  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
-  IMAGE_OPERATOR_NAME: ${{ env.IMAGE_PREFIX }}/http-add-on-operator
-  IMAGE_INTERCEPTOR_NAME: ${{ env.IMAGE_PREFIX }}/http-add-on-interceptor
-  IMAGE_SCALER_NAME: ${{ env.IMAGE_PREFIX }}/http-add-on-scaler
+  IMAGE_OPERATOR_NAME: ghcr.io/${{ github.repository_owner }}/http-add-on-operator
+  IMAGE_INTERCEPTOR_NAME: ghcr.io/${{ github.repository_owner }}/http-add-on-interceptor
+  IMAGE_SCALER_NAME: ghcr.io/${{ github.repository_owner }}/http-add-on-scaler
 
 jobs:
   build_operator:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -5,10 +5,9 @@ on:
     tags: [ "v[0-9].[0-9].[0-9]" ]
 
 env:
-  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
-  IMAGE_OPERATOR_NAME: ${{ env.IMAGE_PREFIX }}/http-add-on-operator
-  IMAGE_INTERCEPTOR_NAME: ${{ env.IMAGE_PREFIX }}/http-add-on-interceptor
-  IMAGE_SCALER_NAME: ${{ env.IMAGE_PREFIX }}/http-add-on-scaler
+  IMAGE_OPERATOR_NAME: ghcr.io/${{ github.repository_owner }}/http-add-on-operator
+  IMAGE_INTERCEPTOR_NAME: ghcr.io/${{ github.repository_owner }}/http-add-on-interceptor
+  IMAGE_SCALER_NAME: ghcr.io/${{ github.repository_owner }}/http-add-on-scaler
 
 jobs:
   build_operator:


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

Don't use env. in environment definitions which is not supported.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [`docs/`](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
