### PR TITLE
Compile binaries and docker images with git SHA

### DIFF
--- a/.github/workflows/build_canary.yml
+++ b/.github/workflows/build_canary.yml
@@ -47,6 +47,7 @@ jobs:
             sh.keda.http.image.source=${{github.event.repository.html_url}}
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
             sh.keda.http.image.revision=${{github.sha}}
+          build-args: "VERSION=${{ steps.prep.outputs.sha }}"
           file: operator/Dockerfile
           context: .
           push: true

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -50,6 +50,7 @@ jobs:
             sh.keda.http.image.created=${{steps.prep.outputs.created}}
             sh.keda.http.image.revision=${{github.sha}}
             sh.keda.http.image.release=${{github.ref}}
+          build-args: "VERSION=${{ steps.prep.outputs.VERSION }}"
           file: operator/Dockerfile
           context: .
           push: true

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -13,8 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build The Scaler
-        run:
-          docker build -t scaler -f scaler/Dockerfile .
+        run: |
+          COMMIT=$(git rev-parse --short HEAD)
+          docker build --build-arg VERSION=${COMMIT} -t scaler -f scaler/Dockerfile .
   
   build_operator:
     
@@ -23,8 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build The Operator
-        run:
-          docker build -t operator -f operator/Dockerfile .
+        run: |
+          COMMIT=$(git rev-parse --short=7 HEAD)
+          docker build --build-arg VERSION=${COMMIT} -t operator -f operator/Dockerfile .
 
   build_interceptor:
     
@@ -33,5 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build The Interceptor
-        run:
-          docker build -t interceptor -f interceptor/Dockerfile .
+        run: |
+          COMMIT=$(git rev-parse --short=7 HEAD)
+          docker build --build-arg VERSION=${COMMIT} -t interceptor -f interceptor/Dockerfile .

--- a/interceptor/Dockerfile
+++ b/interceptor/Dockerfile
@@ -20,7 +20,7 @@ ENV CGO_ENABLED=0
 ENV GOOS=${GOOS}
 ENV GOARCH=${GOARCH}
 ENV GOPROXY="https://proxy.golang.org"
-RUN go build -ldflags "-X github.com/kedacore/http-add-on/pkg/build.version=$VERSION" -a -o /bin/interceptor ./interceptor
+RUN go build -ldflags "-X github.com/kedacore/http-add-on/pkg/build.version=${VERSION}" -a -o /bin/interceptor ./interceptor
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/interceptor/Dockerfile
+++ b/interceptor/Dockerfile
@@ -3,6 +3,7 @@
 ARG GOLANG_VERSION=1.17.2
 ARG GOARCH=amd64
 ARG GOOS=linux
+ARG VERSION="unset"
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 
@@ -19,7 +20,7 @@ ENV CGO_ENABLED=0
 ENV GOOS=${GOOS}
 ENV GOARCH=${GOARCH}
 ENV GOPROXY="https://proxy.golang.org"
-RUN go build -o /bin/interceptor ./interceptor
+RUN go build -ldflags "-X github.com/kedacore/http-add-on/pkg/build.version=$VERSION" -a -o /bin/interceptor ./interceptor
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -223,6 +223,7 @@ func runAdminServer(
 		},
 	)
 	kedahttp.AddConfigEndpoint(lggr, adminServer, servingConfig, timeoutConfig)
+	kedahttp.AddVersionEndpoint(lggr, adminServer)
 
 	addr := fmt.Sprintf("0.0.0.0:%d", port)
 	lggr.Info("admin server starting", "address", addr)

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -223,7 +223,7 @@ func runAdminServer(
 		},
 	)
 	kedahttp.AddConfigEndpoint(lggr, adminServer, servingConfig, timeoutConfig)
-	kedahttp.AddVersionEndpoint(lggr, adminServer)
+	kedahttp.AddVersionEndpoint(lggr.WithName("interceptorAdmin"), adminServer)
 
 	addr := fmt.Sprintf("0.0.0.0:%d", port)
 	lggr.Info("admin server starting", "address", addr)

