### PR TITLE
Adding proper nginx-ingress annotation to the xkcd chart's ingress resource

### DIFF
--- a/examples/xkcd/templates/ingress.yaml
+++ b/examples/xkcd/templates/ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "xkcd.fullname" . }}
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: nginx
 spec:
   rules:
   - host: {{ .Values.host }}


### PR DESCRIPTION
This PR includes the `kubernetes.io/ingress.class: "nginx"` annotation on the XKCD chart's `Ingress` resource. This annotation is listed here: kubernetes.io/ingress.class: "nginx"

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
