### PR TITLE
fix: Add retries during interceptor e2e to fix the flaky test

### DIFF
--- a/tests/checks/interceptor_scaledobject/interceptor_scaledobject_test.go
+++ b/tests/checks/interceptor_scaledobject/interceptor_scaledobject_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/kedacore/http-add-on/tests/helper"
 	"github.com/stretchr/testify/assert"
+
+	. "github.com/kedacore/http-add-on/tests/helper"
 )
 
 const (

--- a/tests/checks/interceptor_scaledobject/interceptor_scaledobject_test.go
+++ b/tests/checks/interceptor_scaledobject/interceptor_scaledobject_test.go
@@ -5,8 +5,10 @@ package interceptor_scaledobject_test
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/kedacore/http-add-on/tests/helper"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -18,5 +20,13 @@ const (
 func TestCheck(t *testing.T) {
 	predicate := `-o jsonpath="{.status.conditions[?(@.type=="Ready")].status}"`
 	expectedResult := "True"
-	CheckKubectlGetResult(t, scaledObject, interceptorScaledObjectName, kedaNamespace, predicate, expectedResult)
+	result := "False"
+	for i := 0; i < 4; i++ {
+		result = KubectlGetResult(t, scaledObject, interceptorScaledObjectName, kedaNamespace, predicate)
+		if result == expectedResult {
+			break
+		}
+		time.Sleep(15 * time.Second)
+	}
+	assert.Equal(t, expectedResult, result)
 }

--- a/tests/helper/helper.go
+++ b/tests/helper/helper.go
@@ -638,14 +638,13 @@ func WaitForPodsTerminated(t *testing.T, kc *kubernetes.Clientset, selector, nam
 	return false
 }
 
-// CheckKubectlGetResult runs `kubectl get` with parameters and compares output with expected value
-func CheckKubectlGetResult(t *testing.T, kind string, name string, namespace string, otherparameter string, expected string) {
+// KubectlGetResult runs `kubectl get` with parameters
+func KubectlGetResult(t *testing.T, kind string, name string, namespace string, otherparameter string) string {
 	time.Sleep(1 * time.Second) // wait a second for recource deployment finished
 	kctlGetCmd := fmt.Sprintf(`kubectl get %s/%s -n %s %s"`, kind, name, namespace, otherparameter)
 	t.Log("Running kubectl cmd:", kctlGetCmd)
 	output, err := ExecuteCommand(kctlGetCmd)
 	assert.NoErrorf(t, err, "cannot get rollout info - %s", err)
 
-	unqoutedOutput := strings.ReplaceAll(string(output), "\"", "")
-	assert.Equal(t, expected, unqoutedOutput)
+	return strings.ReplaceAll(string(output), "\"", "")
 }


### PR DESCRIPTION
As the ScaledObject could be not ready because KEDA isn't ready yet, I've added a retry with sleep, giving some extra time to get the SO ready. 
The current problem (which will be solved with the PR) is that the retry system doesn't wait, so it just tries 3 times in a row in a few seconds, so KEDA can't process the ScaledObject (the retries aren't making any difference).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
