### PR TITLE
feat: Propagate HTTPScaledObject labels and annotations to ScaledObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ This changelog keeps track of work items that have been completed and are ready 
 ## Unreleased
 
 ### Breaking Changes
+
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
 
 ### New
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **General**: Propagate HTTPScaledObject labels and annotations to ScaledObject ([#840](https://github.com/kedacore/http-add-on/issues/840))
 
 ### Improvements
 
@@ -41,7 +42,7 @@ New deprecation(s):
 
 Previously announced deprecation(s):
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **General**: Deprecated `KEDA_HTTP_DEPLOYMENT_CACHE_POLLING_INTERVAL_MS` in favor of `KEDA_HTTP_ENDPOINTS_CACHE_POLLING_INTERVAL_MS` ([#438](https://github.com/kedacore/http-add-on/issues/438))
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ You can find all deprecations in [this overview](https://github.com/kedacore/htt
 
 New deprecation(s):
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
 
 Previously announced deprecation(s):
 

--- a/operator/controllers/http/scaled_object.go
+++ b/operator/controllers/http/scaled_object.go
@@ -37,6 +37,8 @@ func (r *HTTPScaledObjectReconciler) createOrUpdateScaledObject(
 	appScaledObject := k8s.NewScaledObject(
 		httpso.GetNamespace(),
 		httpso.GetName(), // HTTPScaledObject name is the same as the ScaledObject name
+		httpso.Labels,
+		httpso.Annotations,
 		httpso.Spec.ScaleTargetRef,
 		externalScalerHostName,
 		httpso.Spec.Hosts,

--- a/operator/controllers/http/scaled_object_test.go
+++ b/operator/controllers/http/scaled_object_test.go
@@ -66,6 +66,16 @@ func TestCreateOrUpdateScaledObject(t *testing.T) {
 		metadata.Name,
 	)
 
+	r.EqualValues(
+		testInfra.httpso.ObjectMeta.Labels,
+		metadata.Labels,
+	)
+
+	r.EqualValues(
+		testInfra.httpso.ObjectMeta.Annotations,
+		metadata.Annotations,
+	)
+
 	var minReplicaCount *int32
 	var maxReplicaCount *int32
 	if replicas := testInfra.httpso.Spec.Replicas; replicas != nil {
@@ -98,6 +108,8 @@ func TestCreateOrUpdateScaledObject(t *testing.T) {
 	}
 	*testInfra.httpso.Spec.Replicas.Min++
 	*testInfra.httpso.Spec.Replicas.Max++
+	testInfra.httpso.ObjectMeta.Labels["test"] = "test-label"
+	testInfra.httpso.ObjectMeta.Annotations["test"] = "test-annotation"
 	r.NoError(reconciller.createOrUpdateScaledObject(
 		testInfra.ctx,
 		testInfra.cl,
@@ -114,6 +126,18 @@ func TestCreateOrUpdateScaledObject(t *testing.T) {
 		testInfra.httpso,
 	)
 	r.NoError(err)
+
+	metadata = retSO.ObjectMeta
+	r.EqualValues(
+		testInfra.httpso.ObjectMeta.Labels,
+		metadata.Labels,
+	)
+
+	r.EqualValues(
+		testInfra.httpso.ObjectMeta.Annotations,
+		metadata.Annotations,
+	)
+
 	spec = retSO.Spec
 	r.Equal(
 		*testInfra.httpso.Spec.Replicas.Min,

--- a/operator/controllers/http/suite_test.go
+++ b/operator/controllers/http/suite_test.go
@@ -106,6 +106,12 @@ func newCommonTestInfra(namespace, appName string) *commonTestInfra {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      appName,
+			Labels: map[string]string{
+				"label": "a",
+			},
+			Annotations: map[string]string{
+				"annotation": "b",
+			},
 		},
 		Spec: httpv1alpha1.HTTPScaledObjectSpec{
 			ScaleTargetRef: httpv1alpha1.ScaleTargetRef{

--- a/pkg/k8s/scaledobject.go
+++ b/pkg/k8s/scaledobject.go
@@ -23,6 +23,8 @@ const (
 func NewScaledObject(
 	namespace string,
 	name string,
+	labels map[string]string,
+	annotations map[string]string,
 	workloadRef v1alpha1.ScaleTargetRef,
 	scalerAddress string,
 	hosts []string,
@@ -37,8 +39,10 @@ func NewScaledObject(
 			Kind:       ObjectKind(&kedav1alpha1.ScaledObject{}),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+			Namespace:   namespace,
+			Name:        name,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: kedav1alpha1.ScaledObjectSpec{
 			ScaleTargetRef: &kedav1alpha1.ScaleTarget{


### PR DESCRIPTION
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)


Fixes https://github.com/kedacore/http-add-on/issues/840
