### PR TITLE
chore: Remove v1.23 from e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -95,10 +95,6 @@ jobs:
         - kubernetesVersion: v1.24
           kindImage: kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-          cache: true
       - uses: actions/checkout@v3
 
       - name: Helm install

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -20,8 +20,6 @@ jobs:
           kindImage: kindest/node:v1.25.0@sha256:428aaa17ec82ccde0131cb2d1ca6547d13cf5fdabcc0bbecf749baa935387cbf
         - kubernetesVersion: v1.24
           kindImage: kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98
-        - kubernetesVersion: v1.23
-          kindImage: kindest/node:v1.23.10@sha256:f047448af6a656fae7bc909e2fab360c18c487ef3edc93f06d78cdfd864b2d12
     steps:
       - name: Install prerequisites
         run: |
@@ -88,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetesVersion: [v1.26, v1.25, v1.24, v1.23]
+        kubernetesVersion: [v1.26, v1.25, v1.24]
         include:
         - kubernetesVersion: v1.26
           kindImage: kindest/node:v1.26.0@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
@@ -96,8 +94,6 @@ jobs:
           kindImage: kindest/node:v1.25.0@sha256:428aaa17ec82ccde0131cb2d1ca6547d13cf5fdabcc0bbecf749baa935387cbf
         - kubernetesVersion: v1.24
           kindImage: kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98
-        - kubernetesVersion: v1.23
-          kindImage: kindest/node:v1.23.10@sha256:f047448af6a656fae7bc909e2fab360c18c487ef3edc93f06d78cdfd864b2d12
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetesVersion: [v1.26, v1.25, v1.24, v1.23]
+        kubernetesVersion: [v1.26, v1.25, v1.24]
         include:
         - kubernetesVersion: v1.26
           kindImage: kindest/node:v1.26.0@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -95,6 +95,10 @@ jobs:
         - kubernetesVersion: v1.24
           kindImage: kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98
     steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+          cache: true
       - uses: actions/checkout@v3
 
       - name: Helm install


### PR DESCRIPTION
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

