### PR TITLE
fix: broken links for PropulsionAI

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,7 +6,7 @@ This page contains a list of organizations who are using KEDA's HTTP Add-on in p
 
 | Organization | Status | More Information (Blog post, etc.) |
 | ------------ | ---------| ---------------|
-|<a href="https://github.com/propulsion-ai" target="_blank"><picture><source media="(prefers-color-scheme: dark)" srcset="https://propulsionhq.com/assets/images/propulsion-white.png"><img alt="PropulsionAI" src="https://propulsionhq.com/assets/images/propulsion-full-color.png"></picture></a>|![testing](https://img.shields.io/badge/-development%20&%20testing-green?style=flat)|[PropulsionAI](https://propulsionhq.com) allows you to add AI to your apps, without writing code.|
+| PropulsionAI |![testing](https://img.shields.io/badge/-development%20&%20testing-green?style=flat)|[PropulsionAI](https://propulsionhq.com) allows you to add AI to your apps, without writing code.|
 
 ## Become an adopter!
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

The link check has been complaining for broken links for some time now
https://github.com/kedacore/http-add-on/actions/workflows/linkinator.yaml

```
Error: [404] https://propulsionhq.com/assets/images/propulsion-full-color.png
Error: [404] https://propulsionhq.com/assets/images/propulsion-white.png
```
looks like the images provided in https://github.com/kedacore/http-add-on/pull/913/ no longer exist.

FYI @Rohithzr 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)