### PR TITLE
routing: lookup host without port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Fixes
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Routing**: Lookup host without port ([#608](https://github.com/kedacore/http-add-on/issues/608))
 
 ### Deprecations
 

--- a/interceptor/proxy_handlers.go
+++ b/interceptor/proxy_handlers.go
@@ -92,7 +92,7 @@ func newForwardingHandler(
 			}
 			return
 		}
-		targetSvcURL, err := targetSvcURL(routingTarget)
+		targetSvcURL, err := targetSvcURL(*routingTarget)
 		if err != nil {
 			lggr.Error(err, "forwarding failed")
 			w.WriteHeader(500)

--- a/operator/controllers/routing_table_test.go
+++ b/operator/controllers/routing_table_test.go
@@ -58,7 +58,7 @@ func TestRoutingTable(t *testing.T) {
 
 	retTarget, err := table.Lookup(host)
 	r.NoError(err)
-	r.Equal(target, retTarget)
+	r.Equal(&target, retTarget)
 
 	r.NoError(removeAndUpdateRoutingTable(
 		ctx,

--- a/pkg/routing/suite_test.go
+++ b/pkg/routing/suite_test.go
@@ -1,0 +1,13 @@
+package routing
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRouting(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Routing Suite")
+}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

Move from exact match for routing table host lookup to a domain-only match, ignoring ports.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #608
