### PR TITLE
Fix flaky E2E tests by changing replica count constants

### DIFF
--- a/tests/checks/ingress_in_app_namespace/ingress_in_app_namespace_test.go
+++ b/tests/checks/ingress_in_app_namespace/ingress_in_app_namespace_test.go
@@ -23,7 +23,7 @@ var (
 	serviceName          = fmt.Sprintf("%s-service", testName)
 	ingressName          = fmt.Sprintf("%s-ingress", testName)
 	httpScaledObjectName = fmt.Sprintf("%s-http-so", testName)
-	ingressHost          = fmt.Sprintf("http://%s-controller.%s", IngressReleaseName, IngressNamespace)
+	ingressHost          = fmt.Sprintf("http://%s-controller.%s/", IngressReleaseName, IngressNamespace)
 	host                 = testName
 	initReplicaCount     = 0
 	minReplicaCount      = 1
@@ -141,10 +141,13 @@ spec:
   template:
     spec:
       containers:
-      - name: curl-client
-        image: curlimages/curl
+      - name: generate-request
+        image: alpine
         imagePullPolicy: Always
-        command: ["curl", "-H", "Host: {{.Host}}", "{{.IngressHost}}"]
+        command:
+		- sh
+		- -c
+		- 'apk add apache2-utils && ab -H "Host: {{.Host}}" -c 25 -n 1000000 "{{.IngressHost}}"'
       restartPolicy: Never
   activeDeadlineSeconds: 600
   backoffLimit: 5

--- a/tests/checks/ingress_in_app_namespace/ingress_in_app_namespace_test.go
+++ b/tests/checks/ingress_in_app_namespace/ingress_in_app_namespace_test.go
@@ -25,8 +25,9 @@ var (
 	httpScaledObjectName = fmt.Sprintf("%s-http-so", testName)
 	ingressHost          = fmt.Sprintf("http://%s-controller.%s", IngressReleaseName, IngressNamespace)
 	host                 = testName
-	minReplicaCount      = 0
-	maxReplicaCount      = 1
+	initReplicaCount     = 0
+	minReplicaCount      = 1
+	maxReplicaCount      = 2
 )
 
 type templateData struct {
@@ -38,6 +39,7 @@ type templateData struct {
 	IngressHost          string
 	HTTPScaledObjectName string
 	Host                 string
+	Replicas             int
 	MinReplicas          int
 	MaxReplicas          int
 }
@@ -105,7 +107,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: {{.Replicas}}
   selector:
     matchLabels:
       app: {{.DeploymentName}}
@@ -216,6 +218,7 @@ func getTemplateData() (templateData, []Template) {
 			HTTPScaledObjectName: httpScaledObjectName,
 			IngressHost:          ingressHost,
 			Host:                 host,
+			Replicas:             initReplicaCount,
 			MinReplicas:          minReplicaCount,
 			MaxReplicas:          maxReplicaCount,
 		}, []Template{

--- a/tests/checks/ingress_in_keda_namespace/ingress_in_keda_namespace_test.go
+++ b/tests/checks/ingress_in_keda_namespace/ingress_in_keda_namespace_test.go
@@ -25,8 +25,9 @@ var (
 	httpScaledObjectName = fmt.Sprintf("%s-http-so", testName)
 	ingressHost          = fmt.Sprintf("http://%s-controller.%s", IngressReleaseName, IngressNamespace)
 	host                 = testName
-	minReplicaCount      = 0
-	maxReplicaCount      = 1
+	initReplicaCount     = 0
+	minReplicaCount      = 1
+	maxReplicaCount      = 2
 )
 
 type templateData struct {
@@ -38,6 +39,7 @@ type templateData struct {
 	IngressHost          string
 	HTTPScaledObjectName string
 	Host                 string
+	Replicas             int
 	MinReplicas          int
 	MaxReplicas          int
 }
@@ -93,7 +95,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: {{.Replicas}}
   selector:
     matchLabels:
       app: {{.DeploymentName}}
@@ -204,6 +206,7 @@ func getTemplateData() (templateData, []Template) {
 			HTTPScaledObjectName: httpScaledObjectName,
 			IngressHost:          ingressHost,
 			Host:                 host,
+			Replicas:             initReplicaCount,
 			MinReplicas:          minReplicaCount,
 			MaxReplicas:          maxReplicaCount,
 		}, []Template{

--- a/tests/checks/ingress_in_keda_namespace/ingress_in_keda_namespace_test.go
+++ b/tests/checks/ingress_in_keda_namespace/ingress_in_keda_namespace_test.go
@@ -23,7 +23,7 @@ var (
 	serviceName          = fmt.Sprintf("%s-service", testName)
 	ingressName          = fmt.Sprintf("%s-ingress", testName)
 	httpScaledObjectName = fmt.Sprintf("%s-http-so", testName)
-	ingressHost          = fmt.Sprintf("http://%s-controller.%s", IngressReleaseName, IngressNamespace)
+	ingressHost          = fmt.Sprintf("http://%s-controller.%s/", IngressReleaseName, IngressNamespace)
 	host                 = testName
 	initReplicaCount     = 0
 	minReplicaCount      = 1
@@ -129,10 +129,13 @@ spec:
   template:
     spec:
       containers:
-      - name: curl-client
-        image: curlimages/curl
+      - name: generate-request
+        image: alpine
         imagePullPolicy: Always
-        command: ["curl", "-H", "Host: {{.Host}}", "{{.IngressHost}}"]
+        command:
+		- sh
+		- -c
+		- 'apk add apache2-utils && ab -H "Host: {{.Host}}" -c 25 -n 1000000 "{{.IngressHost}}"'
       restartPolicy: Never
   activeDeadlineSeconds: 600
   backoffLimit: 5

--- a/tests/checks/internal_service/internal_service_test.go
+++ b/tests/checks/internal_service/internal_service_test.go
@@ -101,10 +101,13 @@ spec:
   template:
     spec:
       containers:
-      - name: curl-client
-        image: curlimages/curl
+      - name: generate-request
+        image: alpine
         imagePullPolicy: Always
-        command: ["curl", "-H", "Host: {{.Host}}", "keda-http-add-on-interceptor-proxy.keda:8080"]
+        command:
+		- sh
+		- -c
+		- 'apk add apache2-utils && ab -H "Host: {{.Host}}" -c 25 -n 1000000 "http://keda-http-add-on-interceptor-proxy.keda:8080/"'
       restartPolicy: Never
   activeDeadlineSeconds: 600
   backoffLimit: 5

--- a/tests/checks/internal_service/internal_service_test.go
+++ b/tests/checks/internal_service/internal_service_test.go
@@ -23,8 +23,9 @@ var (
 	serviceName          = fmt.Sprintf("%s-service", testName)
 	httpScaledObjectName = fmt.Sprintf("%s-http-so", testName)
 	host                 = testName
-	minReplicaCount      = 0
-	maxReplicaCount      = 1
+	initReplicaCount     = 0
+	minReplicaCount      = 1
+	maxReplicaCount      = 2
 )
 
 type templateData struct {
@@ -33,6 +34,7 @@ type templateData struct {
 	ServiceName          string
 	HTTPScaledObjectName string
 	Host                 string
+	Replicas             int
 	MinReplicas          int
 	MaxReplicas          int
 }
@@ -65,7 +67,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: {{.Replicas}}
   selector:
     matchLabels:
       app: {{.DeploymentName}}
@@ -171,6 +173,7 @@ func getTemplateData() (templateData, []Template) {
 			ServiceName:          serviceName,
 			HTTPScaledObjectName: httpScaledObjectName,
 			Host:                 host,
+			Replicas:             initReplicaCount,
 			MinReplicas:          minReplicaCount,
 			MaxReplicas:          maxReplicaCount,
 		}, []Template{

--- a/tests/checks/multiple_hosts/multiple_hosts_test.go
+++ b/tests/checks/multiple_hosts/multiple_hosts_test.go
@@ -24,8 +24,9 @@ var (
 	httpScaledObjectName = fmt.Sprintf("%s-http-so", testName)
 	host1                = fmt.Sprintf("%s-host1", testName)
 	host2                = fmt.Sprintf("%s-host2", testName)
-	minReplicaCount      = 0
-	maxReplicaCount      = 1
+	initReplicaCount     = 0
+	minReplicaCount      = 1
+	maxReplicaCount      = 2
 )
 
 type templateData struct {
@@ -36,6 +37,7 @@ type templateData struct {
 	Host                 string
 	Host1                string
 	Host2                string
+	Replicas             int
 	MinReplicas          int
 	MaxReplicas          int
 }
@@ -68,7 +70,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: {{.Replicas}}
   selector:
     matchLabels:
       app: {{.DeploymentName}}
@@ -179,6 +181,7 @@ func getTemplateData() (templateData, []Template) {
 			HTTPScaledObjectName: httpScaledObjectName,
 			Host1:                host1,
 			Host2:                host2,
+			Replicas:             initReplicaCount,
 			MinReplicas:          minReplicaCount,
 			MaxReplicas:          maxReplicaCount,
 		}, []Template{

--- a/tests/checks/multiple_hosts/multiple_hosts_test.go
+++ b/tests/checks/multiple_hosts/multiple_hosts_test.go
@@ -104,10 +104,13 @@ spec:
   template:
     spec:
       containers:
-      - name: curl-client
-        image: curlimages/curl
+      - name: generate-request
+        image: alpine
         imagePullPolicy: Always
-        command: ["curl", "-H", "Host: {{.Host}}", "keda-http-add-on-interceptor-proxy.keda:8080"]
+        command:
+		- sh
+		- -c
+		- 'apk add apache2-utils && ab -H "Host: {{.Host}}" -c 25 -n 1000000 "http://keda-http-add-on-interceptor-proxy.keda:8080/"'
       restartPolicy: Never
   activeDeadlineSeconds: 600
   backoffLimit: 5

--- a/tests/checks/path_prefix/path_prefix_test.go
+++ b/tests/checks/path_prefix/path_prefix_test.go
@@ -108,10 +108,13 @@ spec:
   template:
     spec:
       containers:
-      - name: curl-client
-        image: curlimages/curl
+      - name: generate-request
+        image: alpine
         imagePullPolicy: Always
-        command: ["curl", "-H", "Host: {{.Host}}", "keda-http-add-on-interceptor-proxy.keda:8080{{.PathPrefix}}"]
+        command:
+		- sh
+		- -c
+		- 'apk add apache2-utils && ab -H "Host: {{.Host}}" -c 25 -n 1000000 "http://keda-http-add-on-interceptor-proxy.keda:8080/"'
       restartPolicy: Never
   activeDeadlineSeconds: 600
   backoffLimit: 5

--- a/tests/checks/path_prefix/path_prefix_test.go
+++ b/tests/checks/path_prefix/path_prefix_test.go
@@ -27,8 +27,9 @@ var (
 	notPathPrefix0       = "/123/4567"
 	pathPrefix1          = "/qwe/rty"
 	notPathPrefix1       = "/qwe/rt"
-	minReplicaCount      = 0
-	maxReplicaCount      = 1
+	initReplicaCount     = 0
+	minReplicaCount      = 1
+	maxReplicaCount      = 2
 )
 
 type templateData struct {
@@ -42,6 +43,7 @@ type templateData struct {
 	PathPrefix1          string
 	MinReplicas          int
 	MaxReplicas          int
+	Replicas             int
 }
 
 const (
@@ -72,7 +74,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: {{.Replicas}}
   selector:
     matchLabels:
       app: {{.DeploymentName}}
@@ -210,6 +212,7 @@ func getTemplateData() (templateData, []Template) {
 			Host:                 host,
 			PathPrefix0:          pathPrefix0,
 			PathPrefix1:          pathPrefix1,
+			Replicas:             initReplicaCount,
 			MinReplicas:          minReplicaCount,
 			MaxReplicas:          maxReplicaCount,
 		}, []Template{

--- a/tests/checks/single_host/single_host_test.go
+++ b/tests/checks/single_host/single_host_test.go
@@ -23,8 +23,9 @@ var (
 	serviceName          = fmt.Sprintf("%s-service", testName)
 	httpScaledObjectName = fmt.Sprintf("%s-http-so", testName)
 	host                 = testName
-	minReplicaCount      = 0
-	maxReplicaCount      = 1
+	initReplicaCount     = 0
+	minReplicaCount      = 1
+	maxReplicaCount      = 2
 )
 
 type templateData struct {
@@ -33,6 +34,7 @@ type templateData struct {
 	ServiceName          string
 	HTTPScaledObjectName string
 	Host                 string
+	Replicas             int
 	MinReplicas          int
 	MaxReplicas          int
 }
@@ -65,7 +67,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: {{.Replicas}}
   selector:
     matchLabels:
       app: {{.DeploymentName}}
@@ -170,6 +172,7 @@ func getTemplateData() (templateData, []Template) {
 			ServiceName:          serviceName,
 			HTTPScaledObjectName: httpScaledObjectName,
 			Host:                 host,
+			Replicas:             initReplicaCount,
 			MinReplicas:          minReplicaCount,
 			MaxReplicas:          maxReplicaCount,
 		}, []Template{

--- a/tests/checks/single_host/single_host_test.go
+++ b/tests/checks/single_host/single_host_test.go
@@ -101,10 +101,13 @@ spec:
   template:
     spec:
       containers:
-      - name: curl-client
-        image: curlimages/curl
+      - name: generate-request
+        image: alpine
         imagePullPolicy: Always
-        command: ["curl", "-H", "Host: {{.Host}}", "keda-http-add-on-interceptor-proxy.keda:8080"]
+        command:
+		- sh
+		- -c
+		- 'apk add apache2-utils && ab -H "Host: {{.Host}}" -c 25 -n 1000000 "http://keda-http-add-on-interceptor-proxy.keda:8080/"'
       restartPolicy: Never
   activeDeadlineSeconds: 600
   backoffLimit: 5


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

Before, the initial replica count was 1, the minimum replica count was 0, and the maximum replica count was 1.

The first step of each E2E test is to wait for the ready replicas of the Deployment to reach the minimum replica count. But any Deployment starts with 0 ready replicas and increases that number up to the initial replica count value as pods are created and become ready.

This was being misinterpreted as the scaler performing these operations, causing some tests to always succeed and other ones to occasionally fail.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)
