### PR TITLE
chore: Add an e2e test to check interceptor ScaledObject

### DIFF
--- a/tests/checks/interceptor_scaledobject/interceptor_scaledobject_test.go
+++ b/tests/checks/interceptor_scaledobject/interceptor_scaledobject_test.go
@@ -1,0 +1,22 @@
+//go:build e2e
+// +build e2e
+
+package interceptor_scaledobject_test
+
+import (
+	"testing"
+
+	. "github.com/kedacore/http-add-on/tests/helper"
+)
+
+const (
+	kedaNamespace               = "keda"
+	interceptorScaledObjectName = "keda-http-add-on-interceptor"
+	scaledObject                = "scaledobject"
+)
+
+func TestCheck(t *testing.T) {
+	predicate := `-o jsonpath="{.status.conditions[?(@.type=="Ready")].status}"`
+	expectedResult := "True"
+	CheckKubectlGetResult(t, scaledObject, interceptorScaledObjectName, kedaNamespace, predicate, expectedResult)
+}

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -635,3 +635,15 @@ func WaitForPodsTerminated(t *testing.T, kc *kubernetes.Clientset, selector, nam
 
 	return false
 }
+
+// CheckKubectlGetResult runs `kubectl get` with parameters and compares output with expected value
+func CheckKubectlGetResult(t *testing.T, kind string, name string, namespace string, otherparameter string, expected string) {
+	time.Sleep(1 * time.Second) // wait a second for recource deployment finished
+	kctlGetCmd := fmt.Sprintf(`kubectl get %s/%s -n %s %s"`, kind, name, namespace, otherparameter)
+	t.Log("Running kubectl cmd:", kctlGetCmd)
+	output, err := ExecuteCommand(kctlGetCmd)
+	assert.NoErrorf(t, err, "cannot get rollout info - %s", err)
+
+	unqoutedOutput := strings.ReplaceAll(string(output), "\"", "")
+	assert.Equal(t, expected, unqoutedOutput)
+}


### PR DESCRIPTION
To ensure that interceptor scaledobject doesn't stop working (as it has happened in the past), this PR adds an e2e check validating that the ScaledObject is ready

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
