### PR TITLE
interceptor: make request logging optional

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_release_tracker.md
+++ b/.github/ISSUE_TEMPLATE/3_release_tracker.md
@@ -8,7 +8,7 @@ assignees: tomkerkhove,jorturfer
 
 This issue template is used to track the rollout of a new KEDA HTTP add-on version.
 
-For the full release process, we recommend reading [this document]([https://github.com/kedacore/keda/blob/main/RELEASE-PROCESS.md](https://github.com/kedacore/http-add-on/blob/main/RELEASE-PROCESS.md)).
+For the full release process, we recommend reading [this document](https://github.com/kedacore/http-add-on/blob/main/RELEASE-PROCESS.md).
 
 ## Required items
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ _Provide a description of what has been changed_
 - [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
 - [ ] Any necessary documentation is added, such as:
   - [`README.md`](../README.md)
-  - [The `docs/` directory](./docs)
+  - [The `docs/` directory](../docs)
   - [The docs repo](https://github.com/kedacore/keda-docs)
 
 Fixes #

--- a/.github/workflows/linkinator.yaml
+++ b/.github/workflows/linkinator.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: >
-            --base-url "."
+            --root-dir "${{ github.workspace }}"
             --cache --max-cache-age 1d
             --max-concurrency 6
             --max-retries 6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Improvements
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **General**: Make interceptor request logging optional ([#1375](https://github.com/kedacore/http-add-on/pull/1375))
 
 ### Fixes
 

--- a/docs/operate.md
+++ b/docs/operate.md
@@ -70,4 +70,8 @@ Optional variables
 `OTEL_EXPORTER_OTLP_TRACES_INSECURE` - To send traces to the tracing via HTTP rather than HTTPS (`false` by default)
 `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` - The batcher timeout in seconds to send batch of data points (`5` by default)
 
+### Configuring interceptor proxy request logging
+
+The interceptor proxy can log incoming requests for debugging and monitoring purposes. Request logging can be enabled by setting the `KEDA_HTTP_LOG_REQUESTS` environment variable to `true` on the interceptor deployment (`false` by default).
+
 ### Configuring Service Failover

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -51,6 +51,8 @@ type Serving struct {
 	ProfilingAddr string `envconfig:"PROFILING_BIND_ADDRESS" default:""`
 	// EnableColdStartHeader enables/disables the X-KEDA-HTTP-Cold-Start response header
 	EnableColdStartHeader bool `envconfig:"KEDA_HTTP_ENABLE_COLD_START_HEADER" default:"true"`
+	// LogRequests enables/disables logging of incoming requests
+	LogRequests bool `envconfig:"KEDA_HTTP_LOG_REQUESTS" default:"false"`
 }
 
 // Parse parses standard configs using envconfig and returns a pointer to the

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -463,10 +463,9 @@ func runProxyServer(
 		rootHandler = otelhttp.NewHandler(rootHandler, "keda-http-interceptor")
 	}
 
-	rootHandler = middleware.NewLogging(
-		logger,
-		rootHandler,
-	)
+	if serving.LogRequests {
+		rootHandler = middleware.NewLogging(logger, rootHandler)
+	}
 
 	rootHandler = middleware.NewMetrics(
 		rootHandler,


### PR DESCRIPTION
This PR contains two minor changes
* makes the request logs optional (and disabled by default)
* also fixes link checking step with lychee, the `--base-url` no longer accepts relative paths and should be replaced by `--root-dir` - see also: https://github.com/lycheeverse/lychee/pull/1857 and https://github.com/lycheeverse/lychee/releases/tag/lychee-v0.21.0

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [The `docs/` directory](./docs)