### PR TITLE
fix: prevent HTTP scaler from interfering with other scalers in multi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Fixes
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **General**: Fix HTTP scaler interfering with other scalers in multi-trigger setups ([#1262](https://github.com/kedacore/http-add-on/issues/1262))
 
 ### Deprecations
 


### PR DESCRIPTION
This commit addresses issue #1262 where the HTTP scaler was erroneously scaling workloads to 0 when used with multiple triggers (e.g., CPU + HTTP).

Changes:
- Modified StreamIsActive to only send activation signals when transitioning from inactive to active state
- Prevented sending deactivation signals that would interfere with other scalers (like CPU) in multi-trigger ScaledObjects
- Added comprehensive tests to verify transition behavior
- Updated existing tests to handle new activation-only signal behavior

The fix ensures that:
1. HTTP scaler only activates workloads when HTTP requests are detected
2. HTTP scaler never deactivates workloads, allowing other scalers to maintain proper scaling decisions
3. Multiple triggers can work together without interference

Fixes #1262

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](/README.md)
  - [The `docs/` directory](./docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
