### PR TITLE
adding @asw101 to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-*       @ahmelsayed @zroubalik @tomkerkhove @arschles @khaosdoctor @ajanth97
+*       @ahmelsayed @zroubalik @tomkerkhove @arschles @asw101 @ajanth97


### PR DESCRIPTION
Adding @asw101 to Codeowners file.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
