### PR TITLE
fixing release script for interceptor and scaler

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -66,6 +66,11 @@ jobs:
         run: |
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
+      - name: Get the version
+        id: get_version
+        run: |
+          echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -103,6 +108,11 @@ jobs:
         id: prep
         run: |
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+      - name: Get the version
+        id: get_version
+        run: |
+          echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
The interceptor and scaler release script for GH actions was missing a version value. This adds it. The error only pops up when you release a new tag and the `build_release.yml` action runs, so this PR should be merged before the next release is cut.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
