### PR TITLE
Adding documentation for how to issue curl requests

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -65,3 +65,15 @@ An [`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress/)
 When you're ready, please run `kubectl get svc -n ${NAMESPACE}`, find the `ingress-nginx-controller` service, and copy and paste its `EXTERNAL-IP`. This is the IP address that your application will be running at on the public internet.
 
 >Note: you should go further and set your DNS records appropriately and set up a TLS certificate for this IP address. Instructions to do that are out of scope of this document, though.
+
+### Making an HTTP Request to your App
+
+Now that you have your application running and your ingress configured, you can issue an HTTP request. To do so, you'll need to know the IP address to request. If you're using an ingress controller, that is the IP of the ingress controller's `Service`. If you're using a "raw" `Service` with `type: LoadBalancer`, that is the IP address of the `Service` itself.
+
+Regardless, you can use the below `curl` command to make a request to your application:
+
+```shell
+curl -H "Host: myhost.com" <Your IP>
+```
+
+>Note the `-H` flag above to specify the `Host` header. This is needed to tell the interceptor how to route the request. If you have a DNS name set up for the IP, you don't need this header.


### PR DESCRIPTION
This PR adds instructions to the end of the `walkthrough.md` documentation that explain how to issue `curl` requests to your newly created application. Thanks to @iompo for the suggestion in https://github.com/kedacore/http-add-on/discussions/335#discussioncomment-1769458 to add this documentation

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

@iompo can you let me know if this documentation makes sense?
