### PR TITLE
fix: Rename keda-http-add-on-interceptor-proxy to keda-add-ons-http-interceptor-proxy

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -75,9 +75,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: https://uploads.github.com/repos/kedacore/http-add-on/releases/${{ steps.get-release-info.outputs.id }}/assets?name=keda-http-add-on-${{ steps.get_version.outputs.VERSION }}.yaml
-          asset_path: keda-http-add-on-${{ steps.get_version.outputs.VERSION }}.yaml
-          asset_name: keda-http-add-on-${{ steps.get_version.outputs.VERSION }}.yaml
+          upload_url: https://uploads.github.com/repos/kedacore/http-add-on/releases/${{ steps.get-release-info.outputs.id }}/assets?name=keda-add-ons-http-${{ steps.get_version.outputs.VERSION }}.yaml
+          asset_path: keda-add-ons-http-${{ steps.get_version.outputs.VERSION }}.yaml
+          asset_name: keda-add-ons-http-${{ steps.get_version.outputs.VERSION }}.yaml
           asset_content_type: application/x-yaml
 
       # Upload CRD deployment YAML file to GitHub release
@@ -87,7 +87,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: https://uploads.github.com/repos/kedacore/http-add-on/releases/${{ steps.get-release-info.outputs.id }}/assets?name=keda-http-add-on-${{ steps.get_version.outputs.VERSION }}-crds.yaml
-          asset_path: keda-http-add-on-${{ steps.get_version.outputs.VERSION }}-crds.yaml
-          asset_name: keda-http-add-on-${{ steps.get_version.outputs.VERSION }}-crds.yaml
+          upload_url: https://uploads.github.com/repos/kedacore/http-add-on/releases/${{ steps.get-release-info.outputs.id }}/assets?name=keda-add-ons-http-${{ steps.get_version.outputs.VERSION }}-crds.yaml
+          asset_path: keda-add-ons-http-${{ steps.get_version.outputs.VERSION }}-crds.yaml
+          asset_name: keda-add-ons-http-${{ steps.get_version.outputs.VERSION }}-crds.yaml
           asset_content_type: application/x-yaml

--- a/Makefile
+++ b/Makefile
@@ -128,15 +128,15 @@ publish-scaler-multiarch:
 
 publish-multiarch: publish-operator-multiarch publish-interceptor-multiarch publish-scaler-multiarch
 
-release: manifests kustomize ## Produce new KEDA Http Add-on release in keda-http-add-on-$(VERSION).yaml file.
+release: manifests kustomize ## Produce new KEDA Http Add-on release in keda-add-ons-http-$(VERSION).yaml file.
 	cd config/interceptor && \
 	$(KUSTOMIZE) edit set image ghcr.io/kedacore/http-add-on-interceptor=${IMAGE_INTERCEPTOR_VERSIONED_TAG}
 	cd config/scaler && \
 	$(KUSTOMIZE) edit set image ghcr.io/kedacore/http-add-on-scaler=${IMAGE_SCALER_VERSIONED_TAG}
 	cd config/operator && \
 	$(KUSTOMIZE) edit set image ghcr.io/kedacore/http-add-on-operator=${IMAGE_OPERATOR_VERSIONED_TAG}
-	$(KUSTOMIZE) build config/default > keda-http-add-on-$(VERSION).yaml
-	$(KUSTOMIZE) build config/crd     > keda-http-add-on-$(VERSION)-crds.yaml
+	$(KUSTOMIZE) build config/default > keda-add-ons-http-$(VERSION).yaml
+	$(KUSTOMIZE) build config/crd     > keda-add-ons-http-$(VERSION)-crds.yaml
 
 # Development
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - ../operator
 - ../scaler
 namespace: keda
-namePrefix: keda-http-add-on-
+namePrefix: keda-add-ons-http-
 labels:
 - includeSelectors: true
   includeTemplates: true

--- a/config/operator/deployment.yaml
+++ b/config/operator/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - --zap-time-encoding=rfc3339
         env:
         - name: KEDAHTTP_OPERATOR_EXTERNAL_SCALER_SERVICE
-          value: "keda-http-add-on-external-scaler"
+          value: "keda-add-ons-http-external-scaler"
         - name: KEDAHTTP_OPERATOR_EXTERNAL_SCALER_PORT
           value: "9090"
         - name: KEDA_HTTP_OPERATOR_NAMESPACE

