### PR TITLE
Adding GOOS and GOARCH to the Dockerfiles

### DIFF
--- a/interceptor/Dockerfile
+++ b/interceptor/Dockerfile
@@ -1,7 +1,8 @@
 # adapted from Athens
 # https://github.com/gomods/athens/blob/main/cmd/proxy/Dockerfile
 ARG GOLANG_VERSION=1.16
-ARG ALPINE_VERSION=3.11.5
+ARG GOARCH=amd64
+ARG GOOS=linux
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 
@@ -15,6 +16,8 @@ COPY . .
 
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
+ENV GOOS=${GOOS}
+ENV GOARCH=${GOARCH}
 ENV GOPROXY="https://proxy.golang.org"
 RUN go build -o /bin/interceptor ./interceptor
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,6 +1,8 @@
 # adapted from Athens 
 # https://github.com/gomods/athens/blob/main/cmd/proxy/Dockerfile
 ARG GOLANG_VERSION=1.16
+ARG GOARCH=amd64
+ARG GOOS=linux
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 
@@ -14,6 +16,8 @@ COPY . .
 
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
+ENV GOOS=${GOOS}
+ENV GOARCH=${GOARCH}
 ENV GOPROXY="https://proxy.golang.org"
 
 # Build

--- a/scaler/Dockerfile
+++ b/scaler/Dockerfile
@@ -1,7 +1,9 @@
 # taken from Athens
 # https://github.com/gomods/athens/blob/main/cmd/proxy/Dockerfile
 ARG GOLANG_VERSION=1.16
-ARG ALPINE_VERSION=3.11.5
+ARG GOARCH=amd64
+ARG GOOS=linux
+
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 
@@ -15,6 +17,8 @@ COPY . .
 
 ENV GO111MODULE=on
 ENV CGO_ENABLED=0
+ENV GOOS=${GOOS}
+ENV GOARCH=${GOARCH}
 ENV GOPROXY="https://proxy.golang.org"
 RUN go build -o /bin/scaler ./scaler
 


### PR DESCRIPTION
This patch ensures that all Go binaries are built inside Docker images with `GOOS` and `GOARCH` env variables set. They default to `GOOS=linux` and `GOARCH=amd64` but can be overridden via [docker build arguments](https://blog.dockbit.com/making-use-of-docker-build-arguments-68792d751f3)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [`docs/`](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #185 
