### PR TITLE
Adding test for interceptor headers and redirection

### DIFF
--- a/interceptor/request_forwarder_test.go
+++ b/interceptor/request_forwarder_test.go
@@ -237,3 +237,40 @@ func TestForwarderConnectionRetryAndTimeout(t *testing.T) {
 	)
 	r.Contains(res.Body.String(), "error on backend")
 }
+
+func TestForwardRequestRedirectAndHeaders(t *testing.T) {
+	r := require.New(t)
+
+	srv, srvURL, err := kedanet.StartTestServer(
+		kedanet.NewTestHTTPHandlerWrapper(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.Header().Set("X-Custom-Header", "somethingcustom")
+				w.Header().Set("Location", "abc123.com")
+				w.WriteHeader(301)
+				w.Write([]byte("Hello from srv"))
+			}),
+		),
+	)
+	r.NoError(err)
+	defer srv.Close()
+
+	timeouts := defaultTimeouts()
+	timeouts.Connect = 10 * time.Millisecond
+	timeouts.ResponseHeader = 10 * time.Millisecond
+	backoff := timeouts.Backoff(2, 2, 1)
+	dialCtxFunc := retryDialContextFunc(timeouts, backoff)
+	res, req, err := reqAndRes("/testfwd")
+	r.NoError(err)
+	forwardRequest(
+		res,
+		req,
+		newRoundTripper(dialCtxFunc, timeouts.ResponseHeader),
+		srvURL,
+	)
+	r.Equal(301, res.Code)
+	r.Equal("abc123.com", res.Header().Get("Location"))
+	r.Equal("text/html; charset=utf-8", res.Header().Get("Content-Type"))
+	r.Equal("somethingcustom", res.Header().Get("X-Custom-Header"))
+	r.Equal("Hello from srv", res.Body.String())
+}


### PR DESCRIPTION
This patch adds a test to ensure that the interceptor handles headers - including `Location` header and `301` response codes - properly.

This is a proposed solution to #249 based on https://github.com/kedacore/http-add-on/issues/249#issuecomment-917158376

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #249

cc/ @yaron2 