--- a/config/scaler/deployment.yaml
+++ b/config/scaler/deployment.yaml
@@ -29,13 +29,13 @@ spec:
         - --zap-time-encoding=rfc3339
         env:
         - name: KEDA_HTTP_SCALER_TARGET_ADMIN_DEPLOYMENT
-          value: "keda-http-add-on-interceptor"
+          value: "keda-add-ons-http-interceptor"
         - name: KEDA_HTTP_SCALER_PORT
           value: "9090"
         - name: KEDA_HTTP_SCALER_TARGET_ADMIN_NAMESPACE
           value: "keda"
         - name: KEDA_HTTP_SCALER_TARGET_ADMIN_SERVICE
-          value: "keda-http-add-on-interceptor-admin"
+          value: "keda-add-ons-http-interceptor-admin"
         - name: KEDA_HTTP_SCALER_TARGET_ADMIN_PORT
           value: "9090"
         - name: KEDA_HTTP_SCALER_STREAM_INTERVAL_MS

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -53,8 +53,6 @@ As said above, you need to route your HTTP traffic to the `Service` that the add
 keda-add-ons-http-interceptor-proxy
 ```
 
-> This is installed by raw manifests. If you are using the [Helm chart](https://github.com/kedacore/charts/tree/main/http-add-on) to install the add-on, it crates a service named `keda-add-ons-http-interceptor-proxy` as a `ClusterIP` by default.
-
 #### Installing and Using the [ingress-nginx](https://kubernetes.github.io/ingress-nginx/deploy/#using-helm) Ingress Controller
 
 As mentioned above, the `Service` that the add-on creates will be inaccessible over the network from outside of your Kubernetes cluster.

--- a/examples/xkcd/templates/externalservice.yaml
+++ b/examples/xkcd/templates/externalservice.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "xkcd.labels" . | nindent 4 }}
 spec:
   type: ExternalName
-  externalName: keda-http-add-on-interceptor-proxy.keda
+  externalName: keda-add-ons-http-interceptor-proxy.keda

--- a/tests/checks/httproute_in_app_namespace/httproute_in_app_namespace_test.go
+++ b/tests/checks/httproute_in_app_namespace/httproute_in_app_namespace_test.go
@@ -63,7 +63,7 @@ spec:
   rules:
     - backendRefs:
         - kind: Service
-          name: keda-http-add-on-interceptor-proxy
+          name: keda-add-ons-http-interceptor-proxy
           namespace: keda
           port: 8080
       matches:
@@ -86,7 +86,7 @@ spec:
   to:
   - group: ""
     kind: Service
-    name: keda-http-add-on-interceptor-proxy
+    name: keda-add-ons-http-interceptor-proxy
 `
 	serviceTemplate = `
 apiVersion: v1

--- a/tests/checks/ingress_in_app_namespace/ingress_in_app_namespace_test.go
+++ b/tests/checks/ingress_in_app_namespace/ingress_in_app_namespace_test.go
@@ -75,7 +75,7 @@ metadata:
     app: {{.DeploymentName}}
 spec:
   type: ExternalName
-  externalName: keda-http-add-on-interceptor-proxy.{{.KEDANamespace}}
+  externalName: keda-add-ons-http-interceptor-proxy.{{.KEDANamespace}}
 `
 
 	serviceTemplate = `

--- a/tests/checks/ingress_in_keda_namespace/ingress_in_keda_namespace_test.go
+++ b/tests/checks/ingress_in_keda_namespace/ingress_in_keda_namespace_test.go
@@ -61,7 +61,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: keda-http-add-on-interceptor-proxy
+            name: keda-add-ons-http-interceptor-proxy
             port:
               number: 8080
 `

--- a/tests/checks/interceptor_otel_metrics/interceptor_otel_metrics_test.go
+++ b/tests/checks/interceptor_otel_metrics/interceptor_otel_metrics_test.go
@@ -109,7 +109,7 @@ spec:
       - name: curl-client
         image: curlimages/curl
         imagePullPolicy: Always
