### PR TITLE
Add lightweight Scarf analytics pixel to thewebsite

### DIFF
--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,1 @@
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=bd8914ff-fcda-4c0c-ab57-6fc671ae6cff" style="display:none;" />


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

This analytics pixel provides high-level web traffic insights for project maintainers so they can better understand how docs are being read and used. This pixel does not use cookies (or JavaScript at all) and is GDPR-compliant. It is a clear 1x1 pixel that won't affect page rendering or load times.


The same stuff has been done for keda.sh website: https://github.com/kedacore/keda-docs/pull/1426