### PR TITLE
Adding golang-ci lint checks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,5 +16,9 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.16.x
+    - name: Lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.29
     - name: Test
       run: go test ./...

--- a/e2e/k8s.go
+++ b/e2e/k8s.go
@@ -2,12 +2,10 @@ package e2e
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/kedacore/http-add-on/pkg/k8s"
 	"github.com/magefile/mage/sh"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,14 +30,6 @@ func getClient() (
 
 func deleteNS(ns string) error {
 	return sh.RunV("kubectl", "delete", "namespace", ns)
-}
-
-func getPortStrings(svc *corev1.Service) []string {
-	ret := []string{}
-	for _, port := range svc.Spec.Ports {
-		ret = append(ret, strconv.Itoa(int(port.Port)))
-	}
-	return ret
 }
 
 func getScaledObject(

--- a/interceptor/middleware.go
+++ b/interceptor/middleware.go
@@ -34,7 +34,9 @@ func countMiddleware(
 		if err != nil {
 			lggr.Error(err, "not forwarding request")
 			w.WriteHeader(400)
-			w.Write([]byte("Host not found, not forwarding request"))
+			if _, err := w.Write([]byte("Host not found, not forwarding request")); err != nil {
+				lggr.Error(err, "could not write error message to client")
+			}
 			return
 		}
 		if err := q.Resize(host, +1); err != nil {

--- a/interceptor/middleware_test.go
+++ b/interceptor/middleware_test.go
@@ -23,9 +23,10 @@ func TestCountMiddleware(t *testing.T) {
 	middleware := countMiddleware(
 		logr.Discard(),
 		queueCounter,
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(200)
-			w.Write([]byte("OK"))
+		http.HandlerFunc(func(wr http.ResponseWriter, req *http.Request) {
+			wr.WriteHeader(200)
+			_, err := wr.Write([]byte("OK"))
+			r.NoError(err)
 		}),
 	)
 

--- a/interceptor/request_forwarder.go
+++ b/interceptor/request_forwarder.go
@@ -5,9 +5,12 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+
+	"github.com/go-logr/logr"
 )
 
 func forwardRequest(
+	lggr logr.Logger,
 	w http.ResponseWriter,
 	r *http.Request,
 	roundTripper http.RoundTripper,
@@ -30,7 +33,12 @@ func forwardRequest(
 		// not Sprintf or anything similar. this means we have to create the
 		// failure string in this slightly convoluted way.
 		errMsg := fmt.Errorf("error on backend (%w)", err).Error()
-		w.Write([]byte(errMsg))
+		if _, err := w.Write([]byte(errMsg)); err != nil {
+			lggr.Error(
+				err,
+				"could not write error response to client",
+			)
+		}
 	}
 
 	proxy.ServeHTTP(w, r)

--- a/operator/controllers/suite_test.go
+++ b/operator/controllers/suite_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	logrtest "github.com/go-logr/logr/testing"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,12 +63,12 @@ type commonTestInfra struct {
 
 func newCommonTestInfra(namespace, appName string) *commonTestInfra {
 	ctx := context.Background()
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	cfg := config.AppInfo{
 		Name:      appName,
 		Namespace: namespace,
 	}
-	logger := logrtest.NullLogger{}
+	logger := logr.Discard()
 	httpso := v1alpha1.HTTPScaledObject{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -114,13 +113,12 @@ var _ = BeforeSuite(func(done Done) {
 	// 	UseExistingCluster: &useExistingCluster,
 	// }
 
-	var err error
 	// cfg, err = testEnv.Start()
 	// Expect(err).ToNot(HaveOccurred())
 	// Expect(cfg).ToNot(BeNil())
 
-	err = httpv1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	addSchemeErr := httpv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(addSchemeErr).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 )
 
@@ -13,7 +14,9 @@ func ServeContext(ctx context.Context, addr string, hdl http.Handler) error {
 
 	go func() {
 		<-ctx.Done()
-		srv.Shutdown(ctx)
+		if err := srv.Shutdown(ctx); err != nil {
+			fmt.Println("failed shutting down server:", err)
+		}
 	}()
 	return srv.ListenAndServe()
 }

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -17,7 +17,10 @@ func TestServeContext(t *testing.T) {
 	)
 	hdl := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("foo", "bar")
-		w.Write([]byte("hello world"))
+		_, err := w.Write([]byte("hello world"))
+		if err != nil {
+			t.Fatalf("error writing message to client from handler")
+		}
 	})
 	addr := "localhost:1234"
 	const cancelDur = 500 * time.Millisecond

--- a/pkg/queue/queue_rpc.go
+++ b/pkg/queue/queue_rpc.go
@@ -33,17 +33,27 @@ func newSizeHandler(
 		if err != nil {
 			lggr.Error(err, "getting queue size")
 			w.WriteHeader(500)
-			w.Write([]byte(
+			if _, err := w.Write([]byte(
 				"error getting queue size",
-			))
+			)); err != nil {
+				lggr.Error(
+					err,
+					"could not send error message to client",
+				)
+			}
 			return
 		}
 		if err := json.NewEncoder(w).Encode(cur); err != nil {
 			lggr.Error(err, "encoding QueueCounts")
 			w.WriteHeader(500)
-			w.Write([]byte(
+			if _, err := w.Write([]byte(
 				"error encoding queue counts",
-			))
+			)); err != nil {
+				lggr.Error(
+					err,
+					"could not send error message to client",
+				)
+			}
 			return
 		}
 	})

--- a/pkg/routing/config_map_updater_test.go
+++ b/pkg/routing/config_map_updater_test.go
@@ -72,12 +72,12 @@ func TestStartUpdateLoop(t *testing.T) {
 
 	q := queue.NewFakeCounter()
 	table := NewTable()
-	table.AddTarget("host1", NewTarget(
+	r.NoError(table.AddTarget("host1", NewTarget(
 		"svc1",
 		8080,
 		"depl1",
 		100,
-	))
+	)))
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/routing/table_rpc.go
+++ b/pkg/routing/table_rpc.go
@@ -50,9 +50,14 @@ func AddPingRoute(
 		if err != nil {
 			lggr.Error(err, "fetching new routing table")
 			w.WriteHeader(500)
-			w.Write([]byte(
+			if _, err := w.Write([]byte(
 				"error fetching routing table",
-			))
+			)); err != nil {
+				lggr.Error(
+					err,
+					"could not write error response to client",
+				)
+			}
 			return
 		}
 		w.WriteHeader(200)
@@ -74,9 +79,14 @@ func newTableHandler(
 		if err != nil {
 			w.WriteHeader(500)
 			lggr.Error(err, "encoding logging table JSON")
-			w.Write([]byte(
+			if _, err := w.Write([]byte(
 				"error encoding and transmitting the routing table",
-			))
+			)); err != nil {
+				lggr.Error(
+					err,
+					"could not send error message to client",
+				)
+			}
 		}
 	})
 }

--- a/pkg/routing/table_rpc_test.go
+++ b/pkg/routing/table_rpc_test.go
@@ -12,10 +12,13 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func newTableFromMap(m map[string]Target) *Table {
+func newTableFromMap(t *testing.T, m map[string]Target) *Table {
+	t.Helper()
 	table := NewTable()
 	for host, target := range m {
-		table.AddTarget(host, target)
+		if err := table.AddTarget(host, target); err != nil {
+			t.Fatalf("Error adding target to table: %s", err)
+		}
 	}
 	return table
 }
@@ -59,7 +62,7 @@ func TestRPCIntegration(t *testing.T) {
 
 	retTable = NewTable()
 	k8sCl, err = fakeConfigMapClientForTable(
-		newTableFromMap(targetMap),
+		newTableFromMap(t, targetMap),
 		ns,
 		ConfigMapRoutingTableName,
 	)

--- a/pkg/routing/table_test.go
+++ b/pkg/routing/table_test.go
@@ -16,7 +16,7 @@ func TestTableJSONRoundTrip(t *testing.T) {
 		Port:       8082,
 		Deployment: "testdepl",
 	}
-	tbl.AddTarget(host, tgt)
+	r.NoError(tbl.AddTarget(host, tgt))
 
 	b, err := json.Marshal(&tbl)
 	r.NoError(err)
@@ -42,7 +42,7 @@ func TestTableRemove(t *testing.T) {
 	tbl := NewTable()
 
 	// add the target to the table and ensure that you can look it up
-	tbl.AddTarget(host, tgt)
+	r.NoError(tbl.AddTarget(host, tgt))
 	retTgt, err := tbl.Lookup(host)
 	r.Equal(tgt, retTgt)
 	r.NoError(err)
@@ -70,9 +70,9 @@ func TestTableReplace(t *testing.T) {
 	}
 	// create two routing tables, each with different targets
 	tbl1 := NewTable()
-	tbl1.AddTarget(host1, tgt1)
+	r.NoError(tbl1.AddTarget(host1, tgt1))
 	tbl2 := NewTable()
-	tbl2.AddTarget(host2, tgt2)
+	r.NoError(tbl2.AddTarget(host2, tgt2))
 
 	// replace the second table with the first and ensure that the tables
 	// are now equal

--- a/scaler/handlers.go
+++ b/scaler/handlers.go
@@ -100,9 +100,14 @@ func (e *impl) StreamIsActive(
 				)
 				continue
 			}
-			server.Send(&externalscaler.IsActiveResponse{
+			if err := server.Send(&externalscaler.IsActiveResponse{
 				Result: active.Result,
-			})
+			}); err != nil {
+				e.lggr.Error(
+					err,
+					"error sending active status in stream, continuing",
+				)
+			}
 		}
 	}
 }

--- a/scaler/handlers_test.go
+++ b/scaler/handlers_test.go
@@ -74,12 +74,12 @@ func TestGetMetricSpec(t *testing.T) {
 	ctx := context.Background()
 	lggr := logr.Discard()
 	table := routing.NewTable()
-	table.AddTarget(host, routing.NewTarget(
+	r.NoError(table.AddTarget(host, routing.NewTarget(
 		"testsrv",
 		8080,
 		"testdepl",
 		int32(target),
-	))
+	)))
 	ticker, pinger := newFakeQueuePinger(ctx, lggr)
 	defer ticker.Stop()
 	hdl := newImpl(lggr, pinger, table, 123, 200)

--- a/scaler/queue_pinger_test.go
+++ b/scaler/queue_pinger_test.go
@@ -33,7 +33,7 @@ func TestRequestCounts(t *testing.T) {
 
 	q := queue.NewMemory()
 	for host, count := range counts {
-		q.Resize(host, count)
+		r.NoError(q.Resize(host, count))
 	}
 
 	hdl := http.NewServeMux()


### PR DESCRIPTION
This PR adds lint checks for [golang-ci](https://golangci-lint.run/) to the GitHub actions. It also implements fixes for all the lint errors that golang-ci reports.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
