### PR TITLE
document GatewayAPI example with xkcd application

### DIFF
--- a/examples/xkcd/templates/httproute.yaml
+++ b/examples/xkcd/templates/httproute.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.httproute }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "xkcd.fullname" . }}
+spec:
+  parentRefs:
+    - name: eg
+      namespace: envoy-gateway-system
+  hostnames:
+  {{- range .Values.hosts }}
+    - {{ . | toString }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - kind: Service
+          name: keda-add-ons-http-interceptor-proxy
+          namespace: keda
+          port: 8080
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: {{ include "xkcd.fullname" . }}
+  namespace: keda
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: {{ .Release.Namespace }}
+  to:
+  - group: ""
+    kind: Service
+    name: keda-add-ons-http-interceptor-proxy
+{{- end }}


### PR DESCRIPTION
This PR documents additional steps to try http-add-on along with GatewayAPI, similar to how `Igress` setup is documented.

The selected GatewayAPI implementation [Envoy Gateway](https://github.com/envoyproxy/gateway/) is stable and well adopted by the community, which should complement the `Ingress` documentation with `nginx-ingress`. The `HTTPRoute` interceptor network path is very similar to the `Ingress` interceptor path.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Any necessary documentation is added, such as:

see also: https://github.com/kedacore/http-add-on/issues/33
