### PR TITLE
ci: fix semver release trigger

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -2,7 +2,7 @@ name: Publish official image to GitHub Container Registry
 
 on:
   push:
-    tags: ["v[0-9].[0-9].[0-9]"]
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 
 jobs:
   build:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

This ensures that the image builds are triggered on releases for all valid semver tags. Double digits were silently ignored.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)