### PR TITLE
Set the proxy RawPath to original requests RawPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 - **General**: Add new user agent probe ([#862](https://github.com/kedacore/http-add-on/issues/862))
 - **General**: Increase ScaledObject polling interval to 15 seconds ([#799](https://github.com/kedacore/http-add-on/issues/799))
+- **General**: Set forward request RawPath to original request RawPath ([#864](https://github.com/kedacore/http-add-on/issues/864))
 
 ### Deprecations
 

--- a/interceptor/handler/upstream.go
+++ b/interceptor/handler/upstream.go
@@ -43,6 +43,7 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		superDirector(req)
 		req.URL = stream
 		req.URL.Path = r.URL.Path
+		req.URL.RawPath = r.URL.RawPath
 		req.URL.RawQuery = r.URL.RawQuery
 		// delete the incoming X-Forwarded-For header so the proxy
 		// puts its own in. This is also important to prevent IP spoofing


### PR DESCRIPTION
I have set the RawPath of what I think is the forward request to that of the original request with the expectation escaped values in the request path are forwarded unmodified (still escaped).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #

#864
