### PR TITLE
Update deprecated annotations in example demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ You can find all deprecations in [this overview](https://github.com/kedacore/htt
 ### Other
 
 - **General**: Unify loggers ([#958](https://github.com/kedacore/http-add-on/issues/958))
+- **General**: Align with the new format of Ingress in the example demo ([#979](https://github.com/kedacore/http-add-on/pull/979))
 
 ## v0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,8 @@ You can find all deprecations in [this overview](https://github.com/kedacore/htt
 
 ### Other
 
-- **General**: Unify loggers ([#958](https://github.com/kedacore/http-add-on/issues/958))
 - **General**: Align with the new format of Ingress in the example demo ([#979](https://github.com/kedacore/http-add-on/pull/979))
+- **General**: Unify loggers ([#958](https://github.com/kedacore/http-add-on/issues/958))
 
 ## v0.7.0
 

--- a/examples/xkcd/templates/ingress.yaml
+++ b/examples/xkcd/templates/ingress.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ include "xkcd.fullname" . }}
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
-    kubernetes.io/ingress.class: nginx
 spec:
+  ingressClassName: nginx
   rules:
   {{- range .Values.hosts }}
   - host: {{ . | toString }}


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

The old annotation is being deprecated, and there will be a warning popped up for that.
```
helm install xkcd ./http-add-on/examples/xkcd 
fatal: destination path 'http-add-on' already exists and is not an empty directory.
W0418 05:55:35.571507    5828 warnings.go:70] annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
```


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
Replace the annotation with current format, as indicated in: https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/

Test #
Works fine with the deployment of AKS.
```
# Create AKS
rG=joey-aks-keda-21612
aks=joey-aks-keda-21612

az group create -n ${rG} -l eastus 

az aks create -n ${aks} -g ${rG} --no-ssh-key --enable-keda --node-count 2 --node-vm-size Standard_A4_v2
az aks get-credentials -n ${aks} -g ${rG} 

# Install ingress-nginx
helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
helm repo update

helm install ingress-nginx ingress-nginx/ingress-nginx \
  --create-namespace \
  --namespace ingress-basic \
  --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"=/healthz \
  --set controller.service.externalTrafficPolicy=Local

# Install keda http add-on
helm repo add kedacore https://kedacore.github.io/charts
helm repo update
helm install http-add-on kedacore/keda-add-ons-http --namespace kube-system

# Install example application with HTTPScaleObject
git clone -b patch-1 https://github.com/JoeyC-Dev/http-add-on.git
helm install xkcd ./http-add-on/examples/xkcd 

# Patch svc externalName
kubectl patch svc xkcd-proxy -p '{"spec":{"externalName": "keda-add-ons-http-interceptor-proxy.kube-system"}}'

# Get Ingress IP
sleep 30; ip=$(kubectl get ingress xkcd -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')

# Test request
curl -H "Host: myhost.com" ${ip}/path1

# Clean up the resource
az group delete -n ${rG} --no-wait
```