### PR TITLE
Update ARM64 e2e test flow

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -97,6 +97,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.19
+
       - name: Helm install
         uses: Azure/setup-helm@v3
 


### PR DESCRIPTION
ARM64 e2e tests were failing due to missing step to install go

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

