### PR TITLE
Fixing kubectl command in walkthrough documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The KEDA HTTP Add On allows Kubernetes users to automatically scale their HTTP s
 
 | 🚧 **Project status: beta** 🚧|
 |---------------------------------------------|
-| ⚠ The HTTP add-on currently is in [beta](https://github.com/kedacore/http-add-on/releases/tag/0.1.0). We can't yet recommend it for production usage because we are still developing and testing it. It may have "rough edges" including missing documentation, bugs and other issues. It is currently provided as-is without support.
+| ⚠ The HTTP add-on currently is in [beta](https://github.com/kedacore/http-add-on/releases/tag/v0.1.0). We can't yet recommend it for production usage because we are still developing and testing it. It may have "rough edges" including missing documentation, bugs and other issues. It is currently provided as-is without support.
 
 ## HTTP Autoscaling Made Simple
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -2,7 +2,9 @@
 
 After you've installed KEDA and the HTTP Add On (this project, we'll call it the "add on" for short), this document will show you how to get started with an example app.
 
-If you haven't installed KEDA and the HTTP Add On (this project), please do so first. Follow instructions [install.md](./install.md) to complete your installation. Before you continue, make sure that you have your `NAMESPACE` environment variable set to the same value as it was when you installed.
+If you haven't installed KEDA and the HTTP Add On (this project), please do so first. Follow instructions [install.md](./install.md) to complete your installation.
+
+>Before you continue, make sure that you have your `NAMESPACE` environment variable set to the same value as it was when you installed.
 
 ## Creating An Application
 
@@ -31,7 +33,7 @@ kubectl create -f -n $NAMESPACE examples/v0.0.2/httpscaledobject.yaml
 You've now installed a web application and activated autoscaling by creating an `HTTPScaledObject` for it. For autoscaling to work properly, HTTP traffic needs to route through the `Service` that the add on has set up. You can use `kubectl port-forward` to quickly test things out:
 
 ```shell
-k port-forward svc/xkcd-interceptor-proxy -n ${NAMESPACE} 8080:80
+kubectl port-forward svc/xkcd-interceptor-proxy -n ${NAMESPACE} 8080:80
 ```
 
 ### Routing to the Right `Service`


### PR DESCRIPTION
The existing `port-forward` command used the `k` alias. This PR:

- changes that command to be `kubectl` so that folks who don't have that alias set up will still be able to use it properly
- emphasizes the need to set up your `NAMESPACE` env var.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

