### PR TITLE
Local testing documentation added to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,11 @@ There are many areas we can use contributions - ranging from code, documentation
   - [Project governance](#project-governance)
   - [Including Documentation Changes](#including-documentation-changes)
   - [Development Environment Setup](#development-environment-setup)
+  - [Locally Build & Deploy KEDA HTTP Addon](#locally-build--deploy-keda-http-addon)
+    - [Pre-requisite](#pre-requisite)
+    - [Building](#building)
+    - [Deploying](#deploying)
+    - [Load testing with k9s](#load-testing-with-k9s)
   - [Developer Certificate of Origin: Signing your work](#developer-certificate-of-origin-signing-your-work)
     - [Every commit needs to be signed](#every-commit-needs-to-be-signed)
     - [I didn't sign my commit, now what?!](#i-didnt-sign-my-commit-now-what)
@@ -32,6 +37,83 @@ For any contribution you make that impacts the behavior or experience of the KED
 We have a comprehensive how-to document that details the setup and configuration of the development environment for this project.
 
 Please find it at [docs/developing.md](./docs/developing.md).
+
+## Locally Build & Deploy KEDA HTTP Addon
+
+### Pre-requisite:
+
+- A running cluster with Keda installed.
+- [Mage](https://magefile.org/)
+- [Helm](https://helm.sh/)
+- [k9s](https://github.com/derailed/k9s) 
+- Set the required environment variables explained [here](https://github.com/kedacore/http-add-on/blob/main/docs/developing.md#required-environment-variables).
+
+### Building: 
+
+- Fork & clone the repo : https://github.com/kedacore/http-add-on.git
+- cd http-add-on
+- Use Mage to build with : 
+   ```
+   mage build: build local binaries
+   mage dockerBuild: build docker images of the components
+   ```
+ If the environment variables are not setup , the docker build will fail so remember to export the right variable values.
+
+### Deploying:
+
+Custom KEDA-http-addon as an image
+
+- Make your changes in the code
+- Build and publish images with your changes, remember  to 	set your environment variables for images as per the registry of your choice and run 
+  ```
+  $ mage dockerBuild
+  ```
+ If you want to deploy with docker or any other registry of your choice then use right address in setting the images. 
+
+ There are local clusters with local registries provided, in such cases  make sure to use and push your images to its local registry. In the case of MicroK8s, the address is localhost:32000 and the helm install command would look like the following.
+```   
+$ helm repo add kedacore https://kedacore.github.io/charts
+$ helm repo update
+$ helm pull kedacore/keda-add-ons-http --untar --untardir ./charts
+$ helm upgrade kedahttp ./charts/keda-add-ons-http \
+  --install \
+  --namespace ${NAMESPACE} \
+  --create-namespace \
+  --set image=localhost:32000/keda-http-operator \
+  --set images.scaler=localhost:32000/keda-http-scaler \
+  --set images.interceptor=localhost:32000/keda-http-interceptor
+```  
+ If you want to install the latest build of the HTTP Add on, set version to canary:
+ ``` 
+ $ helm install http-add-on kedacore/keda-add-ons-http --create-namespace --namespace ${NAMESPACE} --set images.tag=canary
+ ```
+### Load testing with k9s:
+
+K9s integrates Hey, a CLI tool to benchmark HTTP endpoints similar to AB bench. This preliminary feature currently supports benchmarking port-forwards and services. You can use this feature in load testing as follows:
+
+- Install an application to scale: we used the sample provided for which you have to clone 
+  ```
+  $ helm install xkcd ./examples/xkcd -n ${NAMESPACE}
+  ```
+- You'll need to clone the repository to get access to this chart. If you have your own Deployment and Service installed, you can go right to creating an HTTPScaledObject by
+  ```
+  $ kubectl create -n $NAMESPACE -f examples/v0.2.0/httpscaledobject.yaml
+  ```
+- Testing Your Installation using k9s:
+  ```
+  (a) Enter k9s dashboard using command:  `k9s`
+
+  (b) search for services using - “:service”
+
+  (c) HTTP traffic needs to route through the Service that the add on has set up. Find interceptor proxy service i.e. ‘keda-add-ons-http-interceptor-proxy’ and port forward it using <SHIFT+F>
+
+  (d) Search for the same port-forward in the list you get by command - “:pf”
+
+  (e) Enter the port-forward and apply <CTRL+L> to start a benchmark
+
+  (f) You can enter the port-forward to see the run stat details and performance.
+  ```  
+>You can customize the benchmark in k9s also. It's explained well in [here](https://k9scli.io/topics/bench/).
 
 ## Developer Certificate of Origin: Signing your work
 


### PR DESCRIPTION
Signed-off-by: Ritikaa96 <ritika@india.nec.com>

This PR adds documentation for local testing HTTP Addon in the CONTRIBUTING.md including build and deploy instruction on local setup as well as load testing using k9s.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #160 