### PR TITLE
Make PollingInterval configurable in HTTPScaledObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
 - **General**: Fix kubectl active printcolumn ([#1211](https://github.com/kedacore/http-add-on/issues/1211))
+- **General**: Allow configuration of PollingInterval in HTTPScaledObject ([#1251](https://github.com/kedacore/http-add-on/issues/1251))
 
 ### Improvements
 

--- a/config/crd/bases/http.keda.sh_httpscaledobjects.yaml
+++ b/config/crd/bases/http.keda.sh_httpscaledobjects.yaml
@@ -78,6 +78,11 @@ spec:
                 items:
                   type: string
                 type: array
+              pollingInterval:
+                description: (optional) Configuration for the polling interval of
+                  the scaling metric
+                format: int32
+                type: integer
               replicas:
                 description: (optional) Replica information
                 properties:

--- a/operator/apis/http/v1alpha1/httpscaledobject_types.go
+++ b/operator/apis/http/v1alpha1/httpscaledobject_types.go
@@ -102,6 +102,9 @@ type HTTPScaledObjectSpec struct {
 	// (optional) Cooldown period value
 	// +optional
 	CooldownPeriod *int32 `json:"scaledownPeriod,omitempty" description:"Cooldown period (seconds) for resources to scale down (Default 300)"`
+	// (optional) Configuration for the polling interval of the scaling metric
+	// +optional
+	PollingInterval *int32 `json:"pollingInterval,omitempty" description:"Polling interval (seconds) for the metric used for scaling (Default 15)"`
 	// (optional) Configuration for the metric used for scaling
 	// +optional
 	ScalingMetric *ScalingMetricSpec `json:"scalingMetric,omitempty" description:"Configuration for the metric used for scaling. If empty 'concurrency' will be used"`

--- a/operator/apis/http/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/apis/http/v1alpha1/zz_generated.deepcopy.go
@@ -161,6 +161,11 @@ func (in *HTTPScaledObjectSpec) DeepCopyInto(out *HTTPScaledObjectSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.PollingInterval != nil {
+		in, out := &in.PollingInterval, &out.PollingInterval
+		*out = new(int32)
+		**out = **in
+	}
 	if in.ScalingMetric != nil {
 		in, out := &in.ScalingMetric, &out.ScalingMetric
 		*out = new(ScalingMetricSpec)

--- a/operator/controllers/http/scaled_object.go
+++ b/operator/controllers/http/scaled_object.go
@@ -44,6 +44,7 @@ func (r *HTTPScaledObjectReconciler) createOrUpdateScaledObject(
 		minReplicaCount,
 		maxReplicaCount,
 		httpso.Spec.CooldownPeriod,
+		httpso.Spec.PollingInterval,
 	)
 
 	// Set HTTPScaledObject instance as the owner and controller

--- a/pkg/k8s/scaledobject.go
+++ b/pkg/k8s/scaledobject.go
@@ -27,7 +27,12 @@ func NewScaledObject(
 	minReplicas *int32,
 	maxReplicas *int32,
 	cooldownPeriod *int32,
+	pollingInterval *int32,
 ) *kedav1alpha1.ScaledObject {
+	if pollingInterval == nil {
+		pollingInterval = ptr.To[int32](soPollingInterval)
+	}
+
 	return &kedav1alpha1.ScaledObject{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: kedav1alpha1.SchemeGroupVersion.Identifier(),
@@ -45,7 +50,7 @@ func NewScaledObject(
 				Kind:       workloadRef.Kind,
 				Name:       workloadRef.Name,
 			},
-			PollingInterval: ptr.To[int32](soPollingInterval),
+			PollingInterval: pollingInterval,
 			CooldownPeriod:  cooldownPeriod,
 			MinReplicaCount: minReplicas,
 			MaxReplicaCount: maxReplicas,


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

Provide the PollingInterval of the ScaledObject as parameter in the HTTPScaledObject.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #1251
