### PR TITLE
Fix issue where external scaler gets wedged in a bad state when queue count metric fetch fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Fixes
 
 - **General**: Add new user agent probe ([#862](https://github.com/kedacore/http-add-on/issues/862))
-- **General**: Increase ScaledObject polling interval to 15 seconds ([#799](https://github.com/kedacore/http-add-on/issues/799))
 - **General**: Fix external scaler getting into bad state when retrieving queue lengths fails. ([#870](https://github.com/kedacore/http-add-on/issues/870))
+- **General**: Increase ScaledObject polling interval to 15 seconds ([#799](https://github.com/kedacore/http-add-on/issues/799))
 - **General**: Set forward request RawPath to original request RawPath ([#864](https://github.com/kedacore/http-add-on/issues/864))
 
 ### Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ This changelog keeps track of work items that have been completed and are ready 
 
 - **General**: Add new user agent probe ([#862](https://github.com/kedacore/http-add-on/issues/862))
 - **General**: Increase ScaledObject polling interval to 15 seconds ([#799](https://github.com/kedacore/http-add-on/issues/799))
+- **General**: Fix external scaler getting into bad state when retrieving queue lengths fails. ([#870](https://github.com/kedacore/http-add-on/issues/870))
 - **General**: Set forward request RawPath to original request RawPath ([#864](https://github.com/kedacore/http-add-on/issues/864))
-- **General**: Fix external scaler getting into bad state when retrieving queue lengths fails.
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This changelog keeps track of work items that have been completed and are ready 
 - **General**: Add new user agent probe ([#862](https://github.com/kedacore/http-add-on/issues/862))
 - **General**: Increase ScaledObject polling interval to 15 seconds ([#799](https://github.com/kedacore/http-add-on/issues/799))
 - **General**: Set forward request RawPath to original request RawPath ([#864](https://github.com/kedacore/http-add-on/issues/864))
+- **General**: Fix external scaler getting into bad state when retrieving queue lengths fails.
 
 ### Deprecations
 

--- a/scaler/queue_pinger.go
+++ b/scaler/queue_pinger.go
@@ -99,7 +99,6 @@ func (q *queuePinger) start(
 			err := q.fetchAndSaveCounts(ctx)
 			if err != nil {
 				lggr.Error(err, "getting request counts")
-				return fmt.Errorf("error getting request counts: %w", err)
 			}
 		// handle changes to the interceptor fleet
 		// Endpoints


### PR DESCRIPTION
Instead of returning an error when queue count fetch fails, only log an error and let the loop continue.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #870 
