### PR TITLE
Return custom header when request was returned from a cold start 

### DIFF
--- a/interceptor/forward_wait_func.go
+++ b/interceptor/forward_wait_func.go
@@ -11,7 +11,7 @@ import (
 
 // forwardWaitFunc is a function that waits for a condition
 // before proceeding to serve the request.
-type forwardWaitFunc func(context.Context, string, string) error
+type forwardWaitFunc func(context.Context, string, string) (int, error)
 
 func deploymentCanServe(depl appsv1.Deployment) bool {
 	return depl.Status.ReadyReplicas > 0
@@ -21,7 +21,7 @@ func newDeployReplicasForwardWaitFunc(
 	lggr logr.Logger,
 	deployCache k8s.DeploymentCache,
 ) forwardWaitFunc {
-	return func(ctx context.Context, deployNS, deployName string) error {
+	return func(ctx context.Context, deployNS, deployName string) (int, error) {
 		// get a watcher & its result channel before querying the
 		// deployment cache, to ensure we don't miss events
 		watcher := deployCache.Watch(deployNS, deployName)
@@ -31,7 +31,7 @@ func newDeployReplicasForwardWaitFunc(
 		deployment, err := deployCache.Get(deployNS, deployName)
 		if err != nil {
 			// if we didn't get the initial deployment state, bail out
-			return fmt.Errorf(
+			return 0, fmt.Errorf(
 				"error getting state for deployment %s/%s (%s)",
 				deployNS,
 				deployName,
@@ -40,7 +40,7 @@ func newDeployReplicasForwardWaitFunc(
 		}
 		// if there is 1 or more replica, we're done waiting
 		if deploymentCanServe(deployment) {
-			return nil
+			return int(deployment.Status.ReadyReplicas), nil
 		}
 
 		for {
@@ -51,14 +51,13 @@ func newDeployReplicasForwardWaitFunc(
 					lggr.Info(
 						"Didn't get a deployment back in event",
 					)
-				}
-				if deploymentCanServe(*deployment) {
-					return nil
+				} else if deploymentCanServe(*deployment) {
+					return 0, nil
 				}
 			case <-ctx.Done():
 				// otherwise, if the context is marked done before
 				// we're done waiting, fail.
-				return fmt.Errorf(
+				return 0, fmt.Errorf(
 					"context marked done while waiting for deployment %s to reach > 0 replicas (%w)",
 					deployName,
 					ctx.Err(),

--- a/interceptor/forward_wait_func_test.go
+++ b/interceptor/forward_wait_func_test.go
@@ -43,7 +43,8 @@ func TestForwardWaitFuncOneReplica(t *testing.T) {
 	)
 
 	group.Go(func() error {
-		return waitFunc(ctx, ns, deployName)
+		_, err := waitFunc(ctx, ns, deployName)
+		return err
 	})
 	r.NoError(group.Wait(), "wait function failed, but it shouldn't have")
 }
@@ -76,7 +77,7 @@ func TestForwardWaitFuncNoReplicas(t *testing.T) {
 		cache,
 	)
 
-	err := waitFunc(ctx, ns, deployName)
+	_, err := waitFunc(ctx, ns, deployName)
 	r.Error(err)
 }
 
@@ -120,6 +121,7 @@ func TestWaitFuncWaitsUntilReplicas(t *testing.T) {
 		watcher.Action(watch.Modified, modifiedDeployment)
 		close(replicasIncreasedCh)
 	}()
-	r.NoError(waitFunc(ctx, ns, deployName))
+	_, err := waitFunc(ctx, ns, deployName)
+	r.NoError(err)
 	done()
 }

--- a/interceptor/main_test.go
+++ b/interceptor/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -108,7 +107,7 @@ func TestRunProxyServerCountMiddleware(t *testing.T) {
 			)
 		}
 		if resp.Header.Get("X-KEDA-HTTP-Cold-Start") != "false" {
-			return fmt.Errorf("expected X-KEDA-HTTP-Cold-Start false, but got %s", resp.Header.Get("X-KEDA-HTTP-Cold-Start))
+			return fmt.Errorf("expected X-KEDA-HTTP-Cold-Start false, but got %s", resp.Header.Get("X-KEDA-HTTP-Cold-Start"))
 		}
 		return nil
 	})

--- a/interceptor/main_test.go
+++ b/interceptor/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -66,9 +67,9 @@ func TestRunProxyServerCountMiddleware(t *testing.T) {
 	)
 	timeouts := &config.Timeouts{}
 	waiterCh := make(chan struct{})
-	waitFunc := func(ctx context.Context, ns, name string) error {
+	waitFunc := func(ctx context.Context, ns, name string) (int, error) {
 		<-waiterCh
-		return nil
+		return 1, nil
 	}
 	g.Go(func() error {
 		return runProxyServer(
@@ -105,6 +106,9 @@ func TestRunProxyServerCountMiddleware(t *testing.T) {
 				"unexpected status code: %d",
 				resp.StatusCode,
 			)
+		}
+		if resp.Header.Get("X-KEDA-HTTP-Cold-Start") != "false" {
+			return errors.New("expected X-KEDA-HTTP-Cold-Start false")
 		}
 		return nil
 	})

--- a/interceptor/main_test.go
+++ b/interceptor/main_test.go
@@ -108,7 +108,7 @@ func TestRunProxyServerCountMiddleware(t *testing.T) {
 			)
 		}
 		if resp.Header.Get("X-KEDA-HTTP-Cold-Start") != "false" {
-			return errors.New("expected X-KEDA-HTTP-Cold-Start false")
+			return fmt.Errorf("expected X-KEDA-HTTP-Cold-Start false, but got %s", resp.Header.Get("X-KEDA-HTTP-Cold-Start))
 		}
 		return nil
 	})


### PR DESCRIPTION
This PR returns a custom header, X-KEDA-HTTP-Cold-Start, when a request was returned from a cold start. That is, when we previously had zero replicas.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #365
