### PR TITLE
Removing unused ginkgo setup code

### DIFF
--- a/operator/controllers/suite_test.go
+++ b/operator/controllers/suite_test.go
@@ -17,37 +17,15 @@ package controllers
 
 import (
 	"context"
-	"testing"
 
 	"github.com/go-logr/logr"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kedacore/http-add-on/operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
-// var cfg *rest.Config
-// var k8sClient client.Client
-// var testEnv *envtest.Environment
-
-func TestAPIs(t *testing.T) {
-	RegisterFailHandler(Fail)
-
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
-}
 
 type commonTestInfra struct {
 	ns      string
@@ -90,41 +68,3 @@ func newCommonTestInfra(namespace, appName string) *commonTestInfra {
 		httpso:  httpso,
 	}
 }
-
-var _ = BeforeSuite(func(done Done) {
-	// The commented code in this function connects to a test Kubernetes cluster.
-	// We don't currently have tests that exercise functionality that needs a cluster,
-	// so we're keeping it commented.
-	logf.SetLogger(zap.New(func(opts *zap.Options) {
-		opts.DestWriter = GinkgoWriter
-	}))
-
-	// By("bootstrapping test environment")
-	// useExistingCluster := true
-	// testEnv = &envtest.Environment{
-	// 	CRDDirectoryPaths:  []string{filepath.Join("..", "config", "crd", "bases")},
-	// 	UseExistingCluster: &useExistingCluster,
-	// }
-
-	var err error
-	// cfg, err = testEnv.Start()
-	// Expect(err).ToNot(HaveOccurred())
-	// Expect(cfg).ToNot(BeNil())
-
-	err = v1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	// +kubebuilder:scaffold:scheme
-
-	// k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	// Expect(err).ToNot(HaveOccurred())
-	// Expect(k8sClient).ToNot(BeNil())
-
-	close(done)
-}, 60)
-
-var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	// err := testEnv.Stop()
-	// Expect(err).ToNot(HaveOccurred())
-})


### PR DESCRIPTION
This PR removes unused ginkgo setup code in `operator/controllers/suite_test.go`. All that remains in that file is test infra setup code

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