-        command: ["curl", "-H", "Host: {{.Host}}", "keda-http-add-on-interceptor-proxy.keda:8080"]
+        command: ["curl", "-H", "Host: {{.Host}}", "keda-add-ons-http-interceptor-proxy.keda:8080"]
       restartPolicy: Never
   activeDeadlineSeconds: 600
   backoffLimit: 5

--- a/tests/checks/interceptor_prometheus_metrics/interceptor_prometheus_metrics_test.go
+++ b/tests/checks/interceptor_prometheus_metrics/interceptor_prometheus_metrics_test.go
@@ -29,7 +29,7 @@ var (
 	host                         = testName
 	minReplicaCount              = 0
 	maxReplicaCount              = 1
-	kedaInterceptorPrometheusURL = "http://keda-http-add-on-interceptor-metrics.keda:2223/metrics"
+	kedaInterceptorPrometheusURL = "http://keda-add-ons-http-interceptor-metrics.keda:2223/metrics"
 )
 
 type templateData struct {
@@ -108,7 +108,7 @@ spec:
       - name: curl-client
         image: curlimages/curl
         imagePullPolicy: Always
-        command: ["curl", "-H", "Host: {{.Host}}", "keda-http-add-on-interceptor-proxy.keda:8080"]
+        command: ["curl", "-H", "Host: {{.Host}}", "keda-add-ons-http-interceptor-proxy.keda:8080"]
       restartPolicy: Never
   activeDeadlineSeconds: 600
   backoffLimit: 5

--- a/tests/checks/interceptor_scaledobject/interceptor_scaledobject_test.go
+++ b/tests/checks/interceptor_scaledobject/interceptor_scaledobject_test.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	kedaNamespace               = "keda"
-	interceptorScaledObjectName = "keda-http-add-on-interceptor"
+	interceptorScaledObjectName = "keda-add-ons-http-interceptor"
 	scaledObject                = "scaledobject"
 )
 

