### PR TITLE
interceptor: don't override Host header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This changelog keeps track of work items that have been completed and are ready 
 - **Operator**: Remove ScaledObject `name` & `app` custom labels ([#717](https://github.com/kedacore/http-add-on/issues/717))
 - **Interceptor**: fatal error: concurrent map iteration and map write ([#726](https://github.com/kedacore/http-add-on/issues/726))
 - **Interceptor**: Provide graceful shutdown for http servers on SIGINT and SIGTERM ([#731](https://github.com/kedacore/http-add-on/issues/731))
+- **Interceptor**: Keep original Host in the Host header ([#731](https://github.com/kedacore/http-add-on/issues/331))
 - **Scaler**: Provide graceful shutdown for grpc server on SIGINT and SIGTERM ([#731](https://github.com/kedacore/http-add-on/issues/731))
 
 ### Deprecations

--- a/interceptor/handler/upstream.go
+++ b/interceptor/handler/upstream.go
@@ -37,10 +37,11 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(stream)
+	superDirector := proxy.Director
 	proxy.Transport = uh.roundTripper
 	proxy.Director = func(req *http.Request) {
+		superDirector(req)
 		req.URL = stream
-		req.Host = stream.Host
 		req.URL.Path = r.URL.Path
 		req.URL.RawQuery = r.URL.RawQuery
 		// delete the incoming X-Forwarded-For header so the proxy


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

As per my previous [PR](https://github.com/kedacore/http-add-on/pull/678) which was closed. Fixes [#331](https://github.com/kedacore/http-add-on/issues/331)
I believe this is relevant to quite some users, as there is no reasonable logic behind putting the target `SVC.NAMESPACE` as the value of the request's Host header.
Moreover, it breaks a lot of functionality.
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #331

