### PR TITLE
tests: remove sleep from e2e test

### DIFF
--- a/tests/checks/internal_service_port_name/internal_service_port_name_test.go
+++ b/tests/checks/internal_service_port_name/internal_service_port_name_test.go
@@ -6,7 +6,6 @@ package internal_service_port_name_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/kubernetes"
@@ -151,7 +150,6 @@ func TestCheck(t *testing.T) {
 func testScaleOut(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 	t.Log("--- testing scale out ---")
 
-	time.Sleep(5 * time.Second)
 	KubectlApplyWithTemplate(t, data, "loadJobTemplate", loadJobTemplate)
 
 	assert.True(t, WaitForDeploymentReplicaReadyCount(t, kc, deploymentName, testNamespace, maxReplicaCount, 6, 10),


### PR DESCRIPTION
I accidentally forgot `time.Sleep` in https://github.com/kedacore/http-add-on/pull/1174