### PR TITLE
Scaler fails only when failing to get counts from all the interceptor endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This changelog keeps track of work items that have been completed and are ready 
 - [v0.5.0](#v050)
 
 ## Unreleased
+Scaler fails only when failing to get counts from all the interceptor endpoints.
 
 ### Breaking Changes
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))

--- a/pkg/queue/queue_rpc.go
+++ b/pkg/queue/queue_rpc.go
@@ -66,7 +66,7 @@ func GetCounts(
 	resp, err := httpCl.Get(interceptorURL.String())
 	if err != nil {
 		m := &Counts{
-			Counts: map[string]int{"all failed": -1},
+			Counts: map[string]int{"all failed": 0},
 		}
 		return m, nil
 	}

--- a/pkg/queue/queue_rpc.go
+++ b/pkg/queue/queue_rpc.go
@@ -65,7 +65,10 @@ func GetCounts(
 	interceptorURL.Path = countsPath
 	resp, err := httpCl.Get(interceptorURL.String())
 	if err != nil {
-		return nil, fmt.Errorf("requesting the queue counts from %s: %w", interceptorURL.String(), err)
+		m := &Counts{
+			Counts: map[string]int{"all failed": -1},
+		}
+		return m, nil
 	}
 	defer resp.Body.Close()
 	counts := NewCounts()

--- a/scaler/queue_pinger.go
+++ b/scaler/queue_pinger.go
@@ -254,6 +254,8 @@ func fetchCounts(
 		}
 	}
 
+	// if fetch all failed, throw error
+	// if any fetch succeeded, return counts from them
 	if _, found := totalCounts["all failed"]; found && len(totalCounts) == 1 {
 		return nil, 0, fmt.Errorf("fetching all counts failed, cannot reach any of the endpoints")
 	}

--- a/scaler/queue_pinger.go
+++ b/scaler/queue_pinger.go
@@ -254,5 +254,9 @@ func fetchCounts(
 		}
 	}
 
+	if _, found := totalCounts["all failed"]; found && len(totalCounts) == 1 {
+		return nil, 0, fmt.Errorf("fetching all counts failed, cannot reach any of the endpoints")
+	}
+
 	return totalCounts, agg, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_
We observe behavior that the scaler fails and exit the loop when failing to get counts from any of the interceptor replica.
Not sure this is the intended behavior but sometimes one interceptor replica is down only because it is on a spot node. When the node is down and the endpoints of the interceptor service is not updated yet, the scaler still try to get from and endpoint which does not exist. And most of the time the killed interceptor pod will heal itself.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
Change so that the scaler fails only when fetching all the counts failed.

Comment:
I am new to this, not sure the existing version is the intended behavior. Please let me know if there is a better way or it can be handled by any config value that I am not aware of. Appreciated.