### PR TITLE
fix(doc): use correct service name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Other
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Documentation**: Correct the service name used in the walkthrough documentation ([#1244](https://github.com/kedacore/http-add-on/pull/1244))
 
 ## v0.9.0
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -42,7 +42,7 @@ kubectl apply -n $NAMESPACE -f examples/v0.9.0/httpscaledobject.yaml
 You've now installed a web application and activated autoscaling by creating an `HTTPScaledObject` for it. For autoscaling to work properly, HTTP traffic needs to route through the `Service` that the add-on has set up. You can use `kubectl port-forward` to quickly test things out:
 
 ```console
-kubectl port-forward svc/keda-http-add-on-interceptor-proxy -n ${NAMESPACE} 8080:8080
+kubectl port-forward svc/keda-add-ons-http-interceptor-proxy -n ${NAMESPACE} 8080:8080
 ```
 
 ### Routing to the Right `Service`
@@ -50,7 +50,7 @@ kubectl port-forward svc/keda-http-add-on-interceptor-proxy -n ${NAMESPACE} 8080
 As said above, you need to route your HTTP traffic to the `Service` that the add-on has created during the installation. If you have existing systems - like an ingress controller - you'll need to anticipate the name of these created `Service`s. Each one will be named consistently like so, in the same namespace as the `HTTPScaledObject` and your application (i.e. `$NAMESPACE`):
 
 ```console
-keda-http-add-on-interceptor-proxy
+keda-add-ons-http-interceptor-proxy
 ```
 
 > This is installed by raw manifests. If you are using the [Helm chart](https://github.com/kedacore/charts/tree/main/http-add-on) to install the add-on, it crates a service named `keda-add-ons-http-interceptor-proxy` as a `ClusterIP` by default.
@@ -144,7 +144,7 @@ curl -H "Host: myhost.com" <Your IP>/path1
 You can also use port-forward to interceptor service for making the request:
 
 ```console
-kubectl port-forward svc/keda-http-add-on-interceptor-proxy -n ${NAMESPACE} 8080:8080
+kubectl port-forward svc/keda-add-ons-http-interceptor-proxy -n ${NAMESPACE} 8080:8080
 curl -H "Host: myhost.com" localhost:8080/path1
 ```
 
@@ -172,7 +172,7 @@ For example:
   - type: external-push
     metadata:
       httpScaledObject: YOUR_HTTPSCALEDOBJECT_NAME
-      scalerAddress: keda-http-add-on-external-scaler.keda:9090
+      scalerAddress: keda-add-ons-http-external-scaler.keda:9090
 ```
 
 3. Apply the `"httpscaledobject.keda.sh/skip-scaledobject-creation"` annotation with `true` and apply the change. This will remove the originally created `ScaledObject` allowing you to create your own.


### PR DESCRIPTION

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

_Correct the service name used in the walkthrough documentation_

After a fresh installation, the following services are available:

```shell
➜ k get services -n keda -o name | grep http
service/keda-add-ons-http-controller-manager-metrics-service
service/keda-add-ons-http-external-scaler
service/keda-add-ons-http-interceptor-admin
service/keda-add-ons-http-interceptor-proxy
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
