### PR TITLE
feat: expose cooldownPeriod param to httpScaledObject

### DIFF
--- a/e2e/k8s.go
+++ b/e2e/k8s.go
@@ -56,6 +56,7 @@ func getScaledObject(
 		"",
 		1,
 		2,
+		30,
 	)
 	if err != nil {
 		return nil, err

--- a/operator/api/v1alpha1/httpscaledobject_types.go
+++ b/operator/api/v1alpha1/httpscaledobject_types.go
@@ -100,6 +100,8 @@ type HTTPScaledObjectSpec struct {
 	Replicas ReplicaStruct `json:"replicas,omitempty"`
 	//(optional) Target metric value
 	TargetPendingRequests int32 `json:"targetPendingRequests,omitempty" description:"The target metric value for the HPA (Default 100)"`
+	//(optional) Cooldown period value
+	CooldownPeriod int32 `json:"scaledownPeriod,omniempty" description:"Cooldown period (seconds) for resources to scale down(Default x)"`
 }
 
 // ScaleTargetRef contains all the details about an HTTP application to scale and route to

--- a/operator/controllers/scaled_object.go
+++ b/operator/controllers/scaled_object.go
@@ -34,6 +34,7 @@ func createOrUpdateScaledObject(
 		httpso.Spec.Host,
 		httpso.Spec.Replicas.Min,
 		httpso.Spec.Replicas.Max,
+		httpso.Spec.CooldownPeriod,
 	)
 	if appErr != nil {
 		return appErr

--- a/pkg/k8s/scaledobject.go
+++ b/pkg/k8s/scaledobject.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"embed"
 	"text/template"
+	"time"
 
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -53,6 +54,7 @@ func NewScaledObject(
 	host string,
 	minReplicas,
 	maxReplicas int32,
+	cooldownPeriod time.Duration,
 ) (*unstructured.Unstructured, error) {
 	// https://keda.sh/docs/1.5/faq/
 	// https://github.com/kedacore/keda/blob/aa0ea79450a1c7549133aab46f5b916efa2364ab/api/v1alpha1/scaledobject_types.go
@@ -81,6 +83,7 @@ func NewScaledObject(
 		"DeploymentName": deploymentName,
 		"ScalerAddress":  scalerAddress,
 		"Host":           host,
+		"CooldownPeriod": 
 	}); tplErr != nil {
 		return nil, tplErr
 	}

--- a/pkg/k8s/scaledobject.go
+++ b/pkg/k8s/scaledobject.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"embed"
 	"text/template"
-	"time"
 
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -54,7 +53,7 @@ func NewScaledObject(
 	host string,
 	minReplicas,
 	maxReplicas int32,
-	cooldownPeriod time.Duration,
+	cooldownPeriod int32,
 ) (*unstructured.Unstructured, error) {
 	// https://keda.sh/docs/1.5/faq/
 	// https://github.com/kedacore/keda/blob/aa0ea79450a1c7549133aab46f5b916efa2364ab/api/v1alpha1/scaledobject_types.go
@@ -83,7 +82,7 @@ func NewScaledObject(
 		"DeploymentName": deploymentName,
 		"ScalerAddress":  scalerAddress,
 		"Host":           host,
-		"CooldownPeriod": 
+		"CooldownPeriod": cooldownPeriod,
 	}); tplErr != nil {
 		return nil, tplErr
 	}


### PR DESCRIPTION
 - add cooldown to httpScaledObjectSpec
 - pass cooldown to ScaledObject factory

Signed-off-by: Somesh Koli <somesh.koli@headout.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_
Small feature patch for #562
PR exposes scaledobject param from keda core to httpscaledobject and passes down the same to scaledobject

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
