### PR TITLE
Restore target to original replica count after deleting httpscaledobject resource.

### DIFF
--- a/pkg/k8s/templates/scaledobject.yaml
+++ b/pkg/k8s/templates/scaledobject.yaml
@@ -19,3 +19,5 @@ spec:
       metadata:
         scalerAddress: {{ .ScalerAddress }}
         host: {{ .Host }}
+  advanced:
+    restoreToOriginalReplicaCount: true


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

Enable the [advanced.restoreToOriginalReplicaCount](https://github.com/kedacore/keda/blob/main/apis/keda/v1alpha1/scaledobject_types.go#L100) attribute of the **scaledobject** resource corresponding to the **httpscaledobject** resource to restore the replicas of the target workload to the original count (i.e. `spec.replicas` in the **deployments.app**) after deleting the **httpscaledobject** resource.

Reference:

```yaml
advanced:
  restoreToOriginalReplicaCount: true/false        # Optional. Default: false
```

This property specifies whether the target resource (`Deployment`, `StatefulSet`,...) should be scaled back to original replicas count, after the `ScaledObject` is deleted. 
Default behavior is to keep the replica count at the same number as it is in the moment of `ScaledObject's` deletion.

For example a `Deployment` with `3 replicas` is created, then `ScaledObject` is created and the `Deployment` is scaled by KEDA to `10 replicas`. Then `ScaledObject` is deleted:
 1. if `restoreToOriginalReplicaCount = false` (default behavior) then `Deployment` replicas count is `10`
 2. if `restoreToOriginalReplicaCount = true` then `Deployment` replicas count is set back to `3` (the original value)

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #332 

Signed-off-by: laminar <fangtian@kubesphere.io>