### PR TITLE
feat: flush writes to http response on every chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,13 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Fixes
 
-- **Interceptor**: fatal error: concurrent map iteration and map write ([#726](https://github.com/kedacore/http-add-on/issues/726))
+- **Interceptor**: Add support for streaming responses ([#743](https://github.com/kedacore/http-add-on/issues/743))
+- **Interceptor**: Fatal error: concurrent map iteration and map write ([#726](https://github.com/kedacore/http-add-on/issues/726))
 - **Interceptor**: Keep original Host in the Host header ([#331](https://github.com/kedacore/http-add-on/issues/331))
 - **Interceptor**: Provide graceful shutdown for http servers on SIGINT and SIGTERM ([#731](https://github.com/kedacore/http-add-on/issues/731))
 - **Operator**: Remove ScaledObject `name` & `app` custom labels ([#717](https://github.com/kedacore/http-add-on/issues/717))
 - **Scaler**: Provide graceful shutdown for grpc server on SIGINT and SIGTERM ([#731](https://github.com/kedacore/http-add-on/issues/731))
 - **Scaler**: remplement custom interceptor metrics ([#718](https://github.com/kedacore/http-add-on/issues/718))
-- **Interceptor**: Add support for streaming responses ([#743](https://github.com/kedacore/http-add-on/issues/742))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This changelog keeps track of work items that have been completed and are ready 
 - **Operator**: Remove ScaledObject `name` & `app` custom labels ([#717](https://github.com/kedacore/http-add-on/issues/717))
 - **Scaler**: Provide graceful shutdown for grpc server on SIGINT and SIGTERM ([#731](https://github.com/kedacore/http-add-on/issues/731))
 - **Scaler**: remplement custom interceptor metrics ([#718](https://github.com/kedacore/http-add-on/issues/718))
-- **Interceptor**: Add support for streaming responses ([#726](https://github.com/kedacore/http-add-on/issues/743))
+- **Interceptor**: Add support for streaming responses ([#743](https://github.com/kedacore/http-add-on/issues/742))
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This changelog keeps track of work items that have been completed and are ready 
 - **Operator**: Remove ScaledObject `name` & `app` custom labels ([#717](https://github.com/kedacore/http-add-on/issues/717))
 - **Scaler**: Provide graceful shutdown for grpc server on SIGINT and SIGTERM ([#731](https://github.com/kedacore/http-add-on/issues/731))
 - **Scaler**: remplement custom interceptor metrics ([#718](https://github.com/kedacore/http-add-on/issues/718))
+- **Interceptor**: Add support for streaming responses ([#726](https://github.com/kedacore/http-add-on/issues/743))
 
 ### Deprecations
 

--- a/interceptor/middleware/loggingresponsewriter.go
+++ b/interceptor/middleware/loggingresponsewriter.go
@@ -32,6 +32,9 @@ func (lrw *loggingResponseWriter) Header() http.Header {
 
 func (lrw *loggingResponseWriter) Write(bytes []byte) (int, error) {
 	n, err := lrw.downstreamResponseWriter.Write(bytes)
+	if f, ok := lrw.downstreamResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 
 	lrw.bytesWritten += n
 


### PR DESCRIPTION
This pr enables streaming responses using the proxy code
Currently the logging middleware breaks streaming and responses are sent only upon completion

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #742 
