### PR TITLE
Increase scaler stream interval to 200ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Improvements
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Scaler**: Decrease memory usage by increasing stream interval from 5ms to 200ms.
 
 ### Fixes
 

--- a/scaler/handlers.go
+++ b/scaler/handlers.go
@@ -89,7 +89,7 @@ func (e *impl) StreamIsActive(
 	// this function communicates with KEDA via the 'server' parameter.
 	// we call server.Send (below) every 200ms, which tells it to immediately
 	// ping our IsActive RPC
-	ticker := time.NewTicker(5 * time.Millisecond)
+	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
 	for {
 		select {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

Currently the scaler uses a lot of memory when there're a lot of `HTTPScaledObject`s (We have 300+). Based on the heap snapshots, it seems that the `StreamIsActive` handler consumes most of memory. I adjusted the interval from 5ms to 200ms to fix this issue.

Part of heap graph, you can open heap snapshot files below for details.

<img width="370" alt="截圖 2023-07-31 16 01 35" src="https://github.com/kedacore/http-add-on/assets/411425/41c03e84-4f0f-4125-a186-d5e2bbbf9178">

Heap snapshots:
- [Before](https://github.com/kedacore/http-add-on/files/12212783/keda-http-addon-before.gz)
- [After](https://github.com/kedacore/http-add-on/files/12212790/keda-http-addon-after.gz)

Memory usage:

Before:

<img width="740" alt="截圖 2023-07-31 15 28 09拷貝" src="https://github.com/kedacore/http-add-on/assets/411425/c315dd6b-02f5-4e7c-9c6b-dfdd170efc54">

After:

<img width="722" alt="截圖 2023-07-31 15 34 16" src="https://github.com/kedacore/http-add-on/assets/411425/c019172e-5f64-4326-b1cf-8a8714026629">


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)