--- a/magefile.go
+++ b/magefile.go
@@ -36,14 +36,16 @@ const (
 	NAMESPACE_ENV_VAR         = "KEDAHTTP_NAMESPACE"
 )
 
-var goBuild = sh.OutCmd("go", "build", "-o")
-
 type Scaler mg.Namespace
 
 // Generate Go build of the scaler binary
 func (Scaler) Build(ctx context.Context) error {
 	fmt.Println("Running scaler binary build")
-	out, err := goBuild("bin/scaler", "./scaler")
+	buildFunc, err := build.GoBuild()
+	if err != nil {
+		return err
+	}
+	out, err := buildFunc("bin/scaler", "./scaler")
 	if err != nil {
 		return err
 	}
@@ -107,7 +109,11 @@ type Operator mg.Namespace
 // Generate Go build of the operator binary
 func (Operator) Build(ctx context.Context) error {
 	fmt.Println("Running operator binary build")
-	out, err := goBuild("bin/operator", "./operator")
+	buildFunc, err := build.GoBuild()
+	if err != nil {
+		return err
+	}
+	out, err := buildFunc("bin/operator", "./operator")
 	if err != nil {
 		return err
 	}
@@ -171,7 +177,11 @@ type Interceptor mg.Namespace
 // Generate Go build of the interceptor binary
 func (Interceptor) Build(ctx context.Context) error {
 	fmt.Println("Running interceptor binary build")
-	out, err := goBuild("bin/interceptor", "./interceptor")
+	buildFunc, err := build.GoBuild()
+	if err != nil {
+		return err
+	}
+	out, err := buildFunc("bin/interceptor", "./interceptor")
 	if err != nil {
 		return err
 	}

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -22,7 +22,7 @@ ENV GOARCH=${GOARCH}
 ENV GOPROXY="https://proxy.golang.org"
 
 # Build
-RUN go build -ldflags "-X github.com/kedacore/http-add-on/pkg/build.version=$VERSION" -a -o /bin/operator ./operator
+RUN go build -ldflags "-X github.com/kedacore/http-add-on/pkg/build.version=${VERSION}" -a -o /bin/operator ./operator
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -3,6 +3,7 @@
 ARG GOLANG_VERSION=1.17.2
 ARG GOARCH=amd64
 ARG GOOS=linux
+ARG VERSION="unset"
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 
@@ -21,7 +22,7 @@ ENV GOARCH=${GOARCH}
 ENV GOPROXY="https://proxy.golang.org"
 
 # Build
-RUN go build -a -o /bin/operator ./operator
+RUN go build -ldflags "-X github.com/kedacore/http-add-on/pkg/build.version=$VERSION" -a -o /bin/operator ./operator
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/operator/main.go
+++ b/operator/main.go
@@ -185,6 +185,7 @@ func runAdminServer(
 		interceptorCfg,
 		externalScalerCfg,
 	)
+	kedahttp.AddVersionEndpoint(lggr.WithName("operatorAdmin"), mux)
 	addr := fmt.Sprintf(":%d", port)
 	lggr.Info(
 		"starting admin RPC server",

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1,0 +1,19 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/magefile/mage/sh"
+)
+
+type Cmd = func(args ...string) (string, error)
+
+// GoBuild runs the go build command with the -ldflags flag and
+// the git sha of the current build
+func GoBuild() (Cmd, error) {
+	version, err := getGitSHA()
+	if err != nil {
+		return nil, err
+	}
+	return sh.OutCmd("go", "build", "-ldflags", fmt.Sprintf(`"-X github.com/kedacore/http-add-on/pkg/build.version=%s"`, version), "-o"), nil
+}

--- a/pkg/build/version.go
+++ b/pkg/build/version.go
@@ -1,0 +1,8 @@
+package build
+
+var version string
+
+// Version returns the current git SHA of commit the binary was built from
+func Version() string {
+	return version
+}

--- a/pkg/http/config_endpoint.go
+++ b/pkg/http/config_endpoint.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/go-logr/logr"
+	"github.com/kedacore/http-add-on/pkg/build"
 )
 
 func AddConfigEndpoint(lggr logr.Logger, mux *http.ServeMux, configs ...interface{}) {
@@ -13,6 +14,18 @@ func AddConfigEndpoint(lggr logr.Logger, mux *http.ServeMux, configs ...interfac
 			"configs": configs,
 		}); err != nil {
 			lggr.Error(err, "failed to encode configs")
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+		}
+	})
+}
+
+func AddVersionEndpoint(lggr logr.Logger, mux *http.ServeMux) {
+	mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"version": build.Version(),
+		}); err != nil {
+			lggr.Error(err, "failed to encode version")
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))
 		}

