### PR TITLE
setting proper tag version in release script

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -21,6 +21,11 @@ jobs:
         id: prep
         run: |
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      
+      - name: Get the version
+        id: get_version
+        run: |
+          echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v1
@@ -39,7 +44,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          tags: ${{ env.IMAGE_OPERATOR_NAME }}:latest,${{ env.IMAGE_OPERATOR_NAME }}:${GITHUB_REF#refs/tags/v}
+          tags: ${{ env.IMAGE_OPERATOR_NAME }}:latest,${{ env.IMAGE_OPERATOR_NAME }}:${{ steps.get_version.outputs.VERSION }}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
@@ -78,7 +83,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          tags: ${{ env.IMAGE_INTERCEPTOR_NAME }}:latest,${{ env.IMAGE_INTERCEPTOR_NAME }}:${GITHUB_REF#refs/tags/v}
+          tags: ${{ env.IMAGE_INTERCEPTOR_NAME }}:latest,${{ env.IMAGE_INTERCEPTOR_NAME }}:${{ steps.get_version.outputs.VERSION }}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
@@ -116,7 +121,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # Docker repository to tag the image with
-          tags: ${{ env.IMAGE_SCALER_NAME }}:latest,${{ env.IMAGE_SCALER_NAME }}:${GITHUB_REF#refs/tags/v}
+          tags: ${{ env.IMAGE_SCALER_NAME }}:latest,${{ env.IMAGE_SCALER_NAME }}:${{ steps.get_version.outputs.VERSION }}
           labels: |
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}


### PR DESCRIPTION
Before this PR, the GitHub action for releasing a tag version was failing as such: 

```
error: invalid tag "ghcr.io/kedacore/http-add-on-operator:${GITHUB_REF#refs/tags/v}": invalid reference format
107
Error: buildx call failed with: error: invalid tag "ghcr.io/kedacore/http-add-on-operator:${GITHUB_REF#refs/tags/v}": invalid reference format
```

(see https://github.com/kedacore/http-add-on/runs/2906000365?check_suite_focus=true#step:6:107 for this log line)

this PR hopefully fixes that. since there is no way to reliably test GH actions locally, we have to wait and see.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
