### PR TITLE
fix kubectl active printcolumn selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ### New
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **General**: Fix kubectl active printcolumn ([#1211](https://github.com/kedacore/http-add-on/issues/1211))
 
 ### Improvements
 

--- a/config/crd/bases/http.keda.sh_httpscaledobjects.yaml
+++ b/config/crd/bases/http.keda.sh_httpscaledobjects.yaml
@@ -32,7 +32,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .status.conditions[?(@.type=="HTTPScaledObjectIsReady")].status
+    - jsonPath: .status.conditions[?(@.reason=="HTTPScaledObjectIsReady")].status
       name: Active
       type: string
     name: v1alpha1

--- a/operator/apis/http/v1alpha1/httpscaledobject_types.go
+++ b/operator/apis/http/v1alpha1/httpscaledobject_types.go
@@ -127,7 +127,7 @@ type HTTPScaledObjectStatus struct {
 // +kubebuilder:printcolumn:name="MinReplicas",type="integer",JSONPath=".spec.replicas.min"
 // +kubebuilder:printcolumn:name="MaxReplicas",type="integer",JSONPath=".spec.replicas.max"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="Active",type="string",JSONPath=".status.conditions[?(@.type==\"HTTPScaledObjectIsReady\")].status"
+// +kubebuilder:printcolumn:name="Active",type="string",JSONPath=".status.conditions[?(@.reason==\"HTTPScaledObjectIsReady\")].status"
 // +kubebuilder:resource:shortName=httpso
 // +kubebuilder:subresource:status
 


### PR DESCRIPTION
The `printcolumn` condition is selecting based on wrong selector resulting in always stating empty string in the `ACTIVE` column.

```
$ k get httpso
NAME   TARGETWORKLOAD            TARGETSERVICE   MINREPLICAS   MAXREPLICAS   AGE   ACTIVE
demo   apps/v1/Deployment/demo   demo:8080       0             10            66m   
```
This is because somehow all condition `type` values are always just `Ready`
```yaml
$ k get httpso demo -o yaml | yq '.status.conditions'
- message: Identified HTTPScaledObject creation signal
  reason: PendingCreation
  status: Unknown
  timestamp: "2025-02-10T13:37:50Z"
  type: Ready
- message: App ScaledObject created
  reason: AppScaledObjectCreated
  status: "True"
  timestamp: "2025-02-10T13:37:50Z"
  type: Ready
- message: Finished object creation
  reason: HTTPScaledObjectIsReady
  status: "True"
  timestamp: "2025-02-10T13:37:50Z"
  type: Ready
```

There are some discrepancies with how conditions are handled in the addon and how usually they are handled in kubernetes API so I would like to propose just a simple fix for the selector. With this fix `kubectl` at least displays correctly
```
$ kubectl get httpso
NAME   TARGETWORKLOAD            TARGETSERVICE   MINREPLICAS   MAXREPLICAS   AGE   ACTIVE
demo   apps/v1/Deployment/demo   demo:8080       0             10            70m   True
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

Fixes #https://github.com/kedacore/http-add-on/issues/1211
