### PR TITLE
chore: KEDA was accepted as CNCF Incubation project

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This project follows the KEDA contributing guidelines, which are outlined in [CO
 If you would like to contribute code to this project, please see [docs/developing.md](./docs/developing.md).
 
 ---
-We are a Cloud Native Computing Foundation (CNCF) sandbox project.
+We are a Cloud Native Computing Foundation (CNCF) incubation project.
 <p align="center"><img src="https://raw.githubusercontent.com/kedacore/keda/main/images/logo-cncf.svg" height="75px"></p>
 
 ## Code of Conduct


### PR DESCRIPTION
KEDA was accepted as CNCF Incubation project as per https://github.com/cncf/toc/pull/622

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Relates to https://github.com/kedacore/governance/issues/2
