### PR TITLE
Fixing typo in go comment

### DIFF
--- a/scaler/queue_pinger_test.go
+++ b/scaler/queue_pinger_test.go
@@ -65,7 +65,7 @@ func TestRequestCounts(t *testing.T) {
 	retCounts := pinger.counts()
 	r.Equal(0, len(retCounts))
 
-	// reset the ticker to tick practically immediatly. sleep for a little
+	// reset the ticker to tick practically immediately. sleep for a little
 	// bit to ensure that the tick occurred and the counts were successfully
 	// computed, then check them.
 	ticker.Reset(1 * time.Nanosecond)


### PR DESCRIPTION
This simple patch only fixes a typo in a comment in a test.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