--- a/tests/checks/interceptor_tls/interceptor_tls_test.go
+++ b/tests/checks/interceptor_tls/interceptor_tls_test.go
@@ -176,7 +176,7 @@ func TestInterceptorTLS(t *testing.T) {
 func sendRequest(t *testing.T) {
 	t.Log("--- sending request ---")
 
-	stdout, _, err := ExecCommandOnSpecificPod(t, clientName, testNamespace, fmt.Sprintf("curl -k -H 'Host: %s' https://keda-http-add-on-interceptor-proxy.keda:8443/echo?msg=tls_test", host))
+	stdout, _, err := ExecCommandOnSpecificPod(t, clientName, testNamespace, fmt.Sprintf("curl -k -H 'Host: %s' https://keda-add-ons-http-interceptor-proxy.keda:8443/echo?msg=tls_test", host))
 	require.NoErrorf(t, err, "could not run command on test client pod - %s", err)
 
 	assert.Equal(t, "tls_test", stdout, fmt.Sprintf("incorrect response body from test request: expected %s, got %s", "tls_test", stdout))

--- a/tests/checks/internal_service/internal_service_test.go
+++ b/tests/checks/internal_service/internal_service_test.go
@@ -102,7 +102,7 @@ spec:
       - name: curl-client
         image: curlimages/curl
         imagePullPolicy: Always
-        command: ["curl", "-H", "Host: {{.Host}}", "keda-http-add-on-interceptor-proxy.keda:8080"]
+        command: ["curl", "-H", "Host: {{.Host}}", "keda-add-ons-http-interceptor-proxy.keda:8080"]
       restartPolicy: Never
   activeDeadlineSeconds: 600
   backoffLimit: 5

--- a/tests/checks/internal_service_port_name/internal_service_port_name_test.go
+++ b/tests/checks/internal_service_port_name/internal_service_port_name_test.go
@@ -102,7 +102,7 @@ spec:
       - name: curl-client
         image: curlimages/curl
         imagePullPolicy: Always
-        command: ["curl", "-H", "Host: {{.Host}}", "keda-http-add-on-interceptor-proxy.keda:8080"]
+        command: ["curl", "-H", "Host: {{.Host}}", "keda-add-ons-http-interceptor-proxy.keda:8080"]
       restartPolicy: Never
   activeDeadlineSeconds: 600
   backoffLimit: 5

--- a/tests/checks/multiple_hosts/multiple_hosts_test.go
+++ b/tests/checks/multiple_hosts/multiple_hosts_test.go
@@ -105,7 +105,7 @@ spec:
       - name: curl-client
         image: curlimages/curl
         imagePullPolicy: Always
-        command: ["curl", "-H", "Host: {{.Host}}", "keda-http-add-on-interceptor-proxy.keda:8080"]
+        command: ["curl", "-H", "Host: {{.Host}}", "keda-add-ons-http-interceptor-proxy.keda:8080"]
       restartPolicy: Never
   activeDeadlineSeconds: 600
   backoffLimit: 5

--- a/tests/checks/path_prefix/path_prefix_test.go
+++ b/tests/checks/path_prefix/path_prefix_test.go
@@ -211,7 +211,7 @@ spec:
       - name: curl-client
         image: curlimages/curl
         imagePullPolicy: Always
-        command: ["curl", "-H", "Host: {{.Host}}", "keda-http-add-on-interceptor-proxy.keda:8080{{.PathPrefix}}"]
+        command: ["curl", "-H", "Host: {{.Host}}", "keda-add-ons-http-interceptor-proxy.keda:8080{{.PathPrefix}}"]
       restartPolicy: Never
   activeDeadlineSeconds: 600
   backoffLimit: 5

--- a/tests/checks/scaling_phase_custom_resource/scaling_phase_custom_resource_test.go
+++ b/tests/checks/scaling_phase_custom_resource/scaling_phase_custom_resource_test.go
@@ -116,7 +116,7 @@ spec:
           - "1"
           - "-H"
           - "Host: {{.Host}}"
-          - "http://keda-http-add-on-interceptor-proxy.keda:8080/"
+          - "http://keda-add-ons-http-interceptor-proxy.keda:8080/"
       restartPolicy: Never
       terminationGracePeriodSeconds: 5
   activeDeadlineSeconds: 600

--- a/tests/checks/scaling_phase_deployment/scaling_phase_deployment_test.go
+++ b/tests/checks/scaling_phase_deployment/scaling_phase_deployment_test.go
@@ -109,7 +109,7 @@ spec:
           - "1"
           - "-H"
           - "Host: {{.Host}}"
-          - "http://keda-http-add-on-interceptor-proxy.keda:8080/"
+          - "http://keda-add-ons-http-interceptor-proxy.keda:8080/"
       restartPolicy: Never
       terminationGracePeriodSeconds: 5
   activeDeadlineSeconds: 600

--- a/tests/checks/scaling_phase_deployment_with_skip_so_creation/scaling_phase_deployment_with_skip_so_creation_test.go
+++ b/tests/checks/scaling_phase_deployment_with_skip_so_creation/scaling_phase_deployment_with_skip_so_creation_test.go
@@ -111,7 +111,7 @@ spec:
           - "1"
           - "-H"
           - "Host: {{.Host}}"
-          - "http://keda-http-add-on-interceptor-proxy.keda:8080/"
+          - "http://keda-add-ons-http-interceptor-proxy.keda:8080/"
       restartPolicy: Never
       terminationGracePeriodSeconds: 5
   activeDeadlineSeconds: 600
@@ -162,7 +162,7 @@ spec:
   - type: external-push
     metadata:
       httpScaledObject: {{.HTTPScaledObjectName}}
-      scalerAddress: keda-http-add-on-external-scaler.keda:9090
+      scalerAddress: keda-add-ons-http-external-scaler.keda:9090
 `
 )
 

--- a/tests/checks/scaling_phase_statefulset/scaling_phase_statefulset_test.go
+++ b/tests/checks/scaling_phase_statefulset/scaling_phase_statefulset_test.go
@@ -109,7 +109,7 @@ spec:
           - "1"
           - "-H"
           - "Host: {{.Host}}"
-          - "http://keda-http-add-on-interceptor-proxy.keda:8080/"
+          - "http://keda-add-ons-http-interceptor-proxy.keda:8080/"
       restartPolicy: Never
       terminationGracePeriodSeconds: 5
   activeDeadlineSeconds: 600


### PR DESCRIPTION
Renamed `keda-http-add-on-interceptor-proxy` to `keda-add-ons-http-interceptor-proxy`

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
