### PR TITLE
Add a way to turn off the profiling for all three http add-on components

### DIFF
--- a/.github/workflows/linkinator.yaml
+++ b/.github/workflows/linkinator.yaml
@@ -21,5 +21,6 @@ jobs:
         with:
           paths: "**/*.md"
           markdown: true
+          concurrency: 1
           retry: true
           linksToSkip: "https://github.com/kedacore/http-add-on/pkgs/container/http-add-on-interceptor, https://github.com/kedacore/http-add-on/pkgs/container/http-add-on-operator, https://github.com/kedacore/http-add-on/pkgs/container/http-add-on-scaler,http://opentelemetry-collector.open-telemetry-system:4318,http://opentelemetry-collector.open-telemetry-system:4318/v1/traces, https://www.gnu.org/software/make/"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ linters:
     - unconvert
     - ineffassign
     - staticcheck
-    - exportloopref
+    - copyloopvar
     #- depguard #https://github.com/kedacore/keda/issues/4980
     - dogsled
     - errcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 - **General**: Add configurable tracing support to the interceptor proxy ([#1021](https://github.com/kedacore/http-add-on/pull/1021))
 - **General**: Allow using HSO and SO with different names ([#1293](https://github.com/kedacore/http-add-on/issues/1293))
+- **General**: Support profiling for KEDA components ([#4789](https://github.com/kedacore/keda/issues/4789))
 
 ### Improvements
 

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -45,6 +45,8 @@ type Serving struct {
 	TLSCertStorePaths string `envconfig:"KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS" default:""`
 	// TLSPort is the port that the server should serve on if TLS is enabled
 	TLSPort int `envconfig:"KEDA_HTTP_PROXY_TLS_PORT" default:"8443"`
+	// ProfilingAddr if not empty, pprof will be available on this address, assuming host:port here
+	ProfilingAddr string `envconfig:"PROFILING_BIND_ADDRESS" default:""`
 }
 
 // Parse parses standard configs using envconfig and returns a pointer to the

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -81,6 +82,7 @@ func main() {
 	proxyPort := servingCfg.ProxyPort
 	adminPort := servingCfg.AdminPort
 	proxyTLSEnabled := servingCfg.ProxyTLSEnabled
+	profilingAddr := servingCfg.ProfilingAddr
 
 	// setup the configured metrics collectors
 	metrics.NewMetricsCollectors(metricsCfg)
@@ -217,6 +219,13 @@ func main() {
 
 		return nil
 	})
+
+	if len(profilingAddr) > 0 {
+		eg.Go(func() error {
+			setupLog.Info("enabling pprof for profiling", "address", profilingAddr)
+			return http.ListenAndServe(profilingAddr, nil)
+		})
+	}
 
 	build.PrintComponentInfo(ctrl.Log, "Interceptor")
 

--- a/operator/main.go
+++ b/operator/main.go
@@ -57,11 +57,13 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var profilingAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&profilingAddr, "profiling-bind-address", "", "The address the profiling would be exposed on.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -96,6 +98,7 @@ func main() {
 		Metrics: server.Options{
 			BindAddress: metricsAddr,
 		},
+		PprofBindAddress:              profilingAddr,
 		HealthProbeBindAddress:        probeAddr,
 		LeaderElection:                enableLeaderElection,
 		LeaderElectionID:              "http-add-on.keda.sh",

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -57,7 +57,6 @@ func TestGetEndpoints(t *testing.T) {
 	addrLookup := map[string]*v1.EndpointAddress{}
 	for _, subset := range endpoints.Subsets {
 		for _, addr := range subset.Addresses {
-			addr := addr
 			key := fmt.Sprintf("http://%s:%s", addr.IP, svcPort)
 			addrLookup[key] = &addr
 		}

--- a/pkg/routing/table_test.go
+++ b/pkg/routing/table_test.go
@@ -190,8 +190,6 @@ var _ = Describe("Table", func() {
 			defer cancel()
 
 			for _, httpso := range httpsoList.Items {
-				httpso := httpso
-
 				key := *k8s.NamespacedNameFromObject(&httpso)
 				t.httpScaledObjects[key] = &httpso
 			}
@@ -216,8 +214,6 @@ var _ = Describe("Table", func() {
 			defer cancel()
 
 			for _, httpso := range httpsoList.Items {
-				httpso := httpso
-
 				key := *k8s.NamespacedNameFromObject(&httpso)
 				t.httpScaledObjects[key] = &httpso
 			}
@@ -285,8 +281,6 @@ var _ = Describe("Table", func() {
 
 		It("returns new memory based on HTTPSOs", func() {
 			for _, httpso := range httpsoList.Items {
-				httpso := httpso
-
 				key := *k8s.NamespacedNameFromObject(&httpso)
 				t.httpScaledObjects[key] = &httpso
 			}

--- a/pkg/routing/tablememory_test.go
+++ b/pkg/routing/tablememory_test.go
@@ -484,8 +484,6 @@ var _ = Describe("TableMemory", func() {
 				store: iradix.New[*httpv1alpha1.HTTPScaledObject](),
 			}
 			for _, httpso := range httpsoList.Items {
-				httpso := httpso
-
 				tm = insertTrees(tm, &httpso)
 			}
 

--- a/scaler/config.go
+++ b/scaler/config.go
@@ -34,6 +34,8 @@ type config struct {
 	DeploymentCacheRsyncPeriod time.Duration `envconfig:"KEDA_HTTP_SCALER_DEPLOYMENT_INFORMER_RSYNC_PERIOD" default:"60m"`
 	// QueueTickDuration is the duration between queue requests
 	QueueTickDuration time.Duration `envconfig:"KEDA_HTTP_QUEUE_TICK_DURATION" default:"500ms"`
+	// ProfilingAddr if not empty, pprof will be available on this address, assuming host:port here
+	ProfilingAddr string `envconfig:"PROFILING_BIND_ADDRESS" default:""`
 }
 
 func mustParseConfig() *config {

--- a/scaler/main.go
+++ b/scaler/main.go
@@ -18,14 +18,13 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
 	"golang.org/x/sync/errgroup"
-	"k8s.io/client-go/kubernetes"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	clientset "github.com/kedacore/http-add-on/operator/generated/clientset/versioned"
 	informers "github.com/kedacore/http-add-on/operator/generated/informers/externalversions"


### PR DESCRIPTION
for testing I did:

```bash
ARCH=arm64 make docker-build
k3d cluster create --no-lb --k3s-arg "--disable=traefik,servicelb@server:*"
k3d image import ghcr.io/kedacore/http-add-on-interceptor:main ghcr.io/kedacore/http-add-on-scaler:main ghcr.io/kedacore/http-add-on-operator:main

helm upgrade -i keda kedacore/keda --namespace keda --create-namespace
cat <<VALUES | helm upgrade -i keda-add-ons-http kedacore/keda-add-ons-http  -f -
images:
  tag: main
  operator: ghcr.io/kedacore/http-add-on-operator
  interceptor: ghcr.io/kedacore/http-add-on-interceptor
  scaler: ghcr.io/kedacore/http-add-on-scaler
interceptor:
  pullPolicy: IfNotPresent
  replicas:
    min: 1
scaler:
  pullPolicy: IfNotPresent
  replicas: 1
operator:
  pullPolicy: IfNotPresent
  replicas: 1
VALUES

# enable the profiling
k set env deployments.apps keda-add-ons-http-interceptor PROFILING_BIND_ADDRESS=":5555"
k set env deployments.apps keda-add-ons-http-external-scaler PROFILING_BIND_ADDRESS=":6666"
kubectl patch deploy/keda-add-ons-http-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/1/args/-", "value": "--profiling-bind-address=:7777"}]'
```

..or install the addon w/ [this change](https://github.com/kedacore/charts/pull/763) in

<details>

<summary>details</summary>

```bash
cat <<VALUES | helm upgrade -i keda-add-ons-http ./http-add-on  -f -
images:
  tag: main
  operator: ghcr.io/kedacore/http-add-on-operator
  interceptor: ghcr.io/kedacore/http-add-on-interceptor
  scaler: ghcr.io/kedacore/http-add-on-scaler
interceptor:
  pullPolicy: IfNotPresent
  replicas:
    min: 1
scaler:
  pullPolicy: IfNotPresent
  replicas: 1
operator:
  pullPolicy: IfNotPresent
  replicas: 1
profiling:
  operator:
    enabled: true
  interceptor:
    enabled: true
  scaler:
    enabled: true
VALUES
```

</details>

```
# port forward all the endpoints
(k port-forward $(k get po -lapp.kubernetes.io/component=interceptor --no-headers -ocustom-columns=":metadata.name") 5555:5555 &> /dev/null)&
(k port-forward $(k get po -lapp.kubernetes.io/component=scaler --no-headers -ocustom-columns=":metadata.name") 6666:6666 &> /dev/null)&
(k port-forward $(k get po -lapp.kubernetes.io/component=operator,app.kubernetes.io/name=http-add-on --no-headers -ocustom-columns=":metadata.name") 7777:7777 &> /dev/null)&
(sleep 60 && pkill kubectl)&

# query the pprof endpoints
for p in 5555 6666 7777; do curl localhost:${p}/debug/pprof; done

<a href="/debug/pprof/">Moved Permanently</a>.

<a href="/debug/pprof/">Moved Permanently</a>.

<a href="/debug/pprof/">Moved Permanently</a>.

```