### PR TITLE
e2e: fix nginx installation via helm

### DIFF
--- a/tests/utils/setup_test.go
+++ b/tests/utils/setup_test.go
@@ -176,7 +176,7 @@ func TestSetupIngress(t *testing.T) {
 	_, err = ExecuteCommand("helm repo update ingress-nginx")
 	require.NoErrorf(t, err, "cannot update ingress-nginx helm repo - %s", err)
 
-	_, err = ExecuteCommand(fmt.Sprintf("helm upgrade --install %s ingress-nginx/ingress-nginx --set fullnameOverride=%s --set controller.service.type=ClusterIP --namespace %s --wait",
+	_, err = ExecuteCommand(fmt.Sprintf("helm upgrade --install %s ingress-nginx/ingress-nginx --set fullnameOverride=%s --set controller.service.type=ClusterIP --set controller.progressDeadlineSeconds=30 --namespace %s --wait",
 		IngressReleaseName, IngressReleaseName, IngressNamespace))
 	require.NoErrorf(t, err, "cannot install ingress - %s", err)
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

There's an issue in Helm causing problems in e2e tests: https://github.com/helm/helm/issues/30878

```
* Deployment.apps "ingress-controller" is invalid: spec.progressDeadlineSeconds: Invalid value: 0: must be greater than minReadySeconds
```
 