--- a/scaler/Dockerfile
+++ b/scaler/Dockerfile
@@ -20,7 +20,7 @@ ENV CGO_ENABLED=0
 ENV GOOS=${GOOS}
 ENV GOARCH=${GOARCH}
 ENV GOPROXY="https://proxy.golang.org"
-RUN go build -ldflags "-X github.com/kedacore/http-add-on/pkg/build.version=$VERSION" -a -o /bin/scaler ./scaler
+RUN go build -ldflags "-X github.com/kedacore/http-add-on/pkg/build.version=${VERSION}" -a -o /bin/scaler ./scaler
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/scaler/Dockerfile
+++ b/scaler/Dockerfile
@@ -3,6 +3,7 @@
 ARG GOLANG_VERSION=1.17.2
 ARG GOARCH=amd64
 ARG GOOS=linux
+ARG VERSION="unset"
 
 FROM golang:${GOLANG_VERSION}-alpine AS builder
 
@@ -19,7 +20,7 @@ ENV CGO_ENABLED=0
 ENV GOOS=${GOOS}
 ENV GOARCH=${GOARCH}
 ENV GOPROXY="https://proxy.golang.org"
-RUN go build -o /bin/scaler ./scaler
+RUN go build -ldflags "-X github.com/kedacore/http-add-on/pkg/build.version=$VERSION" -a -o /bin/scaler ./scaler
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /

--- a/scaler/main.go
+++ b/scaler/main.go
@@ -119,7 +119,7 @@ func main() {
 
 	grp.Go(func() error {
 		defer done()
-		return startHealthcheckServer(
+		return startAdminServer(
 			ctx,
 			lggr,
 			cfg,
@@ -166,7 +166,7 @@ func startGrpcServer(
 	return grpcServer.Serve(lis)
 }
 
-func startHealthcheckServer(
+func startAdminServer(
 	ctx context.Context,
 	lggr logr.Logger,
 	cfg *config,
@@ -210,6 +210,7 @@ func startHealthcheckServer(
 	})
 
 	kedahttp.AddConfigEndpoint(lggr, mux, cfg)
+	kedahttp.AddVersionEndpoint(lggr, mux)
 
 	addr := fmt.Sprintf("0.0.0.0:%d", port)
 	lggr.Info("starting health check server", "addr", addr)

--- a/scaler/main.go
+++ b/scaler/main.go
@@ -210,7 +210,7 @@ func startAdminServer(
 	})
 
 	kedahttp.AddConfigEndpoint(lggr, mux, cfg)
-	kedahttp.AddVersionEndpoint(lggr, mux)
+	kedahttp.AddVersionEndpoint(lggr.WithName("scalerAdmin"), mux)
 
 	addr := fmt.Sprintf("0.0.0.0:%d", port)
 	lggr.Info("starting health check server", "addr", addr)

--- a/scaler/main_test.go
+++ b/scaler/main_test.go
@@ -37,7 +37,7 @@ func TestHealthChecks(t *testing.T) {
 	r.NoError(err)
 	defer ticker.Stop()
 	srvFunc := func() error {
-		return startHealthcheckServer(
+		return startAdminServer(
 			ctx,
 			lggr,
 			cfg,


### PR DESCRIPTION
Compile binaries and build docker images with git SHA both locally, within Dockerfiles, and in GitHub Actions workflows.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #266 
