### PR TITLE
chore: fix kind action

### DIFF
--- a/.github/kind.yaml
+++ b/.github/kind.yaml
@@ -1,8 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-kubeadmConfigPatches:
-  - |
-    kind: ClusterConfiguration
-    etcd:
-      local:
-        dataDir: /tmp/etcd     # /tmp is mapped to tmpfs in kind's nodes

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -22,11 +22,11 @@ jobs:
         kubernetesVersion: [v1.32, v1.31, v1.30]
         include:
         - kubernetesVersion: v1.32
-          kindImage: kindest/node:v1.32.2
+          kindImage: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
         - kubernetesVersion: v1.31
-          kindImage: kindest/node:v1.31.6
+          kindImage: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
         - kubernetesVersion: v1.30
-          kindImage: kindest/node:v1.30.10
+          kindImage: kindest/node:v1.30.8@sha256:17cd608b3971338d9180b00776cb766c50d0a0b6b904ab4ff52fd3fc5c6369bf
     steps:
       - name: Install prerequisites
         run: |
@@ -49,7 +49,6 @@ jobs:
         with:
           node_image: ${{ matrix.kindImage }}
           cluster_name: cluster
-          config: .github/kind.yaml
 
       - name: Generate images and push to the cluster
         run: |
@@ -100,11 +99,11 @@ jobs:
         kubernetesVersion: [v1.32, v1.31, v1.30]
         include:
         - kubernetesVersion: v1.32
-          kindImage: kindest/node:v1.32.2
+          kindImage: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
         - kubernetesVersion: v1.31
-          kindImage: kindest/node:v1.31.6
+          kindImage: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
         - kubernetesVersion: v1.30
-          kindImage: kindest/node:v1.30.10
+          kindImage: kindest/node:v1.30.8@sha256:17cd608b3971338d9180b00776cb766c50d0a0b6b904ab4ff52fd3fc5c6369bf
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
@@ -120,7 +119,6 @@ jobs:
         with:
           node_image: ${{ matrix.kindImage }}
           cluster_name: ${{ runner.name }}
-          config: .github/kind.yaml
 
       - name: Push images to the cluster
         run: |


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

These are the last supported images versions with kind 0.26. The GH Action need to be udpated to support kind 0.27 in order for us to use newer k8s images.

https://github.com/kubernetes-sigs/kind/releases/tag/v0.26.0
https://github.com/helm/kind-action/releases/tag/v1.12.0
