### PR TITLE
fix: HTTPScaledObject is the owner of the underlying ScaledObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Fixes
 
+- **General**: HTTPScaledObject is the owner of the underlying ScaledObject ([#703](https://github.com/kedacore/http-add-on/issues/703))
 - **Routing**: Lookup host without port ([#608](https://github.com/kedacore/http-add-on/issues/608))
 - **Controller**: Use kedav1alpha1.ScaledObject default values ([#607](https://github.com/kedacore/http-add-on/issues/607))
 - **General**: Changes to HTTPScaledObjects now take effect ([#605](https://github.com/kedacore/http-add-on/issues/605))

--- a/operator/controllers/http/app.go
+++ b/operator/controllers/http/app.go
@@ -80,7 +80,7 @@ func removeApplicationResources(
 	return nil
 }
 
-func createOrUpdateApplicationResources(
+func (r *HTTPScaledObjectReconciler) createOrUpdateApplicationResources(
 	ctx context.Context,
 	logger logr.Logger,
 	cl client.Client,
@@ -114,7 +114,7 @@ func createOrUpdateApplicationResources(
 	// the app deployment and the interceptor deployment.
 	// this needs to be submitted so that KEDA will scale both the app and
 	// interceptor
-	return createOrUpdateScaledObject(
+	return r.createOrUpdateScaledObject(
 		ctx,
 		cl,
 		logger,

--- a/operator/controllers/http/app.go
+++ b/operator/controllers/http/app.go
@@ -4,81 +4,12 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kedacore/http-add-on/operator/apis/http/v1alpha1"
 	"github.com/kedacore/http-add-on/operator/controllers/http/config"
 )
-
-func removeApplicationResources(
-	ctx context.Context,
-	logger logr.Logger,
-	cl client.Client,
-	httpso *v1alpha1.HTTPScaledObject,
-) error {
-	defer SaveStatus(context.Background(), logger, cl, httpso)
-	// Set initial statuses
-	AddCondition(
-		httpso,
-		*SetMessage(
-			CreateCondition(
-				v1alpha1.Terminating,
-				v1.ConditionUnknown,
-				v1alpha1.TerminatingResources,
-			),
-			"Received termination signal",
-		),
-	)
-
-	logger = logger.WithValues(
-		"reconciler.appObjects",
-		"removeObjects",
-		"HTTPScaledObject.name",
-		httpso.Name,
-		"HTTPScaledObject.namespace",
-		httpso.Namespace,
-	)
-
-	// Delete App ScaledObject
-	scaledObject := &unstructured.Unstructured{}
-	scaledObject.SetNamespace(httpso.Namespace)
-	scaledObject.SetName(httpso.Name)
-	scaledObject.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "keda.sh",
-		Kind:    "ScaledObject",
-		Version: "v1alpha1",
-	})
-	if err := cl.Delete(ctx, scaledObject); err != nil {
-		if apierrs.IsNotFound(err) {
-			logger.Info("App ScaledObject not found, moving on")
-		} else {
-			logger.Error(err, "Deleting scaledobject")
-			AddCondition(
-				httpso,
-				*SetMessage(
-					CreateCondition(
-						v1alpha1.Error,
-						v1.ConditionFalse,
-						v1alpha1.AppScaledObjectTerminationError,
-					),
-					err.Error(),
-				),
-			)
-			return err
-		}
-	}
-	AddCondition(httpso, *CreateCondition(
-		v1alpha1.Terminated,
-		v1.ConditionTrue,
-		v1alpha1.AppScaledObjectTerminated,
-	))
-
-	return nil
-}
 
 func (r *HTTPScaledObjectReconciler) createOrUpdateApplicationResources(
 	ctx context.Context,

--- a/operator/controllers/http/httpscaledobject_controller.go
+++ b/operator/controllers/http/httpscaledobject_controller.go
@@ -120,7 +120,7 @@ func (r *HTTPScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	)
 
 	// Create required app objects for the application defined by the CRD
-	if err := createOrUpdateApplicationResources(
+	if err := r.createOrUpdateApplicationResources(
 		ctx,
 		logger,
 		r.Client,

--- a/operator/controllers/http/httpscaledobject_controller.go
+++ b/operator/controllers/http/httpscaledobject_controller.go
@@ -76,26 +76,6 @@ func (r *HTTPScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	if httpso.GetDeletionTimestamp() != nil {
-		logger.Info("Deletion timestamp found", "httpscaledobject", *httpso)
-		// if it was marked deleted, delete all the related objects
-		// and don't schedule for another reconcile. Kubernetes
-		// will finalize them
-		// TODO: move this function call into `finalizeScaledObject`
-		removeErr := removeApplicationResources(
-			ctx,
-			logger,
-			r.Client,
-			httpso,
-		)
-		if removeErr != nil {
-			// if we failed to remove app resources, reschedule a reconcile so we can try
-			// again
-			logger.Error(removeErr, "Removing application objects")
-			return ctrl.Result{
-				RequeueAfter: 1000 * time.Millisecond,
-			}, removeErr
-		}
-		// after we've deleted app objects, we can finalize
 		return ctrl.Result{}, finalizeScaledObject(ctx, logger, r.Client, httpso)
 	}
 
@@ -120,25 +100,15 @@ func (r *HTTPScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	)
 
 	// Create required app objects for the application defined by the CRD
-	if err := r.createOrUpdateApplicationResources(
+	err := r.createOrUpdateApplicationResources(
 		ctx,
 		logger,
 		r.Client,
 		r.BaseConfig,
 		r.ExternalScalerConfig,
 		httpso,
-	); err != nil {
-		// if we failed to create app resources, remove what we've created and exit
-		logger.Error(err, "Removing app resources")
-		if removeErr := removeApplicationResources(
-			ctx,
-			logger,
-			r.Client,
-			httpso,
-		); removeErr != nil {
-			logger.Error(removeErr, "Removing previously created resources")
-		}
-
+	)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/tests/checks/ingress_in_app_namespace/ingress_in_app_namespace_test.go
+++ b/tests/checks/ingress_in_app_namespace/ingress_in_app_namespace_test.go
@@ -105,7 +105,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: {{.DeploymentName}}

--- a/tests/checks/ingress_in_keda_namespace/ingress_in_keda_namespace_test.go
+++ b/tests/checks/ingress_in_keda_namespace/ingress_in_keda_namespace_test.go
@@ -93,7 +93,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: {{.DeploymentName}}

--- a/tests/checks/internal_service/internal_service_test.go
+++ b/tests/checks/internal_service/internal_service_test.go
@@ -65,7 +65,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: {{.DeploymentName}}

--- a/tests/checks/multiple_hosts/multiple_hosts_test.go
+++ b/tests/checks/multiple_hosts/multiple_hosts_test.go
@@ -68,7 +68,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: {{.DeploymentName}}

--- a/tests/checks/path_prefix/path_prefix_test.go
+++ b/tests/checks/path_prefix/path_prefix_test.go
@@ -72,7 +72,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: {{.DeploymentName}}

--- a/tests/checks/single_host/single_host_test.go
+++ b/tests/checks/single_host/single_host_test.go
@@ -65,7 +65,7 @@ metadata:
   labels:
     app: {{.DeploymentName}}
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: {{.DeploymentName}}


### PR DESCRIPTION
In order to delete resources in cascade, we should set the owner reference on ScaledObjects

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes https://github.com/kedacore/http-add-on/issues/703
