### PR TITLE
Upgrading images to use Go 1.17.2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,5 @@
-# [Choice] Go version: 1, 1.16, 1.15
-ARG VARIANT=1.17
-FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+ARG GO_VERSION=1.17
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-${GO_VERSION}
 
 # install mage
 RUN git clone https://github.com/magefile/mage && \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,6 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.x
+        go-version: 1.17.2
     - name: Test
       run: go test ./...

--- a/interceptor/Dockerfile
+++ b/interceptor/Dockerfile
@@ -1,6 +1,6 @@
 # adapted from Athens
 # https://github.com/gomods/athens/blob/main/cmd/proxy/Dockerfile
-ARG GOLANG_VERSION=1.16
+ARG GOLANG_VERSION=1.17.2
 ARG GOARCH=amd64
 ARG GOOS=linux
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,6 +1,6 @@
 # adapted from Athens 
 # https://github.com/gomods/athens/blob/main/cmd/proxy/Dockerfile
-ARG GOLANG_VERSION=1.16
+ARG GOLANG_VERSION=1.17.2
 ARG GOARCH=amd64
 ARG GOOS=linux
 

--- a/scaler/Dockerfile
+++ b/scaler/Dockerfile
@@ -1,9 +1,8 @@
 # taken from Athens
 # https://github.com/gomods/athens/blob/main/cmd/proxy/Dockerfile
-ARG GOLANG_VERSION=1.16
+ARG GOLANG_VERSION=1.17.2
 ARG GOARCH=amd64
 ARG GOOS=linux
-
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 


### PR DESCRIPTION
This PR updates the built images & the CI/CD run to use Go version 1.17.2

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
