### PR TITLE
fix: check endpoint readiness before forwarding

### DIFF
--- a/interceptor/forward_wait_func.go
+++ b/interceptor/forward_wait_func.go
@@ -17,7 +17,11 @@ type forwardWaitFunc func(context.Context, string, string) (bool, error)
 func workloadActiveEndpoints(endpoints discov1.EndpointSlice) int {
 	total := 0
 	for _, e := range endpoints.Endpoints {
-		total += len(e.Addresses)
+		if e.Conditions.Ready == nil || *e.Conditions.Ready {
+			// null should be treated as ready, per:
+			// https://github.com/kubernetes/api/blob/1446cdecbe6b6afe81373ddedc4dfdb86a7f0bcd/discovery/v1/types.go#L136-L158
+			total += len(e.Addresses)
+		}
 	}
 	return total
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

during https://github.com/kedacore/http-add-on/pull/1298, we introduced a regression where the interceptor doesn't wait for endpoint to be ready for traffic.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes: https://github.com/kedacore/http-add-on/issues/1344