### PR TITLE
Adding Ajanth as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-*       @ahmelsayed @zroubalik @tomkerkhove @arschles @khaosdoctor
+*       @ahmelsayed @zroubalik @tomkerkhove @arschles @khaosdoctor @ajanth97


### PR DESCRIPTION
@ajanth97 has been a regular contributor - of code, reviews, issues and design - to this repository. This patch adds him as a code owner.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
