### PR TITLE
Adding config endpoints on admin servers for scaler, interceptor and operator

### DIFF
--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -135,6 +135,8 @@ func main() {
 			routingTable,
 			deployCache,
 			adminPort,
+			servingCfg,
+			timeoutCfg,
 		)
 		lggr.Error(err, "admin server failed")
 		return err
@@ -177,6 +179,8 @@ func runAdminServer(
 	routingTable *routing.Table,
 	deployCache k8s.DeploymentCache,
 	port int,
+	servingConfig *config.Serving,
+	timeoutConfig *config.Timeouts,
 ) error {
 	lggr = lggr.WithName("runAdminServer")
 	adminServer := nethttp.NewServeMux()
@@ -205,6 +209,7 @@ func runAdminServer(
 			}
 		},
 	)
+	kedahttp.AddConfigEndpoint(lggr, adminServer, servingConfig, timeoutConfig)
 
 	addr := fmt.Sprintf("0.0.0.0:%d", port)
 	lggr.Info("admin server starting", "address", addr)

--- a/pkg/http/config_endpoint.go
+++ b/pkg/http/config_endpoint.go
@@ -1,0 +1,20 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-logr/logr"
+)
+
+func AddConfigEndpoint(lggr logr.Logger, mux *http.ServeMux, configs ...interface{}) {
+	mux.HandleFunc("/config", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"configs": configs,
+		}); err != nil {
+			lggr.Error(err, "failed to encode configs")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+		}
+	})
+}


### PR DESCRIPTION
Adding endpoints to fetch configuration from interceptor, scaler and operator

### Checklist

- [x] interceptor
- [ ] scaler
- [ ] operator
- [ ] tests
- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Any necessary documentation is added, such as:
  - [`developing.md`](/docs/developing.md)
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #278
