### PR TITLE
Fix KEDA Interceptor/Scaler issues when deleting ScaledObject while scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ## Unreleased
 
+- **General**: Fix infrastructure crashes when deleting ScaledObject while scaling
+
 ### Breaking Changes
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The KEDA HTTP Add-on allows Kubernetes users to automatically scale their HTTP s
 
 | 🚧 **Project status: beta** 🚧|
 |---------------------------------------------|
-| :loudspeaker: **KEDA is actively relying on community contributions to help grow & maintain the add-on. The KEDA maintainers are assisting the community to evolve the add-on but not directly responsible for it.** Feel free to [open a new discussion](https://github.com/kedacore/http-add-on/discussions/new/choose) in case of questions.<br/><br/>⚠ The HTTP Add-on currently is in [beta](https://github.com/kedacore/http-add-on/releases/latest). We can't yet recommend it for production usage because we are still developing and testing it. It may have "rough edges" including missing documentation, bugs and other issues. It is currently provided as-is without support. |
+| :loudspeaker: **KEDA is actively relying on community contributions to help grow & maintain the add-on. The KEDA maintainers are assisting the community to evolve the add-on but not directly responsible for it.** Feel free to [open a new discussion](https://github.com/kedacore/http-add-on/discussions/new/choose) in case of questions.<br/><br/>⚠ The HTTP Add-on currently is in [beta](https://github.com/kedacore/http-add-on/releases/latest). We can't yet recommend it for production usage because we are still developing and testing it. It may have "rough edges" including missing documentation, bugs and other issues. It is currently provided as-is without support.<br/><br/>:bulb: For production-ready needs, you can consider using the [Kedify HTTP Scaler](https://kedify.io/scalers/http), a commercial alternative offering robust and reliable scaling for KEDA. |
 
 ## HTTP Autoscaling Made Simple
 

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -90,11 +90,6 @@ func (r *Memory) Decrease(host string, delta int) error {
 	}
 	r.concurrentMap[host] = newVal
 
-	// Update rpsMap if the key exists
-	if rpsItem, ok := r.rpsMap[host]; ok {
-		rpsItem.Record(time.Now(), -delta)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

In the current KEDA logic, if a ScaledObject is deleted while a request is in transit, then `Memory.RemoveKey()` is called **before** `Memory.Decrease()`. This causes two issues:

1. Once `Memory.RemoveKey()` is called, calling `Memory.Decrease()` will cause the keys of `Memory.concurrentMap` and `Memory.rpsMap` to diverge, leading to an error [here](https://github.com/kedacore/http-add-on/blob/ddbb17ce0b902cbb9134c3811a97d9a1efa61fee/pkg/queue/queue.go#L126).
2. Calling `Memory.Decrease()` will cause the values in `Memory.concurrentMap` to drop below 0, leading to an error [here](https://github.com/kedacore/http-add-on/blob/ddbb17ce0b902cbb9134c3811a97d9a1efa61fee/scaler/handlers.go#L253).

This PR changes the logic so that when `Memory.Decrease()` is called, we check if the key is already deleted from `Memory.concurrentMap` - if so, don't remove anything from `Memory.concurrentMap`. 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)
