### PR TITLE
updating interceptor section in developing.md

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -108,9 +108,9 @@ Then, when you see a `curl` command below, replace the entire path up to and inc
 
 ### Interceptor
 
-Any interceptor pod has both a _proxy_ and _admin_ server running inside it. The proxy server is where users send HTTP requests to, and the admin server is for internal use. The admin server runs on a separate port, fronted by a separate `Service`.
+Any interceptor pod has both a _proxy_ and _admin_ server running inside it. The proxy server is where users send HTTP requests to, and the admin server is for internal use. The admin server runs on a separate port, fronted by a separate `Service`. The admin server also performs following tasks:
 
-1. Prompt the interceptor to re-fetch the routing table from the interceptor, or
+1. Prompt the interceptor to re-fetch the routing table, or
 2. Print out the interceptor's current routing table (useful for debugging)
 
 #### Configuration


### PR DESCRIPTION
Signed-off-by: Ritikaa96 <ritika@india.nec.com>

In [this](https://github.com/kedacore/http-add-on/blob/main/docs/developing.md#interceptor) document related to development, the two points were made but it is not clear what they are describing here. Can we add a little bit clarity in this one?

here is the reference paragraph: 

> Any interceptor pod has both a proxy and admin server running inside it. The proxy server is where users send HTTP requests to, and the admin server is for internal use. The admin server runs on a separate port, fronted by a separate Service.
> 
>  1. Prompt the interceptor to re-fetch the routing table from the interceptor, or
>  2. Print out the interceptor's current routing table (useful for debugging)

also shouldn't the first point be `from the operator` as the update loop updates the routing table from the ConfigMap that the operator updates as HTTPScaledObjects enter and exit the system.

I changed the least bit of text only adding what seemed to be necessary only, please do let me know if I'm going right here or not.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)
