### PR TITLE
Improve interceptor performance and allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,10 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Improvements
 
-- **Interceptor**: Pool HTTP transports to reduce per-request allocations and improve performance ([#1403](https://github.com/kedacore/http-add-on/issues/1403))
 - **General**: Make interceptor request logging optional ([#1375](https://github.com/kedacore/http-add-on/pull/1375))
+- **Interceptor**: Significant performance improvements ([#1403](https://github.com/kedacore/http-add-on/issues/1403))
+  - Pool HTTP transports to reduce per-request allocations
+  - Use dedicated buffer pool for reverse proxy to reduce GC pressure
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This changelog keeps track of work items that have been completed and are ready 
 - **Interceptor**: Significant performance improvements ([#1403](https://github.com/kedacore/http-add-on/issues/1403))
   - Pool HTTP transports to reduce per-request allocations
   - Use dedicated buffer pool for reverse proxy to reduce GC pressure
+  - Increase MaxIdleConnsPerHost to reduce connection churn under load
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,6 @@ This changelog keeps track of work items that have been completed and are ready 
 
 - **General**: Make interceptor request logging optional ([#1375](https://github.com/kedacore/http-add-on/pull/1375))
 - **Interceptor**: Significant performance improvements ([#1403](https://github.com/kedacore/http-add-on/issues/1403))
-  - Pool HTTP transports to reduce per-request allocations
-  - Use dedicated buffer pool for reverse proxy to reduce GC pressure
-  - Increase MaxIdleConnsPerHost to reduce connection churn under load
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Improvements
 
+- **Interceptor**: Pool HTTP transports to reduce per-request allocations and improve performance ([#1403](https://github.com/kedacore/http-add-on/issues/1403))
 - **General**: Make interceptor request logging optional ([#1375](https://github.com/kedacore/http-add-on/pull/1375))
 
 ### Fixes

--- a/interceptor/config/timeouts.go
+++ b/interceptor/config/timeouts.go
@@ -21,9 +21,13 @@ type Timeouts struct {
 	WorkloadReplicas time.Duration `envconfig:"KEDA_CONDITION_WAIT_TIMEOUT" default:"1500ms"`
 	// ForceHTTP2 toggles whether to try to force HTTP2 for all requests
 	ForceHTTP2 bool `envconfig:"KEDA_HTTP_FORCE_HTTP2" default:"false"`
-	// MaxIdleConns is the max number of connections that can be idle in the
-	// interceptor's internal connection pool
+	// MaxIdleConns is the max number of idle connections to keep in the
+	// interceptor's internal connection pool across all backend services.
+	// Increase this if you proxy to many unique backend services.
 	MaxIdleConns int `envconfig:"KEDA_HTTP_MAX_IDLE_CONNS" default:"100"`
+	// MaxIdleConnsPerHost is the max number of idle connections to keep per backend service.
+	// Increase this if you observe many new connection establishments under load.
+	MaxIdleConnsPerHost int `envconfig:"KEDA_HTTP_MAX_IDLE_CONNS_PER_HOST" default:"20"`
 	// IdleConnTimeout is the timeout after which a connection in the interceptor's
 	// internal connection pool will be closed
 	IdleConnTimeout time.Duration `envconfig:"KEDA_HTTP_IDLE_CONN_TIMEOUT" default:"90s"`

--- a/interceptor/handler/bufferpool.go
+++ b/interceptor/handler/bufferpool.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"net/http/httputil"
+	"sync"
+)
+
+// bufferSize is the size of buffers used for copying HTTP request/response bodies.
+// This matches the buffer size used in Go's standard library net/http/httputil.ReverseProxy:
+// https://github.com/golang/go/blob/go1.25.5/src/net/http/httputil/reverseproxy.go#L657
+const bufferSize = 32 * 1024
+
+// bufPool recycles buffers used by the reverse proxy to reduce memory allocations.
+type bufPool struct {
+	pool *sync.Pool
+}
+
+func newBufferPool() httputil.BufferPool {
+	return &bufPool{
+		pool: &sync.Pool{
+			New: func() any {
+				b := make([]byte, bufferSize)
+				return &b
+			},
+		},
+	}
+}
+
+func (bp *bufPool) Get() []byte {
+	return *(bp.pool.Get().(*[]byte))
+}
+
+func (bp *bufPool) Put(b []byte) {
+	bp.pool.Put(&b)
+}

--- a/interceptor/handler/upstream.go
+++ b/interceptor/handler/upstream.go
@@ -15,6 +15,8 @@ import (
 )
 
 var (
+	bufferPool = newBufferPool()
+
 	errNilStream = errors.New("context stream is nil")
 )
 
@@ -66,6 +68,7 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(stream)
+	proxy.BufferPool = bufferPool
 	superDirector := proxy.Director
 	proxy.Transport = uh.roundTripper
 	proxy.Director = func(req *http.Request) {

--- a/interceptor/handler/upstream.go
+++ b/interceptor/handler/upstream.go
@@ -67,23 +67,21 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	proxy := httputil.NewSingleHostReverseProxy(stream)
-	proxy.BufferPool = bufferPool
-	superDirector := proxy.Director
-	proxy.Transport = uh.roundTripper
-	proxy.Director = func(req *http.Request) {
-		superDirector(req)
-		req.URL = stream
-		req.URL.Path = r.URL.Path
-		req.URL.RawPath = r.URL.RawPath
-		req.URL.RawQuery = r.URL.RawQuery
-		// delete the incoming X-Forwarded-For header so the proxy
-		// puts its own in. This is also important to prevent IP spoofing
-		req.Header.Del("X-Forwarded-For ")
-	}
-	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-		sh := NewStatic(http.StatusBadGateway, err)
-		sh.ServeHTTP(w, r)
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(stream)
+			// Preserve original Host header (SetURL rewrites it by default).
+			pr.Out.Host = pr.In.Host
+			// Preserve X-Forwarded-For chain before appending client IP.
+			pr.Out.Header["X-Forwarded-For"] = pr.In.Header["X-Forwarded-For"]
+			pr.SetXForwarded()
+		},
+		BufferPool: bufferPool,
+		Transport:  uh.roundTripper,
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			sh := NewStatic(http.StatusBadGateway, err)
+			sh.ServeHTTP(w, r)
+		},
 	}
 
 	proxy.ServeHTTP(w, r)

--- a/interceptor/handler/upstream_test.go
+++ b/interceptor/handler/upstream_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -440,6 +441,63 @@ func TestForwardRequestRedirectAndHeaders(t *testing.T) {
 	r.Equal("text/html; charset=utf-8", res.Header().Get("Content-Type"))
 	r.Equal("somethingcustom", res.Header().Get("X-Custom-Header"))
 	r.Equal("Hello from srv", res.Body.String())
+}
+
+func TestUpstreamSetsXForwardedFor(t *testing.T) {
+	tests := map[string]struct {
+		forwardedIPs []string
+	}{
+		"appends to existing header chain": {
+			forwardedIPs: []string{"1.2.3.4", "5.6.7.8"},
+		},
+		"sets header when not present": {
+			forwardedIPs: nil,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Prepare a fake backend
+			var receivedHeaders http.Header
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedHeaders = r.Header.Clone()
+			}))
+			defer backend.Close()
+
+			backendURL, err := url.Parse(backend.URL)
+			if err != nil {
+				t.Fatalf("failed to parse backend URL: %v", err)
+			}
+
+			// Configure the Upstream and send a dummy request
+			upstream := NewUpstream(http.DefaultTransport, &config.Tracing{}, false)
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			forwardedIPsStr := strings.Join(tt.forwardedIPs, ", ")
+			if tt.forwardedIPs != nil {
+				req.Header.Set("X-Forwarded-For", forwardedIPsStr)
+			}
+			req = util.RequestWithStream(req, backendURL)
+
+			upstream.ServeHTTP(httptest.NewRecorder(), req)
+
+			// Verify the test conditions
+			xff := receivedHeaders.Get("X-Forwarded-For")
+			if xff == "" {
+				t.Fatal("X-Forwarded-For should not be empty")
+			}
+
+			if tt.forwardedIPs != nil && !strings.HasPrefix(xff, forwardedIPsStr) {
+				t.Errorf("expected X-Forwarded-For to contain %q, got: %q", forwardedIPsStr, xff)
+			}
+
+			ips := strings.Split(xff, ", ")
+			expectedLen := len(tt.forwardedIPs) + 1
+			if len(ips) != expectedLen {
+				t.Errorf("expected %d IPs in X-Forwarded-For, got %d: %q", expectedLen, len(ips), xff)
+			}
+		})
+	}
 }
 
 func newRoundTripper(

--- a/interceptor/middleware/counting_test.go
+++ b/interceptor/middleware/counting_test.go
@@ -30,7 +30,7 @@ func TestCountMiddleware(t *testing.T) {
 
 	httpso := &httpv1alpha1.HTTPScaledObject{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "@",
+			Namespace: "test-namespace",
 		},
 		Spec: httpv1alpha1.HTTPScaledObjectSpec{
 			ScaleTargetRef: httpv1alpha1.ScaleTargetRef{

--- a/interceptor/middleware/routing.go
+++ b/interceptor/middleware/routing.go
@@ -41,8 +41,6 @@ func NewRouting(routingTable routing.Table, probeHandler http.Handler, upstreamH
 var _ http.Handler = (*Routing)(nil)
 
 func (rm *Routing) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	r = util.RequestWithLoggerWithName(r, "RoutingMiddleware")
-
 	httpso := rm.routingTable.Route(r)
 	if httpso == nil {
 		if rm.isProbe(r) {
@@ -55,7 +53,6 @@ func (rm *Routing) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-	r = r.WithContext(util.ContextWithHTTPSO(r.Context(), httpso))
 
 	stream, err := rm.streamFromHTTPSO(r.Context(), httpso, httpso.Spec.ScaleTargetRef)
 	if err != nil {
@@ -64,18 +61,25 @@ func (rm *Routing) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-	r = r.WithContext(util.ContextWithStream(r.Context(), stream))
+
+	// Batch context operations to reduce allocations in the happy path
+	ctx := r.Context()
+	logger := util.LoggerFromContext(ctx)
+	ctx = util.ContextWithLogger(ctx, logger.WithName("RoutingMiddleware"))
+	ctx = util.ContextWithHTTPSO(ctx, httpso)
+	ctx = util.ContextWithStream(ctx, stream)
 
 	if httpso.Spec.ColdStartTimeoutFailoverRef != nil {
-		failoverStream, err := rm.streamFromHTTPSO(r.Context(), httpso, httpso.Spec.ColdStartTimeoutFailoverRef)
+		failoverStream, err := rm.streamFromHTTPSO(ctx, httpso, httpso.Spec.ColdStartTimeoutFailoverRef)
 		if err != nil {
 			sh := handler.NewStatic(http.StatusInternalServerError, err)
 			sh.ServeHTTP(w, r)
 			return
 		}
-		r = r.WithContext(util.ContextWithFailoverStream(r.Context(), failoverStream))
+		ctx = util.ContextWithFailoverStream(ctx, failoverStream)
 	}
 
+	r = r.WithContext(ctx)
 	rm.upstreamHandler.ServeHTTP(w, r)
 }
 

--- a/interceptor/middleware/routing.go
+++ b/interceptor/middleware/routing.go
@@ -109,21 +109,16 @@ func (rm *Routing) streamFromHTTPSO(ctx context.Context, httpso *httpv1alpha1.HT
 	if err != nil {
 		return nil, fmt.Errorf("failed to get port: %w", err)
 	}
+
+	scheme := "http"
 	if rm.tlsEnabled {
-		return url.Parse(fmt.Sprintf(
-			"https://%s.%s:%d",
-			reference.GetServiceName(),
-			httpso.GetNamespace(),
-			port,
-		))
+		scheme = "https"
 	}
-	//goland:noinspection HttpUrlsUsage
-	return url.Parse(fmt.Sprintf(
-		"http://%s.%s:%d",
-		reference.GetServiceName(),
-		httpso.GetNamespace(),
-		port,
-	))
+
+	return &url.URL{
+		Scheme: scheme,
+		Host:   fmt.Sprintf("%s.%s:%d", reference.GetServiceName(), httpso.GetNamespace(), port),
+	}, nil
 }
 
 func (rm *Routing) isProbe(r *http.Request) bool {

--- a/interceptor/proxy_handlers.go
+++ b/interceptor/proxy_handlers.go
@@ -47,9 +47,6 @@ func newForwardingConfigFromTimeouts(t *config.Timeouts, s *config.Serving) forw
 // newForwardingHandler takes in the service URL for the app backend
 // and forwards incoming requests to it. Note that it isn't multitenant.
 // It's intended to be deployed and scaled alongside the application itself.
-//
-// fwdSvcURL must have a valid scheme in it. The best way to do this is
-// creating a URL with url.Parse("https://...")
 func newForwardingHandler(
 	lggr logr.Logger,
 	dialCtxFunc kedanet.DialContextFunc,

--- a/interceptor/proxy_handlers.go
+++ b/interceptor/proxy_handlers.go
@@ -23,6 +23,7 @@ type forwardingConfig struct {
 	respHeaderTimeout     time.Duration
 	forceAttemptHTTP2     bool
 	maxIdleConns          int
+	maxIdleConnsPerHost   int
 	idleConnTimeout       time.Duration
 	tlsHandshakeTimeout   time.Duration
 	expectContinueTimeout time.Duration
@@ -35,6 +36,7 @@ func newForwardingConfigFromTimeouts(t *config.Timeouts, s *config.Serving) forw
 		respHeaderTimeout:     t.ResponseHeader,
 		forceAttemptHTTP2:     t.ForceHTTP2,
 		maxIdleConns:          t.MaxIdleConns,
+		maxIdleConnsPerHost:   t.MaxIdleConnsPerHost,
 		idleConnTimeout:       t.IdleConnTimeout,
 		tlsHandshakeTimeout:   t.TLSHandshakeTimeout,
 		expectContinueTimeout: t.ExpectContinueTimeout,
@@ -61,6 +63,7 @@ func newForwardingHandler(
 		DialContext:           dialCtxFunc,
 		ForceAttemptHTTP2:     fwdCfg.forceAttemptHTTP2,
 		MaxIdleConns:          fwdCfg.maxIdleConns,
+		MaxIdleConnsPerHost:   fwdCfg.maxIdleConnsPerHost,
 		IdleConnTimeout:       fwdCfg.idleConnTimeout,
 		TLSHandshakeTimeout:   fwdCfg.tlsHandshakeTimeout,
 		ExpectContinueTimeout: fwdCfg.expectContinueTimeout,

--- a/interceptor/proxy_handlers_test.go
+++ b/interceptor/proxy_handlers_test.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -198,7 +197,7 @@ func TestImmediatelySuccessfulFailoverProxy(t *testing.T) {
 	req = util.RequestWithHTTPSO(req,
 		&httpv1alpha1.HTTPScaledObject{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "@" + host,
+				Namespace: "test-namespace",
 			},
 			Spec: httpv1alpha1.HTTPScaledObjectSpec{
 				ScaleTargetRef: httpv1alpha1.ScaleTargetRef{
@@ -786,10 +785,9 @@ func targetFromURL(
 	workload string,
 	service string,
 ) *httpv1alpha1.HTTPScaledObject {
-	host := strings.Split(u.Host, ":")[0]
 	return &httpv1alpha1.HTTPScaledObject{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "@" + host,
+			Namespace: "test-namespace",
 		},
 		Spec: httpv1alpha1.HTTPScaledObjectSpec{
 			ScaleTargetRef: httpv1alpha1.ScaleTargetRef{

--- a/pkg/http/transport_pool.go
+++ b/pkg/http/transport_pool.go
@@ -1,0 +1,42 @@
+package http
+
+import (
+	nethttp "net/http"
+	"sync"
+	"time"
+)
+
+// TransportPool manages a pool of nethttp.Transport instances,
+// reusing them based on response header timeout configuration.
+//
+// NOTE: Transports are never evicted, we expect a low cardinality of timeouts
+type TransportPool struct {
+	transports    sync.Map // map[time.Duration]*nethttp.Transport
+	baseTransport *nethttp.Transport
+}
+
+// NewTransportPool creates a new transport pool with a base transport template
+func NewTransportPool(baseTransport *nethttp.Transport) *TransportPool {
+	return &TransportPool{
+		baseTransport: baseTransport,
+	}
+}
+
+// Get returns a cached or new transport for the given response header timeout.
+func (tp *TransportPool) Get(responseHeaderTimeout time.Duration) *nethttp.Transport {
+	// Fast path: check if transport already exists
+	if val, ok := tp.transports.Load(responseHeaderTimeout); ok {
+		return val.(*nethttp.Transport)
+	}
+
+	// Slow path: create new transport
+	transport := tp.baseTransport.Clone()
+	transport.ResponseHeaderTimeout = responseHeaderTimeout
+
+	// Try to store it, but another goroutine might have created one concurrently
+	actual, loaded := tp.transports.LoadOrStore(responseHeaderTimeout, transport)
+	if loaded {
+		return actual.(*nethttp.Transport)
+	}
+	return transport
+}

--- a/pkg/http/transport_pool_test.go
+++ b/pkg/http/transport_pool_test.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTransportPool_ReusesSameTransport(t *testing.T) {
+	pool := NewTransportPool(&http.Transport{})
+
+	timeout := 5 * time.Second
+	transport1 := pool.Get(timeout)
+	transport2 := pool.Get(timeout)
+
+	if transport1 != transport2 {
+		t.Errorf("expected same transport instance for same timeout, got different instances")
+	}
+}
+
+func TestTransportPool_DifferentTimeouts(t *testing.T) {
+	pool := NewTransportPool(&http.Transport{})
+
+	timeout1 := 5 * time.Second
+	timeout2 := 10 * time.Second
+
+	transport1 := pool.Get(timeout1)
+	transport2 := pool.Get(timeout2)
+
+	if transport1 == transport2 {
+		t.Errorf("expected different transport instances for different timeouts, got same instance")
+	}
+
+	if transport1.ResponseHeaderTimeout != timeout1 {
+		t.Errorf("expected transport1 ResponseHeaderTimeout to be %v, got %v", timeout1, transport1.ResponseHeaderTimeout)
+	}
+	if transport2.ResponseHeaderTimeout != timeout2 {
+		t.Errorf("expected transport2 ResponseHeaderTimeout to be %v, got %v", timeout2, transport2.ResponseHeaderTimeout)
+	}
+}
+
+func TestTransportPool_ConcurrentAccess(t *testing.T) {
+	pool := NewTransportPool(&http.Transport{})
+
+	timeout := 5 * time.Second
+	numGoroutines := 100
+	var wg sync.WaitGroup
+	transports := make(chan *http.Transport, numGoroutines)
+
+	for range numGoroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			transports <- pool.Get(timeout)
+		}()
+	}
+
+	wg.Wait()
+	close(transports)
+
+	var allTransports []*http.Transport
+	for transport := range transports {
+		allTransports = append(allTransports, transport)
+	}
+
+	firstTransport := allTransports[0]
+	for i, transport := range allTransports {
+		if transport != firstTransport {
+			t.Errorf("goroutine %d got different transport instance", i)
+		}
+	}
+}


### PR DESCRIPTION
Hi,

this PR contains quite a performance improvement as outlined in the Final Performance Comparison section below.

If you prefer a short meeting where I go over the changes and explain them I'm happy to do that!


## Changes

- Eliminates per-request http.Transport creation by introducing TransportPool that reuses transports based on `ResponseHeaderTimeout`.
   - `ResponseHeaderTimeout` is unfortunately set on the transport requiring us to keep a transport per configured timeout.
   - The pool uses sync.Map for lock-free reads and maintains a small number of transport instances, one per unique timeout configuration.
   - There is currently no expiration of old transports but I don't expect too many different timeouts. Even if unused timeouts would stay in the map the overall memory usage would not be that high - especially compared to having a transport per request as before.
   - Transports per HTTPSO are possible but IMO not needed as we can configure the single Transport (per timeout) with higher MaxIdleConns/MaxIdleConnsPerHost settings (see below).
- Reuse buffers in the ReverseProxy by adding a BufferPool that reduces unneeded allocations quite a lot (see below).
- Increase MaxIdleConnsPerHost and make it configurable
   - Go only keeps 2 idle connections per host [by default](https://cs.opensource.google/go/go/+/refs/tags/go1.25.5:src/net/http/transport.go;l=60) 
   - The default MaxIdleConns is 100 (go default and default in HTTP Addon)
   - Keeping only 2 idle connections causes a lot of connection thrashing which high requests per second
   - As we only increase the limit there is no change for low RPS services, but greatly increases performance for higher RPS, see below.
 - Minor Change: Improve URL construction by defining the URL struct directly instead of creating a string with the URL fields and parsing that immediately afterwards
 - Minor Change: Modify the context multiple times and apply it to the context only once instead of cloning it after each modification
    - I noticed this in the profiling output, not a major thing but still an improvement

## Final Performance Comparison

Besides the more fine grained tests below I also ran a longer final comparison.

I ran the `oha` CLI once with 100 concurrent connections and once without rate limiting for 1min, 30min and also for 1 hour with the following results (evaluation of before and after benchmarks was done by an LLM):

### Fixed QPS Test (100 req/s, 1 hour)

**This test shows performance at a controlled rate - both versions handle the load successfully:**

| Metric | Baseline | Optimized | Improvement |
|--------|----------|-----------|-------------|
| **Requests/sec** | 100.00 | 100.00 | Same (throttled) |
| **Memory Growth** | 9Mi → 403Mi (+394Mi) | 9Mi → 20Mi (+11Mi) | **36× less growth** |
| **Error Rate** | 0% (360,000 OK) | 0% (360,001 OK) | Same (both perfect) |
| **CPU Usage** | 95m | 39m | **2.4× less CPU** |
| **CPU Efficiency** | 1,078 req/CPU-sec | 3,161 req/CPU-sec | **2.9× more efficient** |
| **Avg Latency** | 3.5ms | 2.3ms | **34% faster** |
| **P99 Latency** | 5.2ms | 3.5ms | **33% faster** |

**Key Finding:** At fixed 100 QPS, optimized is better on **every metric** - lower latency, less memory, less CPU.


<details>
<summary>Details of the 100QPS 1h evaluation</summary>

## 1-Hour Throttled Test Results (100 QPS Fixed Rate)

### Throughput & Reliability

| Metric | Baseline | Optimized | Δ |
|--------|----------|-----------|---|
| Requests/sec | 100.0003 | 100.0006 | Same (perfect throttling) |
| Success Rate | 100% | 100% | Same (both perfect) |
| Total Requests | 360,000 | 360,001 | Same (1h @ 100 QPS) |
| Errors | 0 | 0 | Same (zero errors) |
| Avg Latency | 3.5 ms | 2.3 ms | **-1.2 ms (-34%)** |
| P50 Latency | 2.5 ms | 1.7 ms | **-0.8 ms (-32%)** |
| P99 Latency | 5.2 ms | 3.5 ms | **-1.7 ms (-33%)** |
| P99.99 Latency | 3434.6 ms | 1627.5 ms | **-1807 ms (-53%)** |

**Analysis:** At fixed 100 QPS, both versions handle the load without errors. However, optimized delivers **consistently lower latency** across all percentiles. This proves the optimized version is genuinely faster, not just higher capacity.

### Memory Usage (kubectl top)

| Phase | Baseline | Optimized | Δ |
|-------|----------|-----------|---|
| Initial (00min) | 9 Mi | 9 Mi | 0 Mi |
| Final (60min) | **403 Mi** | 20 Mi | **-383 Mi (-95%)** |
| **Growth** | **+394 Mi** | **+11 Mi** | **36× less growth** |
| **CPU (final)** | 95m | 39m | **-56m (-59%)** |

**Finding:** Even at moderate 100 QPS load, baseline still exhibits significant memory growth (394 Mi over 1h = 6.6 Mi/min). Optimized remains stable at 20Mi.

### Heap Growth Analysis (00min → final)

**Baseline:**
```
+46.68 MB  bufio.NewWriterSize       # Per-connection write buffers (34.16%)
+38.65 MB  bufio.NewReaderSize       # Per-connection read buffers (28.28%)
+11.51 MB  queueForIdleConn          # Idle connection queue (8.42%)
+8.51 MB   tryPutIdleConn            # Idle connection management (6.22%)
+7.00 MB   Transport.dialConn        # Active connection setup (5.12%)
+4.50 MB   forwardingHandler         # Request handler allocations (3.29%)
```
**Total: ~136 MB heap growth** (matches kubectl top ~403 Mi including runtime)

**Optimized:**
```
+1.18 MB   pprof.StartCPUProfile    # Profiling overhead (69.16%)
+0.53 MB   regexp.bitState.reset    # Regex state (30.84%)
```
**Total: ~1.7 MB heap growth** (matches kubectl top ~20 Mi)

**Same pattern:** Connection-related allocations dominate baseline growth (85 MB in buffers alone), while optimized shows only profiling overhead.

### CPU Efficiency (3600s / 1hr duration)

| Metric | Baseline | Optimized | Analysis |
|--------|----------|-----------|----------|
| Total CPU samples | 333.97s | 113.87s | **66% less absolute CPU** |
| Total requests | 360,000 | 360,001 | Same workload |
| **CPU efficiency** | **1,078 req/CPU-sec** | **3,161 req/CPU-sec** | **2.9× more efficient** |
| Syscall overhead | 68.50% | 60.31% | Better connection reuse |
| Futex overhead | 20.56% | 32.48% | More lock contention (acceptable) |
| GC overhead | 3.00s (0.90%) | 1.17s (1.03%) | Similar GC pressure |

**Key insight:** Processing the **same number of requests**, optimized uses 66% less CPU. This proves the efficiency gain is real, not just throughput scaling.


</details>

### Max Throughput Test (Unthrottled, 1 hour)

**This test shows maximum sustainable capacity:**

| Metric | Baseline | Optimized | Improvement |
|--------|----------|-----------|-------------|
| **Max Throughput** | 190.77 req/s | 1044.97 req/s | **5.5× higher** |
| **Memory Growth** | 13Mi → 1063Mi (+1050Mi) | 10Mi → 31Mi (+21Mi) | **50× less growth** |
| **Error Rate** | 1.33% (9,163 errors) | 0% (0 errors) | **Zero errors** |
| **CPU Efficiency** | 1,080 req/CPU-sec | 5,225 req/CPU-sec | **4.8× more efficient** |
| **P99 Latency** | 1500.1ms (timeouts) | 195.8ms | **-1304ms** |

**Key Finding:** Baseline hits capacity limit at ~190 req/s with errors. Optimized sustains 5.5× higher load with zero errors.


<details>
<summary>Details of the unthrottled 1h evaluation</summary>

## 1-Hour Test Results

### Throughput & Reliability

| Metric | Baseline | Optimized | Δ |
|--------|----------|-----------|---|
| Requests/sec | 190.77 | 1044.97 | **+448%** |
| Success Rate | 98.67% | 100% | **+1.33%** |
| Total Requests | 677,568 | 3,761,836 | **+455%** |
| Errors (504) | 9,163 | 0 | **-9,163** |
| P50 Latency | 1.0 ms | 9.4 ms | +8.4 ms |
| P99 Latency | 1500.1 ms | 195.8 ms | **-1304.3 ms** |

**Analysis:** Baseline P99 latency (1500ms) indicates timeouts. Optimized maintains sub-200ms P99 while handling 5.5× more load with zero errors.

### Memory Usage (kubectl top)

| Phase | Baseline | Optimized | Δ |
|-------|----------|-----------|---|
| Initial (00min) | 13 Mi | 10 Mi | -3 Mi |
| Final (60min) | **1063 Mi** | 31 Mi | **-1032 Mi (-97%)** |
| **Growth** | **+1050 Mi** | **+21 Mi** | **50× less growth** |
| **CPU (final)** | 136m | 212m | +76m |

**Finding:** Baseline memory grows from 13Mi to 1063Mi (81× growth) over 1 hour. Growth rate: ~17.5 Mi/min.

### Heap Growth Analysis (00min → final)

**Baseline:**
```
+99.87 MB  bufio.NewReaderSize       # Per-connection read buffers (28.37%)
+89.34 MB  bufio.NewWriterSize       # Per-connection write buffers (25.38%)
+26.02 MB  queueForIdleConn          # Idle connection queue (7.39%)
+26.01 MB  runtime.malg              # Goroutine stacks (7.39%)
+20.00 MB  Transport.dialConn        # Active connections (5.68%)
+15.01 MB  Transport.tryPutIdleConn  # Idle connection management (4.26%)
+13.01 MB  forwardingHandler         # Request handler allocations (3.69%)
+12.38 MB  ReverseProxy.copyBuffer   # Proxy copy buffers (3.52%)
```

**Total heap growth: ~351 MB** (matches kubectl top: ~1063 Mi includes runtime overhead)

**Optimized:**
```
+1.18 MB   pprof.StartCPUProfile    # Profiling overhead (13.97%)
+1.03 MB   pprof.profMap.lookup     # Profiling overhead (12.17%)
+0.53 MB   newBufferPool.func1      # Buffer pool (6.23%)
+0.53 MB   regexp.bitState.reset    # Regex state (6.23%)
-2.11 MB   io.ReadAll               # Buffer pool freeing (24.94% negative)
-0.53 MB   bytes.growSlice          # Efficient buffer reuse
```

**Total heap growth: ~8 MB** (matches kubectl top: ~31 Mi)

**Root Causes Identified:**

1. **Transport connection leak (baseline):**
   - 99.87 MB + 89.34 MB = **189 MB in connection buffers**
   - Each connection allocates 4KB read + 4KB write buffers
   - ~23,616 leaked connections (189 MB / 8 KB)
   - Root cause: Creating new `Transport` per request instead of reusing

2. **Idle connection queue growth (baseline):**
   - 26.02 MB in `queueForIdleConn`
   - 15.01 MB in `tryPutIdleConn`
   - Transport configured for high `MaxIdleConnsPerHost` but not reusing

3. **Buffer pool success (optimized):**
   - Negative allocations in `io.ReadAll` (-2.11 MB) and `bytes.growSlice` (-0.53 MB)
   - Indicates successful buffer pooling and reuse

### CPU Efficiency (3600s / 1hr duration)

| Metric | Baseline | Optimized | Analysis |
|--------|----------|-----------|----------|
| Total CPU samples | 627.40s | 719.91s | +92.51s (+15%) more CPU used |
| Total requests | 677,568 | 3,761,836 | 5.5× more requests processed |
| **CPU efficiency** | **1,080 req/CPU-sec** | **5,225 req/CPU-sec** | **4.8× more efficient** |
| Syscall overhead | 83.50% | 66.06% | Better connection reuse |
| GC overhead | 5.61s (0.89%) | 3.83s (0.53%) | Less GC despite 5.5× load |

**Key insight:** Optimized uses 15% more absolute CPU but processes 5.5× more work = 4.8× better CPU efficiency.


</details>


## Performance Tests

### Test Setup

- Local kind cluster on my Macbook M4 Pro
- Single HTTPScaledObject fix 2 fixed replicas using https://github.com/hashicorp/http-echo image
- contour ingress controller (basically just configures envoy as active component)
- Procedure
   1. restart deployment
   2. snapshot heap
   3. run 1min 50 requests per second (with CPU profiling enabled)
   4. snapshot heap
   5. run 1min full load
   6. snapshot heap





### TransportPool Before & After

Performance impact at 50 QPS for a minute on my local kind cluster:
- Latency: -28% to -38% (p50/p95/p99)
- Throughput: +64% (423 → 692 req/s max)
- Memory: -33% per request (74 KB → 50 KB)
- Allocations: -48% per request (508 → 266 objects)


<details>
<summary>Details</summary>


#### CPU Time before Transport Pool
<img width="1425" height="668" alt="image" src="https://github.com/user-attachments/assets/ad1eb160-f46f-456a-8dd1-5304a4ad7627" />


#### CPU Time after Transport Pool
You only see the part right to the curly bracket from the before image.
<img width="1432" height="619" alt="image" src="https://github.com/user-attachments/assets/6051cc38-df8d-424b-94a1-c1d37d7e866e" />

#### Allocated Space Before
<img width="1384" height="434" alt="image" src="https://github.com/user-attachments/assets/8d6f1855-e51e-41f9-bce9-0552bf9721bd" />


#### Allocated Space After
<img width="1384" height="449" alt="image" src="https://github.com/user-attachments/assets/e7273f12-dacd-41b4-87d4-49aa73a03fa7" />

</details>

### BufferPool Before & After

This reduces the GarbageCollector load quite a lot (in my tests ~55%) as we do not allocate as much memory for each request as before.
I also had 3-4% higher throughput and quite a drop in the median latency (-80%) - they might be related or also within the margin of error.

<details>
<summary>Details</summary>

#### Allocated Space Before BufferPool (after TransportPool)

<img width="1427" height="455" alt="image" src="https://github.com/user-attachments/assets/d08c7855-d32f-4c2f-9bbf-b59e3266ef6e" />

#### Allocated Space After BufferPool (after TransportPool)

<img width="1425" height="415" alt="image" src="https://github.com/user-attachments/assets/a77b6848-c72f-41c0-8565-3b112a62eff6" />


</details>

### Increase MaxIdleConnsPerHost Before & After

The `MaxIdleConnsPerHost` fix resulted in immense performance improvements, I ran my tests 2 times with the following results:

- +39-51% throughput increase
- -37-87% median latency reduction 
- -88-95% tail latency improvement (way lower P99/P99.9)
- -57-64% CPU reduction 

<details>
<summary>Details</summary>

#### Allocated Space Before MaxIdleConnsPerHost Increase (after TransportPool and BufferPool)
Not really relevant, mostly a CPU load change.

<img width="1388" height="331" alt="image" src="https://github.com/user-attachments/assets/060cc937-6552-4330-adc3-78dbe4c21099" />


#### Allocated Space After MaxIdleConnsPerHost Increase (after TransportPool and BufferPool)
Not really relevant, mostly a CPU load change.

<img width="1380" height="336" alt="image" src="https://github.com/user-attachments/assets/834975c5-47e2-4736-99a3-78e2d8c293fe" />


#### CPU Before MaxIdleConnsPerHost Increase (after TransportPool and BufferPool)

<img width="1388" height="573" alt="image" src="https://github.com/user-attachments/assets/09e6336a-0853-4718-845f-a570d92b6826" />

#### CPU After MaxIdleConnsPerHost Increase (after TransportPool and BufferPool)

<img width="1433" height="618" alt="image" src="https://github.com/user-attachments/assets/ec88835b-a64f-4d49-9d6c-4ed3acb89bad" />

</details>




## Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #1403 
Related to #1078 
