### PR TITLE
e2e tests: use ghcr registry for otel images

### DIFF
--- a/tests/utils/setup_test.go
+++ b/tests/utils/setup_test.go
@@ -18,7 +18,7 @@ import (
 var (
 	OtlpConfig = `mode: deployment
 image:
-  repository: "otel/opentelemetry-collector-contrib"
+  repository: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib"
 config:
   exporters:
     debug:


### PR DESCRIPTION
otel images are no longer getting published to dockerhub, only ghcr.

see also: https://github.com/open-telemetry/opentelemetry-collector-releases/pull/902