### PR TITLE
feat: expose idleReplicaCount param to httpScaledObject

### DIFF
--- a/config/crd/bases/http.keda.sh_httpscaledobjects.yaml
+++ b/config/crd/bases/http.keda.sh_httpscaledobjects.yaml
@@ -33,6 +33,9 @@ spec:
     - jsonPath: .spec.replicas.max
       name: MaxReplicas
       type: integer
+    - jsonPath: .spec.replicas.idle
+      name: IdleReplicas
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -66,6 +69,11 @@ spec:
               replicas:
                 description: (optional) Replica information
                 properties:
+                  idle:
+                    description: Amount of replicas to have in the deployment while
+                      being idle
+                    format: int32
+                    type: integer
                   max:
                     description: Maximum amount of replicas to have in the deployment
                       (Default 100)

--- a/e2e/k8s.go
+++ b/e2e/k8s.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/codeskyblue/go-sh"
-	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,7 +32,28 @@ func deleteNS(ns string) error {
 	return sh.Command("kubectl", "delete", "namespace", ns).Run()
 }
 
-func getScaledObject(ctx context.Context, cl client.Client, ns string, name string) error {
-	var scaledObject kedav1alpha1.ScaledObject
-	return cl.Get(ctx, k8s.ObjKey(ns, name), &scaledObject)
+func getScaledObject(
+	ctx context.Context,
+	cl client.Client,
+	ns,
+	name string,
+) error {
+	scaledObject, err := k8s.NewScaledObject(
+		ns,
+		name,
+		"",
+		"",
+		"",
+		1,
+		2,
+		0,
+		30,
+	)
+	if err != nil {
+		return err
+	}
+	if err := cl.Get(ctx, k8s.ObjKey(ns, name), scaledObject); err != nil {
+		return err
+	}
+	return nil
 }

--- a/examples/xkcd/templates/httpscaledobject.yaml
+++ b/examples/xkcd/templates/httpscaledobject.yaml
@@ -12,3 +12,4 @@ spec:
     replicas:
         min: {{ .Values.autoscaling.http.minReplicas }}
         max: {{ .Values.autoscaling.http.maxReplicas }}
+        idle: {{ .Values.autoscaling.http.idleReplicas }}

--- a/examples/xkcd/values.yaml
+++ b/examples/xkcd/values.yaml
@@ -46,3 +46,4 @@ autoscaling:
   http:
     minReplicas: 0
     maxReplicas: 10
+    idleReplicas: 0

--- a/operator/api/v1alpha1/httpscaledobject_types.go
+++ b/operator/api/v1alpha1/httpscaledobject_types.go
@@ -83,7 +83,9 @@ type ReplicaStruct struct {
 	// Minimum amount of replicas to have in the deployment (Default 0)
 	Min *int32 `json:"min,omitempty" description:"Minimum amount of replicas to have in the deployment (Default 0)"`
 	// Maximum amount of replicas to have in the deployment (Default 100)
-	Max *int32 `json:"max,omitempty" description:"Maximum amount of replicas to have in the deployment (Default 100)"`
+	Max int32 `json:"max,omitempty" description:"Maximum amount of replicas to have in the deployment (Default 100)"`
+	// Amount of replicas to have in the deployment while being idle
+	Idle int32 `json:"idle,omitempty" description:"Amount of replicas to have in the deployment while being idle"`
 }
 
 // HTTPScaledObjectSpec defines the desired state of HTTPScaledObject
@@ -133,6 +135,7 @@ type HTTPScaledObjectStatus struct {
 // +kubebuilder:printcolumn:name="ScaleTargetPort",type="integer",JSONPath=".spec.scaleTargetRef"
 // +kubebuilder:printcolumn:name="MinReplicas",type="integer",JSONPath=".spec.replicas.min"
 // +kubebuilder:printcolumn:name="MaxReplicas",type="integer",JSONPath=".spec.replicas.max"
+// +kubebuilder:printcolumn:name="IdleReplicas",type="integer",JSONPath=".spec.replicas.idle"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Active",type="string",JSONPath=".status.conditions[?(@.type==\"HTTPScaledObjectIsReady\")].status"
 

--- a/operator/controllers/scaled_object.go
+++ b/operator/controllers/scaled_object.go
@@ -26,22 +26,16 @@ func createOrUpdateScaledObject(
 	httpso *v1alpha1.HTTPScaledObject,
 ) error {
 	logger.Info("Creating scaled objects", "external scaler host name", externalScalerHostName)
-
-	var minReplicaCount *int32
-	var maxReplicaCount *int32
-	if replicas := httpso.Spec.Replicas; replicas != nil {
-		minReplicaCount = replicas.Min
-		maxReplicaCount = replicas.Max
-	}
-
-	appScaledObject := k8s.NewScaledObject(
+	logger.Info("This is the current httpso object", "output", httpso.Spec)
+	appScaledObject, appErr := k8s.NewScaledObject(
 		httpso.GetNamespace(),
 		fmt.Sprintf("%s-app", httpso.GetName()), // HTTPScaledObject name is the same as the ScaledObject name
 		httpso.Spec.ScaleTargetRef.Deployment,
 		externalScalerHostName,
 		httpso.Spec.Host,
-		minReplicaCount,
-		maxReplicaCount,
+		httpso.Spec.Replicas.Min,
+		httpso.Spec.Replicas.Max,
+		httpso.Spec.Replicas.Idle,
 		httpso.Spec.CooldownPeriod,
 	)
 

--- a/operator/controllers/suite_test.go
+++ b/operator/controllers/suite_test.go
@@ -31,6 +31,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/kedacore/http-add-on/operator/api/v1alpha1"
 	httpv1alpha1 "github.com/kedacore/http-add-on/operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
@@ -84,6 +85,11 @@ func newCommonTestInfra(namespace, appName string) *commonTestInfra {
 				Deployment: appName,
 				Service:    appName,
 				Port:       8081,
+			},
+			Replicas: v1alpha1.ReplicaStruct{
+				Min:  0,
+				Max:  20,
+				Idle: 0,
 			},
 		},
 	}

--- a/pkg/k8s/templates/scaledobject.yaml
+++ b/pkg/k8s/templates/scaledobject.yaml
@@ -1,0 +1,25 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+  labels:
+  {{- range $key, $val := .Labels }}
+    {{ $key }}: {{ $val }}
+  {{- end }}
+spec:
+  minReplicaCount: {{ .MinReplicas }}
+  maxReplicaCount: {{ .MaxReplicas }}
+  idleReplicaCount: {{ .IdleReplicas }}
+  cooldownPeriod: {{ .CooldownPeriod }}
+  pollingInterval: 1
+  scaleTargetRef:
+    name: {{ .DeploymentName }}
+    kind: Deployment
+  triggers:
+    - type: external-push
+      metadata:
+        scalerAddress: {{ .ScalerAddress }}
+        host: {{ .Host }}
+  advanced:
+    restoreToOriginalReplicaCount: true


### PR DESCRIPTION
Signed-off-by: Luca Kuendig <luca.kuendig@bedag.ch>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

I added spec.replicas.idle which allows to pass a value for spec.idleReplicaCount to the generated ScaledObject. We need this to work for our current use-case. 

Pls tell me if I need to update any docs. On first glance I could not find anything that would need an update.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
