### PR TITLE
Updatereplicas

### DIFF
--- a/operator/controllers/scaled_object_test.go
+++ b/operator/controllers/scaled_object_test.go
@@ -2,74 +2,76 @@ package controllers
 
 import (
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/kedacore/http-add-on/operator/api/v1alpha1"
 	"github.com/kedacore/http-add-on/operator/controllers/config"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/kedacore/http-add-on/pkg/k8s"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("UserApp", func() {
-	Context("Creating a ScaledObject", func() {
-		const externalScalerHostName = "mysvc.myns.svc.cluster.local:9090"
+func TestCreateOrUpdateScaledObject(t *testing.T) {
+	r := require.New(t)
+	const externalScalerHostName = "mysvc.myns.svc.cluster.local:9090"
 
-		var testInfra *commonTestInfra
-		BeforeEach(func() {
-			testInfra = newCommonTestInfra("testns", "testapp")
-		})
-		It("Should properly create the ScaledObject for the user app", func() {
-			err := createScaledObjects(
-				testInfra.ctx,
-				testInfra.cl,
-				testInfra.logger,
-				externalScalerHostName,
-				&testInfra.httpso,
-			)
-			Expect(err).To(BeNil())
+	testInfra := newCommonTestInfra("testns", "testapp")
+	err := createOrUpdateScaledObject(
+		testInfra.ctx,
+		testInfra.cl,
+		testInfra.logger,
+		externalScalerHostName,
+		&testInfra.httpso,
+	)
+	r.NoError(err)
 
-			// make sure that httpso has the AppScaledObjectCreated
-			// condition on it
-			Expect(len(testInfra.httpso.Status.Conditions)).To(Equal(1))
+	// make sure that httpso has the AppScaledObjectCreated
+	// condition on it
+	r.Equal(1, len(testInfra.httpso.Status.Conditions))
 
-			cond1 := testInfra.httpso.Status.Conditions[0]
-			cond1ts, err := time.Parse(time.RFC3339, cond1.Timestamp)
-			Expect(err).To(BeNil())
-			Expect(time.Since(cond1ts) >= 0).To(BeTrue())
-			Expect(cond1.Type).To(Equal(v1alpha1.Created))
-			Expect(cond1.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond1.Reason).To(Equal(v1alpha1.AppScaledObjectCreated))
+	cond1 := testInfra.httpso.Status.Conditions[0]
+	cond1ts, err := time.Parse(time.RFC3339, cond1.Timestamp)
+	r.NoError(err)
+	r.GreaterOrEqual(time.Since(cond1ts), time.Duration(0))
+	r.Equal(v1alpha1.Created, cond1.Type)
+	r.Equal(metav1.ConditionTrue, cond1.Status)
+	r.Equal(v1alpha1.AppScaledObjectCreated, cond1.Reason)
 
-			// check that the app ScaledObject was created
-			u := &unstructured.Unstructured{}
-			u.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "keda.sh",
-				Kind:    "ScaledObject",
-				Version: "v1alpha1",
-			})
-			objectKey := client.ObjectKey{
-				Namespace: testInfra.ns,
-				Name:      config.AppScaledObjectName(&testInfra.httpso),
-			}
-			err = testInfra.cl.Get(testInfra.ctx, objectKey, u)
-			Expect(err).To(BeNil())
+	// check that the app ScaledObject was created
+	retSO := k8s.NewEmptyScaledObject()
+	err = testInfra.cl.Get(testInfra.ctx, client.ObjectKey{
+		Namespace: testInfra.ns,
+		Name:      config.AppScaledObjectName(&testInfra.httpso),
+	}, retSO)
+	r.NoError(err)
 
-			metadata, err := getKeyAsMap(u.Object, "metadata")
-			Expect(err).To(BeNil())
-			Expect(metadata["namespace"]).To(Equal(testInfra.ns))
-			Expect(metadata["name"]).To(Equal(config.AppScaledObjectName(&testInfra.httpso)))
+	metadata, err := getKeyAsMap(retSO.Object, "metadata")
+	r.NoError(err)
+	r.Equal(testInfra.ns, metadata["namespace"])
+	r.Equal(
+		config.AppScaledObjectName(&testInfra.httpso),
+		metadata["name"],
+	)
 
-			spec, err := getKeyAsMap(u.Object, "spec")
-			Expect(err).To(BeNil())
-			Expect(spec["minReplicaCount"]).To(BeNumerically("==", testInfra.httpso.Spec.Replicas.Min))
-			Expect(spec["maxReplicaCount"]).To(BeNumerically("==", testInfra.httpso.Spec.Replicas.Max))
-		})
-	})
-})
+	spec, err := getKeyAsMap(retSO.Object, "spec")
+	r.NoError(err)
+	// HTTPScaledObject min/max replicas are int32s,
+	// but the ScaledObject's spec is decoded into
+	// an *unsructured.Unstructured (basically a map[string]interface{})
+	// which is an int64. we need to convert the
+	// HTTPScaledObject's values into int64s before we compare
+	r.Equal(
+		int64(testInfra.httpso.Spec.Replicas.Min),
+		spec["minReplicaCount"],
+	)
+	r.Equal(
+		int64(testInfra.httpso.Spec.Replicas.Max),
+		spec["maxReplicaCount"],
+	)
+
+}
 
 func getKeyAsMap(m map[string]interface{}, key string) (map[string]interface{}, error) {
 	iface, ok := m[key]

--- a/pkg/k8s/scaledobject.go
+++ b/pkg/k8s/scaledobject.go
@@ -32,6 +32,18 @@ func DeleteScaledObject(ctx context.Context, name string, namespace string, cl c
 	return nil
 }
 
+func NewEmptyScaledObject() *unstructured.Unstructured {
+	ret := &unstructured.Unstructured{}
+	ret.SetGroupVersionKind(
+		schema.GroupVersionKind{
+			Group:   "keda.sh",
+			Version: "v1alpha1",
+			Kind:    "ScaledObject",
+		},
+	)
+	return ret
+}
+
 // NewScaledObject creates a new ScaledObject in memory
 func NewScaledObject(
 	namespace,


### PR DESCRIPTION
In certain situations, a valid update to an HTTPScaledObject won't trigger any in-kind update to the corresponding ScaledObject


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #323
Fixes #20
