### PR TITLE
add CooldownPeriod to scaledobject template

### DIFF
--- a/pkg/k8s/templates/scaledobject.yaml
+++ b/pkg/k8s/templates/scaledobject.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   minReplicaCount: {{ .MinReplicas }}
   maxReplicaCount: {{ .MaxReplicas }}
+  cooldownPeriod: {{ .CooldownPeriod }}
   pollingInterval: 1
   scaleTargetRef:
     name: {{ .DeploymentName }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

Hi,
During some tests with the http-add-on I noticed, that the scaledownPeriod field of the HTTPScaledObject is not properly applied to the generated ScaledObject resource.
This pull request fixes this issue

Related to https://github.com/kedacore/http-add-on/issues/562
