### PR TITLE
fix: Use the right permissions in release workflow's token

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -4,14 +4,11 @@ on:
   push:
     tags: ["v[0-9].[0-9].[0-9]"]
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
 


### PR DESCRIPTION

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)


Fixes #
