### PR TITLE
e2e: set images to known multiarch versions

### DIFF
--- a/tests/checks/interceptor_websocket/interceptor_websocket_test.go
+++ b/tests/checks/interceptor_websocket/interceptor_websocket_test.go
@@ -78,7 +78,7 @@ spec:
     spec:
       containers:
         - name: {{.DeploymentName}}
-          image: ghcr.io/kedacore/tests-websockets
+          image: ghcr.io/kedacore/tests-websockets:http-add-on-e2e
           ports:
             - name: http
               containerPort: 8080
@@ -184,7 +184,7 @@ spec:
     spec:
       containers:
       - name: websocat-test
-        image: ghcr.io/vi/websocat:v1.14.0
+        image: ghcr.io/vi/websocat
         command: ["/bin/sh"]
         args:
         - -c

--- a/tests/checks/scaling_phase_custom_resource/scaling_phase_custom_resource_test.go
+++ b/tests/checks/scaling_phase_custom_resource/scaling_phase_custom_resource_test.go
@@ -107,7 +107,7 @@ spec:
     spec:
       containers:
       - name: apache-ab
-        image: ghcr.io/kedacore/tests-apache-ab
+        image: ghcr.io/kedacore/tests-apache-ab:http-add-on-e2e
         imagePullPolicy: Always
         args:
           - "-n"

--- a/tests/checks/scaling_phase_deployment/scaling_phase_deployment_test.go
+++ b/tests/checks/scaling_phase_deployment/scaling_phase_deployment_test.go
@@ -100,7 +100,7 @@ spec:
     spec:
       containers:
       - name: apache-ab
-        image: ghcr.io/kedacore/tests-apache-ab
+        image: ghcr.io/kedacore/tests-apache-ab:http-add-on-e2e
         imagePullPolicy: Always
         args:
           - "-n"

--- a/tests/checks/scaling_phase_deployment_with_skip_so_creation/scaling_phase_deployment_with_skip_so_creation_test.go
+++ b/tests/checks/scaling_phase_deployment_with_skip_so_creation/scaling_phase_deployment_with_skip_so_creation_test.go
@@ -102,7 +102,7 @@ spec:
     spec:
       containers:
       - name: apache-ab
-        image: ghcr.io/kedacore/tests-apache-ab
+        image: ghcr.io/kedacore/tests-apache-ab:http-add-on-e2e
         imagePullPolicy: Always
         args:
           - "-n"

--- a/tests/checks/scaling_phase_statefulset/scaling_phase_statefulset_test.go
+++ b/tests/checks/scaling_phase_statefulset/scaling_phase_statefulset_test.go
@@ -100,7 +100,7 @@ spec:
     spec:
       containers:
       - name: apache-ab
-        image: ghcr.io/kedacore/tests-apache-ab
+        image: ghcr.io/kedacore/tests-apache-ab:http-add-on-e2e
         imagePullPolicy: Always
         args:
           - "-n"


### PR DESCRIPTION
e2e tests work for AMD64, but many of them started to fail for ARM64. The issue seems to be that some images have been newly built as AMD64 only and not multiarch:
```
$ docker manifest inspect ghcr.io/kedacore/tests-apache-ab | jq '.mediaType'
"application/vnd.oci.image.index.v1+json"

$ docker manifest inspect ghcr.io/kedacore/tests-apache-ab:8f3801e | jq '.mediaType'
"application/vnd.docker.distribution.manifest.v2+json"
```
This PR pins the images to the latest multiarch versions so ARM64 tests can pass.

see also: https://github.com/kedacore/test-tools/pull/234