### PR TITLE
fix: increase TestRunProxyServerCountMiddleware timeout

### DIFF
--- a/interceptor/main_test.go
+++ b/interceptor/main_test.go
@@ -116,7 +116,7 @@ func TestRunProxyServerCountMiddleware(t *testing.T) {
 	case hostAndCount := <-q.ResizedCh:
 		r.Equal(host, hostAndCount.Host)
 		r.Equal(+1, hostAndCount.Count)
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(1000 * time.Millisecond):
 		r.Fail("timeout waiting for +1 queue resize")
 	}
 
@@ -127,7 +127,7 @@ func TestRunProxyServerCountMiddleware(t *testing.T) {
 	case hostAndCount := <-q.ResizedCh:
 		r.Equal(host, hostAndCount.Host)
 		r.Equal(-1, hostAndCount.Count)
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(1000 * time.Millisecond):
 		r.Fail("timeout waiting for -1 queue resize")
 	}
 


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
