### PR TITLE
Fixing operator startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kedacore/http-add-on
 
-go 1.16
+go 1.17
 
 require (
 	github.com/go-logr/logr v0.4.0


### PR DESCRIPTION
Prior to this PR, the operator would not start properly because it was attempting to use the controller-runtime library's `client.Client` to fetch the routing table `ConfigMap`. That usage failed because it was attempting to use the built-in `client.Client` before the controller started up. This PR changes the behavior of this lookup code to use its own built-in `k8s.io/client-go` based Kubernetes client to do the check.


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
