### PR TITLE
CooldownPeriod (IsActive) is now managed by the Scaler using the time since the last request and not in-flight requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ## Unreleased
 
 ### Breaking Changes
+
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
 
 ### New
@@ -25,7 +26,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Improvements
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **General**: CooldownPeriod (IsActive) is now managed by the Scaler using the time since the last request and not in-flight requests ([#882](https://github.com/kedacore/http-add-on/issues/882))
 
 ### Fixes
 

--- a/interceptor/main_test.go
+++ b/interceptor/main_test.go
@@ -142,7 +142,7 @@ func TestRunProxyServerCountMiddleware(t *testing.T) {
 		"couldn't find host %s in the queue",
 		host,
 	)
-	r.Equal(0, counts[namespacedName])
+	r.Equal(0, counts[namespacedName].Requests)
 
 	done()
 	r.Error(g.Wait())

--- a/operator/controllers/http/scaled_object.go
+++ b/operator/controllers/http/scaled_object.go
@@ -43,7 +43,6 @@ func (r *HTTPScaledObjectReconciler) createOrUpdateScaledObject(
 		httpso.Spec.PathPrefixes,
 		minReplicaCount,
 		maxReplicaCount,
-		httpso.Spec.CooldownPeriod,
 	)
 
 	// Set HTTPScaledObject instance as the owner and controller

--- a/pkg/k8s/scaledobject.go
+++ b/pkg/k8s/scaledobject.go
@@ -14,11 +14,9 @@ const (
 	soPollingInterval = 15
 	soTriggerType     = "external-push"
 
-	mkScalerAddress       = "scalerAddress"
-	mkHosts               = "hosts"
-	mkPathPrefixes        = "pathPrefixes"
-	mkCooldownPeriod      = "cooldownPeriod"
-	defaultCooldownPeriod = "300"
+	mkScalerAddress = "scalerAddress"
+	mkHosts         = "hosts"
+	mkPathPrefixes  = "pathPrefixes"
 )
 
 // NewScaledObject creates a new ScaledObject in memory
@@ -31,13 +29,7 @@ func NewScaledObject(
 	pathPrefixes []string,
 	minReplicas *int32,
 	maxReplicas *int32,
-	cooldownPeriod *int32,
 ) *kedav1alpha1.ScaledObject {
-	scaledObjectCooldownPeriod := defaultCooldownPeriod
-	if cooldownPeriod != nil {
-		scaledObjectCooldownPeriod = string(*cooldownPeriod)
-	}
-
 	return &kedav1alpha1.ScaledObject{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: kedav1alpha1.SchemeGroupVersion.Identifier(),
@@ -64,10 +56,9 @@ func NewScaledObject(
 				{
 					Type: soTriggerType,
 					Metadata: map[string]string{
-						mkScalerAddress:  scalerAddress,
-						mkHosts:          strings.Join(hosts, ","),
-						mkPathPrefixes:   strings.Join(pathPrefixes, ","),
-						mkCooldownPeriod: scaledObjectCooldownPeriod,
+						mkScalerAddress: scalerAddress,
+						mkHosts:         strings.Join(hosts, ","),
+						mkPathPrefixes:  strings.Join(pathPrefixes, ","),
 					},
 				},
 			},

--- a/pkg/k8s/scaledobject.go
+++ b/pkg/k8s/scaledobject.go
@@ -14,9 +14,11 @@ const (
 	soPollingInterval = 15
 	soTriggerType     = "external-push"
 
-	mkScalerAddress = "scalerAddress"
-	mkHosts         = "hosts"
-	mkPathPrefixes  = "pathPrefixes"
+	mkScalerAddress       = "scalerAddress"
+	mkHosts               = "hosts"
+	mkPathPrefixes        = "pathPrefixes"
+	mkCooldownPeriod      = "cooldownPeriod"
+	defaultCooldownPeriod = "300"
 )
 
 // NewScaledObject creates a new ScaledObject in memory
@@ -31,6 +33,11 @@ func NewScaledObject(
 	maxReplicas *int32,
 	cooldownPeriod *int32,
 ) *kedav1alpha1.ScaledObject {
+	scaledObjectCooldownPeriod := defaultCooldownPeriod
+	if cooldownPeriod != nil {
+		scaledObjectCooldownPeriod = string(*cooldownPeriod)
+	}
+
 	return &kedav1alpha1.ScaledObject{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: kedav1alpha1.SchemeGroupVersion.Identifier(),
@@ -47,7 +54,7 @@ func NewScaledObject(
 				Name:       workloadRef.Name,
 			},
 			PollingInterval: ptr.To[int32](soPollingInterval),
-			CooldownPeriod:  cooldownPeriod,
+			CooldownPeriod:  Int32P(0),
 			MinReplicaCount: minReplicas,
 			MaxReplicaCount: maxReplicas,
 			Advanced: &kedav1alpha1.AdvancedConfig{
@@ -57,9 +64,10 @@ func NewScaledObject(
 				{
 					Type: soTriggerType,
 					Metadata: map[string]string{
-						mkScalerAddress: scalerAddress,
-						mkHosts:         strings.Join(hosts, ","),
-						mkPathPrefixes:  strings.Join(pathPrefixes, ","),
+						mkScalerAddress:  scalerAddress,
+						mkHosts:          strings.Join(hosts, ","),
+						mkPathPrefixes:   strings.Join(pathPrefixes, ","),
+						mkCooldownPeriod: scaledObjectCooldownPeriod,
 					},
 				},
 			},

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -93,8 +93,10 @@ func (r *Memory) Current() (*Counts, error) {
 	defer r.mut.RUnlock()
 	cts := NewCounts()
 	for key, val := range r.countMap {
-		cts.Counts[key] = val
-		cts.Activities[key] = r.activityMap[key]
+		cts.Counts[key] = Count{
+			Requests: val,
+			Activity: r.activityMap[key],
+		}
 	}
 	return cts, nil
 }

--- a/pkg/queue/queue_counts.go
+++ b/pkg/queue/queue_counts.go
@@ -16,15 +16,18 @@ type Counts struct {
 	json.Marshaler
 	json.Unmarshaler
 	fmt.Stringer
-	Counts     map[string]int
-	Activities map[string]time.Time
+	Counts map[string]Count
+}
+
+type Count struct {
+	Requests int
+	Activity time.Time
 }
 
 // NewQueueCounts creates a new empty QueueCounts struct
 func NewCounts() *Counts {
 	return &Counts{
-		Counts:     map[string]int{},
-		Activities: map[string]time.Time{},
+		Counts: map[string]Count{},
 	}
 }
 
@@ -32,7 +35,7 @@ func NewCounts() *Counts {
 func (q *Counts) Aggregate() int {
 	agg := 0
 	for _, count := range q.Counts {
-		agg += count
+		agg += count.Requests
 	}
 	return agg
 }
@@ -49,5 +52,5 @@ func (q *Counts) UnmarshalJSON(data []byte) error {
 
 // String implements fmt.Stringer
 func (q *Counts) String() string {
-	return fmt.Sprintf("%v-%v", q.Counts, q.Activities)
+	return fmt.Sprintf("%v", q.Counts)
 }

--- a/pkg/queue/queue_counts.go
+++ b/pkg/queue/queue_counts.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // Counts is a snapshot of the HTTP pending request queue counts
@@ -15,13 +16,15 @@ type Counts struct {
 	json.Marshaler
 	json.Unmarshaler
 	fmt.Stringer
-	Counts map[string]int
+	Counts     map[string]int
+	Activities map[string]time.Time
 }
 
 // NewQueueCounts creates a new empty QueueCounts struct
 func NewCounts() *Counts {
 	return &Counts{
-		Counts: map[string]int{},
+		Counts:     map[string]int{},
+		Activities: map[string]time.Time{},
 	}
 }
 
@@ -46,5 +49,5 @@ func (q *Counts) UnmarshalJSON(data []byte) error {
 
 // String implements fmt.Stringer
 func (q *Counts) String() string {
-	return fmt.Sprintf("%v", q.Counts)
+	return fmt.Sprintf("%v-%v", q.Counts, q.Activities)
 }

--- a/pkg/queue/queue_counts_test.go
+++ b/pkg/queue/queue_counts_test.go
@@ -9,15 +9,23 @@ import (
 func TestAggregate(t *testing.T) {
 	r := require.New(t)
 	counts := NewCounts()
-	counts.Counts = map[string]int{
-		"host1": 123,
-		"host2": 234,
-		"host3": 456,
-		"host4": 567,
+	counts.Counts = map[string]Count{
+		"host1": {
+			Requests: 123,
+		},
+		"host2": {
+			Requests: 234,
+		},
+		"host3": {
+			Requests: 345,
+		},
+		"host4": {
+			Requests: 456,
+		},
 	}
 	expectedAgg := 0
 	for _, v := range counts.Counts {
-		expectedAgg += v
+		expectedAgg += v.Requests
 	}
 	r.Equal(expectedAgg, counts.Aggregate())
 }

--- a/pkg/queue/queue_fakes.go
+++ b/pkg/queue/queue_fakes.go
@@ -73,8 +73,9 @@ func (f *FakeCounter) Current() (*Counts, error) {
 var _ CountReader = &FakeCountReader{}
 
 type FakeCountReader struct {
-	current int
-	err     error
+	current  int
+	activity time.Time
+	err      error
 }
 
 func (f *FakeCountReader) Current() (*Counts, error) {
@@ -82,6 +83,7 @@ func (f *FakeCountReader) Current() (*Counts, error) {
 	ret.Counts = map[string]Count{
 		"sample.com": {
 			Requests: f.current,
+			Activity: f.activity,
 		},
 	}
 	return ret, f.err

--- a/pkg/queue/queue_fakes.go
+++ b/pkg/queue/queue_fakes.go
@@ -62,7 +62,11 @@ func (f *FakeCounter) Current() (*Counts, error) {
 	f.mapMut.RLock()
 	defer f.mapMut.RUnlock()
 	retMap := f.RetMap
-	ret.Counts = retMap
+	for key, val := range retMap {
+		ret.Counts[key] = Count{
+			Requests: val,
+		}
+	}
 	return ret, nil
 }
 
@@ -75,8 +79,10 @@ type FakeCountReader struct {
 
 func (f *FakeCountReader) Current() (*Counts, error) {
 	ret := NewCounts()
-	ret.Counts = map[string]int{
-		"sample.com": f.current,
+	ret.Counts = map[string]Count{
+		"sample.com": {
+			Requests: f.current,
+		},
 	}
 	return ret, f.err
 }

--- a/pkg/queue/queue_rpc_test.go
+++ b/pkg/queue/queue_rpc_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
@@ -16,21 +17,23 @@ func TestQueueSizeHandlerSuccess(t *testing.T) {
 	lggr := logr.Discard()
 	r := require.New(t)
 	reader := &FakeCountReader{
-		current: 123,
-		err:     nil,
+		current:  123,
+		activity: time.Now(),
+		err:      nil,
 	}
 
 	handler := newSizeHandler(lggr, reader)
 	req, rec := pkghttp.NewTestCtx("GET", "/queue")
 	handler.ServeHTTP(rec, req)
 	r.Equal(200, rec.Code, "response code")
-	respMap := map[string]int{}
+	respMap := map[string]Count{}
 	decodeErr := json.NewDecoder(rec.Body).Decode(&respMap)
 	r.NoError(decodeErr)
 	r.Equalf(1, len(respMap), "response JSON length was not 1")
-	sizeVal, ok := respMap["sample.com"]
+	respItem, ok := respMap["sample.com"]
 	r.Truef(ok, "'sample.com' entry not available in return JSON")
-	r.Equalf(reader.current, sizeVal, "returned JSON queue size was wrong")
+	r.Equalf(reader.current, respItem.Requests, "returned JSON queue size was wrong")
+	r.WithinDuration(reader.activity, respItem.Activity, 200*time.Millisecond, "returned JSON activity was wrong")
 
 	reader.err = errors.New("test error")
 	req, rec = pkghttp.NewTestCtx("GET", "/queue")
@@ -56,8 +59,9 @@ func TestQueueSizeHandlerIntegration(t *testing.T) {
 	lggr := logr.Discard()
 	r := require.New(t)
 	reader := &FakeCountReader{
-		current: 50,
-		err:     nil,
+		current:  50,
+		activity: time.Now(),
+		err:      nil,
 	}
 
 	hdl := kedanet.NewTestHTTPHandlerWrapper(newSizeHandler(lggr, reader))
@@ -69,7 +73,8 @@ func TestQueueSizeHandlerIntegration(t *testing.T) {
 	r.NoError(err)
 	r.Equal(1, len(counts.Counts))
 	for _, val := range counts.Counts {
-		r.Equal(reader.current, val)
+		r.Equal(reader.current, val.Requests)
+		r.WithinDuration(reader.activity, val.Activity, 200*time.Millisecond)
 	}
 	reqs := hdl.IncomingRequests()
 	r.Equal(1, len(reqs))

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -14,10 +14,12 @@ func TestCurrent(t *testing.T) {
 	current, err := memory.Current()
 	r.NoError(err)
 	r.Equal(current.Counts, memory.countMap)
+	r.Equal(current.Activities, memory.activityMap)
 
 	err = memory.Resize("host1", 1)
 	r.NoError(err)
 	err = memory.Resize("host2", 1)
 	r.NoError(err)
 	r.NotEqual(current.Counts, memory.countMap)
+	r.NotEqual(current.Activities, memory.activityMap)
 }

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -13,13 +14,19 @@ func TestCurrent(t *testing.T) {
 	r.NoError(err)
 	current, err := memory.Current()
 	r.NoError(err)
-	r.Equal(current.Counts, memory.countMap)
-	r.Equal(current.Activities, memory.activityMap)
+	counts := map[string]int{}
+	activities := map[string]time.Time{}
+	for key, val := range current.Counts {
+		counts[key] = val.Requests
+		activities[key] = val.Activity
+	}
+	r.Equal(counts, memory.countMap)
+	r.Equal(activities, memory.activityMap)
 
 	err = memory.Resize("host1", 1)
 	r.NoError(err)
 	err = memory.Resize("host2", 1)
 	r.NoError(err)
-	r.NotEqual(current.Counts, memory.countMap)
-	r.NotEqual(current.Activities, memory.activityMap)
+	r.NotEqual(counts, memory.countMap)
+	r.NotEqual(activities, memory.activityMap)
 }

--- a/scaler/handlers.go
+++ b/scaler/handlers.go
@@ -61,7 +61,7 @@ func (e *impl) Ping(context.Context, *emptypb.Empty) (*emptypb.Empty, error) {
 }
 
 func (e *impl) IsActive(
-	ctx context.Context,
+	_ context.Context,
 	sor *externalscaler.ScaledObjectRef,
 ) (*externalscaler.IsActiveResponse, error) {
 	lggr := e.lggr.WithName("IsActive")

--- a/scaler/handlers_test.go
+++ b/scaler/handlers_test.go
@@ -37,7 +37,7 @@ func TestStreamIsActive(t *testing.T) {
 	}
 	testCases := []testCase{
 		{
-			name:        "Simple host inactive (deafult values)",
+			name:        "Simple host inactive (default values)",
 			active:      false,
 			expectedErr: false,
 			setup: func(t *testing.T, qp *queuePinger) {

--- a/scaler/queue_pinger.go
+++ b/scaler/queue_pinger.go
@@ -259,10 +259,10 @@ func fetchCounts(
 		// each endpoint returns a map of counts, one count
 		// per host. add up the counts for each host
 		for host, val := range count.Counts {
-			agg += val
-			totalCounts[host] += val
-			if count.Activities[host].After(totalActivities[host]) {
-				totalActivities[host] = count.Activities[host]
+			agg += val.Requests
+			totalCounts[host] += val.Requests
+			if val.Activity.After(totalActivities[host]) {
+				totalActivities[host] = val.Activity
 			}
 		}
 	}

--- a/scaler/queue_pinger_test.go
+++ b/scaler/queue_pinger_test.go
@@ -86,7 +86,6 @@ func TestCounts(t *testing.T) {
 		// note that the returned value should be:
 		// (queue_count * num_endpoints)
 		r.Equal(count.Requests*3, retCount)
-
 	}
 }
 
@@ -220,7 +219,6 @@ func TestFetchCounts(t *testing.T) {
 		r.Equal(val.Requests*numEndpoints, cts[key])
 		r.WithinDuration(activities[key], val.Activity, 200*time.Millisecond)
 	}
-
 }
 
 // startFakeQueuePinger starts a fake server that simulates

--- a/scaler/queue_pinger_test.go
+++ b/scaler/queue_pinger_test.go
@@ -86,6 +86,7 @@ func TestCounts(t *testing.T) {
 		// note that the returned value should be:
 		// (queue_count * num_endpoints)
 		r.Equal(count*3, retCount)
+
 	}
 }
 
@@ -183,7 +184,7 @@ func TestFetchCounts(t *testing.T) {
 		return endpoints, nil
 	}
 
-	cts, agg, err := fetchCounts(
+	cts, activities, agg, err := fetchCounts(
 		ctx,
 		logr.Discard(),
 		endpointsFn,
@@ -203,7 +204,9 @@ func TestFetchCounts(t *testing.T) {
 	for host, val := range expectedCounts {
 		expectedCounts[host] = val * numEndpoints
 	}
+
 	r.Equal(expectedCounts, cts)
+	r.Equal(counts.Activities, activities)
 }
 
 // startFakeQueuePinger starts a fake server that simulates

--- a/tests/checks/is_active/is_active_test.go
+++ b/tests/checks/is_active/is_active_test.go
@@ -1,0 +1,188 @@
+//go:build e2e
+// +build e2e
+
+package is_active_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+
+	. "github.com/kedacore/http-add-on/tests/helper"
+)
+
+const (
+	testName = "is-active-test"
+)
+
+var (
+	testNamespace        = fmt.Sprintf("%s-ns", testName)
+	deploymentName       = fmt.Sprintf("%s-deployment", testName)
+	serviceName          = fmt.Sprintf("%s-service", testName)
+	httpScaledObjectName = fmt.Sprintf("%s-http-so", testName)
+	host                 = testName
+	minReplicaCount      = 0
+	maxReplicaCount      = 1
+)
+
+type templateData struct {
+	TestNamespace        string
+	DeploymentName       string
+	ServiceName          string
+	HTTPScaledObjectName string
+	Host                 string
+	MinReplicas          int
+	MaxReplicas          int
+}
+
+const (
+	serviceTemplate = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{.ServiceName}}
+  namespace: {{.TestNamespace}}
+  labels:
+    app: {{.DeploymentName}}
+spec:
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{.DeploymentName}}
+`
+
+	deploymentTemplate = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.DeploymentName}}
+  namespace: {{.TestNamespace}}
+  labels:
+    app: {{.DeploymentName}}
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: {{.DeploymentName}}
+  template:
+    metadata:
+      labels:
+        app: {{.DeploymentName}}
+    spec:
+      containers:
+        - name: {{.DeploymentName}}
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
+          args:
+          - netexec
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+`
+
+	loadJobTemplate = `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: trigger-job
+  namespace: {{.TestNamespace}}
+spec:
+  template:
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - image: curlimages/curl
+        name: curl-client
+        command: ["/bin/sh"]
+        args: ["-c", "for i in $(seq 1 400);do curl -H 'Host: {{.Host}}' 'keda-http-add-on-interceptor-proxy.keda:8080';sleep 5;done"]
+      restartPolicy: Never
+  activeDeadlineSeconds: 400
+  backoffLimit: 3`
+
+	httpScaledObjectTemplate = `
+kind: HTTPScaledObject
+apiVersion: http.keda.sh/v1alpha1
+metadata:
+  name: {{.HTTPScaledObjectName}}
+  namespace: {{.TestNamespace}}
+spec:
+  hosts:
+  - {{.Host}}
+  targetPendingRequests: 100
+  scaledownPeriod: 10
+  scaleTargetRef:
+    deployment: {{.DeploymentName}}
+    service: {{.ServiceName}}
+    port: 8080
+  replicas:
+    min: {{ .MinReplicas }}
+    max: {{ .MaxReplicas }}
+`
+)
+
+func TestCheck(t *testing.T) {
+	// setup
+	t.Log("--- setting up ---")
+	// Create kubernetes resources
+	kc := GetKubernetesClient(t)
+	data, templates := getTemplateData()
+	CreateKubernetesResources(t, kc, testNamespace, data, templates)
+
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 6, 10),
+		"replica count should be %d after 1 minutes", minReplicaCount)
+
+	testScaleOut(t, kc, data)
+	testIsActive(t, kc)
+	testScaleIn(t, kc, data)
+
+	// cleanup
+	DeleteKubernetesResources(t, testNamespace, data, templates)
+}
+
+func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
+
+	KubectlApplyWithTemplate(t, data, "loadJobTemplate", loadJobTemplate)
+
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 6, 10),
+		"replica count should be %d after 1 minutes", maxReplicaCount)
+}
+
+func testIsActive(t *testing.T, kc *kubernetes.Clientset) {
+	t.Log("--- testing is active ---")
+
+	AssertReplicaCountNotChangeDuringTimePeriod(t, kc, deploymentName, testNamespace, maxReplicaCount, 60)
+}
+
+func testScaleIn(t *testing.T, kc *kubernetes.Clientset, data templateData) {
+	t.Log("--- testing scale out ---")
+
+	KubectlDeleteWithTemplate(t, data, "loadJobTemplate", loadJobTemplate)
+	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, minReplicaCount, 12, 10),
+		"replica count should be %d after 2 minutes", minReplicaCount)
+}
+
+func getTemplateData() (templateData, []Template) {
+	return templateData{
+			TestNamespace:        testNamespace,
+			DeploymentName:       deploymentName,
+			ServiceName:          serviceName,
+			HTTPScaledObjectName: httpScaledObjectName,
+			Host:                 host,
+			MinReplicas:          minReplicaCount,
+			MaxReplicas:          maxReplicaCount,
+		}, []Template{
+			{Name: "deploymentTemplate", Config: deploymentTemplate},
+			{Name: "serviceNameTemplate", Config: serviceTemplate},
+			{Name: "httpScaledObjectTemplate", Config: httpScaledObjectTemplate},
+		}
+}


### PR DESCRIPTION
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes #882
