### PR TITLE
Fixing concurrent map access panic in scaler

### DIFF
--- a/scaler/handlers.go
+++ b/scaler/handlers.go
@@ -73,7 +73,9 @@ func (e *impl) IsActive(
 	)
 	if !ok {
 		err := fmt.Errorf("host '%s' not found in counts", host)
-		allCounts := mergeCountsWithRoutingTable(e.pinger.counts(), e.routingTable)
+		allCounts := e.pinger.mergeCountsWithRoutingTable(
+			e.routingTable,
+		)
 		lggr.Error(err, "Given host was not found in queue count map", "host", host, "allCounts", allCounts)
 		return nil, err
 	}
@@ -173,7 +175,7 @@ func (e *impl) GetMetrics(
 			hostCount = e.pinger.aggregate()
 		} else {
 			err := fmt.Errorf("host '%s' not found in counts", host)
-			allCounts := mergeCountsWithRoutingTable(e.pinger.counts(), e.routingTable)
+			allCounts := e.pinger.mergeCountsWithRoutingTable(e.routingTable)
 			lggr.Error(err, "allCounts", allCounts)
 			return nil, err
 		}

--- a/scaler/host_counts.go
+++ b/scaler/host_counts.go
@@ -4,22 +4,6 @@ import (
 	"github.com/kedacore/http-add-on/pkg/routing"
 )
 
-// mergeCountsWithRoutingTable ensures that all hosts in routing table
-// are present in combined counts, if count is not present value is set to 0
-func mergeCountsWithRoutingTable(
-	counts map[string]int,
-	table routing.TableReader,
-) map[string]int {
-	mergedCounts := make(map[string]int)
-	for _, host := range table.Hosts() {
-		mergedCounts[host] = 0
-	}
-	for key, value := range counts {
-		mergedCounts[key] = value
-	}
-	return mergedCounts
-}
-
 // getHostCount gets proper count for given host regardless whether
 // host is in counts or only in routerTable
 func getHostCount(

--- a/scaler/host_counts_test.go
+++ b/scaler/host_counts_test.go
@@ -14,79 +14,66 @@ type testCase struct {
 	retCounts map[string]int
 }
 
-var cases = []testCase{
-	{
-		name: "empty queue",
-		table: newRoutingTable([]hostAndTarget{
-			{
-				host:   "www.example.com",
-				target: routing.Target{},
+func cases() []testCase {
+	return []testCase{
+		{
+			name: "empty queue",
+			table: newRoutingTable([]hostAndTarget{
+				{
+					host:   "www.example.com",
+					target: routing.Target{},
+				},
+				{
+					host:   "www.example2.com",
+					target: routing.Target{},
+				},
+			}),
+			counts: make(map[string]int),
+			retCounts: map[string]int{
+				"www.example.com":  0,
+				"www.example2.com": 0,
 			},
-			{
-				host:   "www.example2.com",
-				target: routing.Target{},
+		},
+		{
+			name: "one entry in queue, same entry in routing table",
+			table: newRoutingTable([]hostAndTarget{
+				{
+					host:   "example.com",
+					target: routing.Target{},
+				},
+			}),
+			counts: map[string]int{
+				"example.com": 1,
 			},
-		}),
-		counts: make(map[string]int),
-		retCounts: map[string]int{
-			"www.example.com":  0,
-			"www.example2.com": 0,
-		},
-	},
-	{
-		name: "one entry in queue, same entry in routing table",
-		table: newRoutingTable([]hostAndTarget{
-			{
-				host:   "example.com",
-				target: routing.Target{},
+			retCounts: map[string]int{
+				"example.com": 1,
 			},
-		}),
-		counts: map[string]int{
-			"example.com": 1,
 		},
-		retCounts: map[string]int{
-			"example.com": 1,
-		},
-	},
-	{
-		name: "one entry in queue, two in routing table",
-		table: newRoutingTable([]hostAndTarget{
-			{
-				host:   "example.com",
-				target: routing.Target{},
+		{
+			name: "one entry in queue, two in routing table",
+			table: newRoutingTable([]hostAndTarget{
+				{
+					host:   "example.com",
+					target: routing.Target{},
+				},
+				{
+					host:   "example2.com",
+					target: routing.Target{},
+				},
+			}),
+			counts: map[string]int{
+				"example.com": 1,
 			},
-			{
-				host:   "example2.com",
-				target: routing.Target{},
+			retCounts: map[string]int{
+				"example.com":  1,
+				"example2.com": 0,
 			},
-		}),
-		counts: map[string]int{
-			"example.com": 1,
 		},
-		retCounts: map[string]int{
-			"example.com":  1,
-			"example2.com": 0,
-		},
-	},
-}
-
-func TestMergeCountsWithRoutingTable(t *testing.T) {
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := require.New(t)
-			ret := mergeCountsWithRoutingTable(
-				tc.counts,
-				tc.table,
-			)
-			r.Equal(tc.retCounts, ret)
-		})
 	}
+
 }
-
 func TestGetHostCount(t *testing.T) {
-
-	for _, tc := range cases {
+	for _, tc := range cases() {
 		for host, retCount := range tc.retCounts {
 			t.Run(tc.name, func(t *testing.T) {
 				r := require.New(t)


### PR DESCRIPTION
This PR ensures that the data structures that hold the pending queue in the scaler's `queuePinger` are protected by the pinger's mutex.

@morganchristiansson and @stefanbulzan thanks for bringing this up. if you care to review this, please feel free!

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #414
