### PR TITLE
chore: use the `latest` link in GW API section in the walkthrough guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 SHELL           = /bin/bash
 
 IMAGE_REGISTRY 	?= ghcr.io
-IMAGE_REPO     	?= kedacore
-VERSION 		?= main
+IMAGE_REPO     	?= kedify
+VERSION 		?= 0.8.0-1
 
 IMAGE_OPERATOR 		?= ${IMAGE_REGISTRY}/${IMAGE_REPO}/http-add-on-operator
 IMAGE_INTERCEPTOR	?= ${IMAGE_REGISTRY}/${IMAGE_REPO}/http-add-on-interceptor

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -77,7 +77,7 @@ When you're ready, please run `kubectl get svc -n ${NAMESPACE}`, find the `ingre
 
 >Note: you should go further and set your DNS records appropriately and set up a TLS certificate for this IP address. Instructions to do that are out of scope of this document, though.
 
-#### Installing and Using the [eg](https://gateway.envoyproxy.io/v1.0.1/install/install-helm/) GatewayAPI
+#### Installing and Using the [eg](https://gateway.envoyproxy.io/latest/install/install-helm/) GatewayAPI
 
 Similarly to exposing your service with `Ingress`, you can expose your service with `HTTPRoute` as part of [GatewayAPI](https://github.com/kubernetes-sigs/gateway-api). Following steps describe how to install one of may GatewayAPI implementations - Envoy Gateway.
 You should install the `xkcd` helm chart with `--set httproute=true` as [explained above](#xkcd-exposed-with-gatewayapi).

--- a/operator/controllers/http/scaled_object.go
+++ b/operator/controllers/http/scaled_object.go
@@ -18,13 +18,7 @@ import (
 // according to the given parameters. If the create failed because the
 // ScaledObject already exists, attempts to patch the scaledobject.
 // otherwise, fails.
-func (r *HTTPScaledObjectReconciler) createOrUpdateScaledObject(
-	ctx context.Context,
-	cl client.Client,
-	logger logr.Logger,
-	externalScalerHostName string,
-	httpso *httpv1alpha1.HTTPScaledObject,
-) error {
+func (r *HTTPScaledObjectReconciler) createOrUpdateScaledObject(ctx context.Context, cl client.Client, logger logr.Logger, externalScalerHostName string, httpso *httpv1alpha1.HTTPScaledObject) error {
 	logger.Info("Creating scaled objects", "external scaler host name", externalScalerHostName)
 
 	var minReplicaCount *int32
@@ -44,6 +38,7 @@ func (r *HTTPScaledObjectReconciler) createOrUpdateScaledObject(
 		minReplicaCount,
 		maxReplicaCount,
 		httpso.Spec.CooldownPeriod,
+		httpso.ResourceVersion,
 	)
 
 	// Set HTTPScaledObject instance as the owner and controller
@@ -60,17 +55,11 @@ func (r *HTTPScaledObjectReconciler) createOrUpdateScaledObject(
 			}
 			var fetchedSO kedav1alpha1.ScaledObject
 			if err := cl.Get(ctx, existingSOKey, &fetchedSO); err != nil {
-				logger.Error(
-					err,
-					"failed to fetch existing ScaledObject for patching",
-				)
+				logger.Error(err, "failed to fetch existing ScaledObject for patching")
 				return err
 			}
 			if err := cl.Patch(ctx, appScaledObject, client.Merge); err != nil {
-				logger.Error(
-					err,
-					"failed to patch existing ScaledObject",
-				)
+				logger.Error(err, "failed to patch existing ScaledObject")
 				return err
 			}
 		} else {

--- a/pkg/k8s/scaledobject.go
+++ b/pkg/k8s/scaledobject.go
@@ -12,22 +12,14 @@ const (
 	soPollingInterval = 15
 	soTriggerType     = "external-push"
 
-	ScalerAddressKey    = "scalerAddress"
-	HTTPScaledObjectKey = "httpScaledObject"
+	ScalerAddressKey           = "scalerAddress"
+	HTTPScaledObjectKey        = "httpScaledObject"
+	HTTPScaledObjectVersionKey = "httpScaledObjectVersion"
 )
 
 // NewScaledObject creates a new ScaledObject in memory
-func NewScaledObject(
-	namespace string,
-	name string,
-	labels map[string]string,
-	annotations map[string]string,
-	workloadRef v1alpha1.ScaleTargetRef,
-	scalerAddress string,
-	minReplicas *int32,
-	maxReplicas *int32,
-	cooldownPeriod *int32,
-) *kedav1alpha1.ScaledObject {
+func NewScaledObject(namespace string, name string, labels map[string]string, annotations map[string]string,
+	workloadRef v1alpha1.ScaleTargetRef, scalerAddress string, minReplicas *int32, maxReplicas *int32, cooldownPeriod *int32, httpSoVersion string) *kedav1alpha1.ScaledObject {
 	return &kedav1alpha1.ScaledObject{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: kedav1alpha1.SchemeGroupVersion.Identifier(),
@@ -58,6 +50,8 @@ func NewScaledObject(
 					Metadata: map[string]string{
 						ScalerAddressKey:    scalerAddress,
 						HTTPScaledObjectKey: name,
+						// Store HTTPSO resource version in the metadata, this ensures that the ScaledObject is reconciled when the HTTPSO is updated
+						HTTPScaledObjectVersionKey: httpSoVersion,
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubalik@gmail.com>

It causes problems in the GH Actions in the linter, the original 1.0.1 link is no longer present - thus the link doesn't work. `latest` is more durable solution