### PR TITLE
fix shell typo in docs

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -25,7 +25,7 @@ You'll need to clone the repository to get access to this chart. If you have you
 You interact with the operator via a CRD called `HTTPScaledObject`. This CRD object points the To get an example app up and running, read the notes below and then run the subsequent command from the root of this repository.
 
 ```shell
-kubectl create -f -n $NAMESPACE examples/v0.0.2/httpscaledobject.yaml
+kubectl create -n $NAMESPACE -f examples/v0.2.0/httpscaledobject.yaml
 ```
 
 >If you'd like to learn more about this object, please see the [`HTTPScaledObject` reference](./ref/v0.2.0/http_scaled_object.md).


### PR DESCRIPTION
Signed-off-by: XinYang <xinydev@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

fix a shell typo in docs


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
