### PR TITLE
Change path in walkthrough call to match httpscaledobject from example

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -134,7 +134,7 @@ Now that you have your application running and your ingress configured, you can 
 Regardless, you can use the below `curl` command to make a request to your application:
 
 ```console
-curl -H "Host: myhost.com" <Your IP>/path1
+curl -H "Host: myhost.com" <Your IP>/test
 ```
 
 >Note the `-H` flag above to specify the `Host` header. This is needed to tell the interceptor how to route the request. If you have a DNS name set up for the IP, you don't need this header.
@@ -143,7 +143,7 @@ You can also use port-forward to interceptor service for making the request:
 
 ```console
 kubectl port-forward svc/keda-add-ons-http-interceptor-proxy -n ${NAMESPACE} 8080:8080
-curl -H "Host: myhost.com" localhost:8080/path1
+curl -H "Host: myhost.com" localhost:8080/test
 ```
 
 ### Integrating HTTP Add-On Scaler with other KEDA scalers


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->
Changed the curl command in the walktrough to match the path of httpscaledobject which was previously created,
following the walktrough guide (see [examples/v0.10.0/httpscaledobject.yaml](https://github.com/kedacore/http-add-on/blob/main/examples/v0.10.0/httpscaledobject.yaml))

Previously the curl command would request the service on ```/path``` now it uses the ```/test``` path.

I previously followed the walkthrough and wondered why my setup did not work until I noticed this problem.


