### PR TITLE
feat: add wildcard host matching for HTTPScaledObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### New
 
+- **General**: Add multi-level wildcard host matching for HTTPScaledObject routing ([#281](https://github.com/kedacore/http-add-on/issues/281))
 - **General**: Add environment variables for leader election timing configuration ([#1365](https://github.com/kedacore/http-add-on/pull/1365))
 
 ### Improvements

--- a/pkg/routing/key.go
+++ b/pkg/routing/key.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -9,30 +10,43 @@ import (
 	httpv1alpha1 "github.com/kedacore/http-add-on/operator/apis/http/v1alpha1"
 )
 
+// catchAllHostKey is the internal routing key for catch-all host matching.
+const catchAllHostKey = "*"
+
 type Key []byte
+type Keys []Key
 
-func NewKey(host string, path string) Key {
-	if i := strings.LastIndex(host, ":"); i != -1 {
-		host = host[:i]
-	}
+var _ fmt.Stringer = (*Key)(nil)
 
-	path = strings.Trim(path, "/")
-	if path != "" {
-		path += "/"
-	}
-
-	key := fmt.Sprintf("//%s/%s", host, path)
-	return []byte(key)
+func (k Key) String() string {
+	return string(k)
 }
 
+// NewKey creates a routing key from hostname (without port) and path.
+func NewKey(hostname string, path string) Key {
+	path = strings.Trim(path, "/")
+
+	var b strings.Builder
+	b.Grow(len(hostname) + 1 + len(path) + 1)
+	b.WriteString(hostname)
+	b.WriteByte('/')
+	b.WriteString(path)
+	if path != "" {
+		b.WriteByte('/')
+	}
+	return []byte(b.String())
+}
+
+// NewKeyFromURL creates a routing key from a URL.
 func NewKeyFromURL(url *url.URL) Key {
 	if url == nil {
 		return nil
 	}
 
-	return NewKey(url.Host, url.Path)
+	return NewKey(url.Hostname(), url.Path)
 }
 
+// NewKeyFromRequest creates a routing key from an HTTP request.
 func NewKeyFromRequest(req *http.Request) Key {
 	if req == nil {
 		return nil
@@ -51,14 +65,7 @@ func NewKeyFromRequest(req *http.Request) Key {
 	return NewKeyFromURL(&keyURL)
 }
 
-var _ fmt.Stringer = (*Key)(nil)
-
-func (k Key) String() string {
-	return string(k)
-}
-
-type Keys []Key
-
+// NewKeysFromHTTPSO creates routing keys from an HTTPScaledObject.
 func NewKeysFromHTTPSO(httpso *httpv1alpha1.HTTPScaledObject) Keys {
 	if httpso == nil {
 		return nil
@@ -80,11 +87,63 @@ func NewKeysFromHTTPSO(httpso *httpv1alpha1.HTTPScaledObject) Keys {
 	keysSize := hostsSize * pathPrefixesSize
 	keys := make([]Key, 0, keysSize)
 	for _, host := range hosts {
+		hostname := stripPort(host)
+		if isCatchAllHostname(hostname) {
+			hostname = catchAllHostKey
+		}
 		for _, pathPrefix := range pathPrefixes {
-			key := NewKey(host, pathPrefix)
+			key := NewKey(hostname, pathPrefix)
 			keys = append(keys, key)
 		}
 	}
 
 	return keys
+}
+
+// stripPort removes the port from a host string.
+func stripPort(host string) string {
+	if host == "" {
+		return ""
+	}
+	if hostname, _, err := net.SplitHostPort(host); err == nil {
+		return hostname
+	}
+	return host
+}
+
+// wildcardHostnames returns all wildcard patterns for a hostname,
+// ordered from most specific to least specific.
+// "foo.example.com" -> ["*.example.com", "*.com"]
+// "localhost"       -> []  (single-label, no wildcards)
+// ""                -> []  (empty, no wildcards)
+func wildcardHostnames(hostname string) []string {
+	if hostname == "" {
+		return nil
+	}
+
+	// Count dots to pre-allocate exact capacity
+	dotCount := strings.Count(hostname, ".")
+	if dotCount == 0 {
+		return nil // Single-label hostname
+	}
+
+	wildcards := make([]string, 0, dotCount)
+	remaining := hostname
+
+	for {
+		// Use Index instead of SplitN to avoid []string allocation
+		idx := strings.Index(remaining, ".")
+		if idx == -1 {
+			break
+		}
+		remaining = remaining[idx+1:]
+		wildcards = append(wildcards, "*."+remaining)
+	}
+
+	return wildcards
+}
+
+// isCatchAllHostname returns true if hostname is a catch-all wildcard.
+func isCatchAllHostname(hostname string) bool {
+	return hostname == "*" || hostname == ""
 }

--- a/pkg/routing/table.go
+++ b/pkg/routing/table.go
@@ -125,7 +125,7 @@ func (t *table) Start(ctx context.Context) error {
 }
 
 func (t *table) Route(req *http.Request) *httpv1alpha1.HTTPScaledObject {
-	if req == nil {
+	if req == nil || req.URL == nil {
 		return nil
 	}
 
@@ -134,8 +134,9 @@ func (t *table) Route(req *http.Request) *httpv1alpha1.HTTPScaledObject {
 		return nil
 	}
 
-	key := NewKeyFromRequest(req)
-	return tm.Route(key)
+	hostname := stripPort(req.Host)
+
+	return tm.Route(hostname, req.URL.Path)
 }
 
 func (t *table) HasSynced() bool {

--- a/pkg/routing/tablememory_benchmark_test.go
+++ b/pkg/routing/tablememory_benchmark_test.go
@@ -1,0 +1,144 @@
+package routing
+
+import (
+	"strconv"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	httpv1alpha1 "github.com/kedacore/http-add-on/operator/apis/http/v1alpha1"
+)
+
+func BenchmarkExactMatch(b *testing.B) {
+	b.Run("SingleRoute", func(b *testing.B) {
+		httpso := &httpv1alpha1.HTTPScaledObject{
+			ObjectMeta: metav1.ObjectMeta{Name: "exact"},
+			Spec:       httpv1alpha1.HTTPScaledObjectSpec{Hosts: []string{"foo.example.com"}},
+		}
+		tm := NewTableMemory().Remember(httpso)
+
+		for b.Loop() {
+			tm.Route("foo.example.com", "/api/v1")
+		}
+	})
+
+	b.Run("Among100Routes", func(b *testing.B) {
+		tm := setup100ExactRoutes()
+
+		for b.Loop() {
+			tm.Route("host50.example.com", "/api/v1")
+		}
+	})
+}
+
+func BenchmarkWildcard(b *testing.B) {
+	b.Run("1Subdomain", func(b *testing.B) {
+		httpso := &httpv1alpha1.HTTPScaledObject{
+			ObjectMeta: metav1.ObjectMeta{Name: "wildcard"},
+			Spec:       httpv1alpha1.HTTPScaledObjectSpec{Hosts: []string{"*.example.com"}},
+		}
+		tm := NewTableMemory().Remember(httpso)
+
+		for b.Loop() {
+			tm.Route("foo.example.com", "/api/v1")
+		}
+	})
+
+	b.Run("3Subdomains", func(b *testing.B) {
+		httpso := &httpv1alpha1.HTTPScaledObject{
+			ObjectMeta: metav1.ObjectMeta{Name: "wildcard"},
+			Spec:       httpv1alpha1.HTTPScaledObjectSpec{Hosts: []string{"*.example.com"}},
+		}
+		tm := NewTableMemory().Remember(httpso)
+
+		for b.Loop() {
+			tm.Route("a.b.c.example.com", "/api/v1")
+		}
+	})
+
+	b.Run("5Subdomains", func(b *testing.B) {
+		httpso := &httpv1alpha1.HTTPScaledObject{
+			ObjectMeta: metav1.ObjectMeta{Name: "wildcard"},
+			Spec:       httpv1alpha1.HTTPScaledObjectSpec{Hosts: []string{"*.example.com"}},
+		}
+		tm := NewTableMemory().Remember(httpso)
+
+		for b.Loop() {
+			tm.Route("a.b.c.d.e.example.com", "/api/v1")
+		}
+	})
+
+	b.Run("Among100Routes", func(b *testing.B) {
+		tm := setup100ExactRoutes()
+		wildcardHTTPSO := &httpv1alpha1.HTTPScaledObject{
+			ObjectMeta: metav1.ObjectMeta{Name: "wildcard"},
+			Spec:       httpv1alpha1.HTTPScaledObjectSpec{Hosts: []string{"*.other.com"}},
+		}
+		tm = tm.Remember(wildcardHTTPSO)
+
+		for b.Loop() {
+			tm.Route("foo.other.com", "/api/v1")
+		}
+	})
+}
+
+func BenchmarkCatchAll(b *testing.B) {
+	b.Run("SingleRoute", func(b *testing.B) {
+		httpso := &httpv1alpha1.HTTPScaledObject{
+			ObjectMeta: metav1.ObjectMeta{Name: "catchall"},
+			Spec:       httpv1alpha1.HTTPScaledObjectSpec{Hosts: []string{"*"}},
+		}
+		tm := NewTableMemory().Remember(httpso)
+
+		for b.Loop() {
+			tm.Route("unknown.domain.com", "/api/v1")
+		}
+	})
+
+	b.Run("Among100Routes", func(b *testing.B) {
+		tm := setup100ExactRoutes()
+		catchAllHTTPSO := &httpv1alpha1.HTTPScaledObject{
+			ObjectMeta: metav1.ObjectMeta{Name: "catchall"},
+			Spec:       httpv1alpha1.HTTPScaledObjectSpec{Hosts: []string{"*"}},
+		}
+		tm = tm.Remember(catchAllHTTPSO)
+
+		for b.Loop() {
+			tm.Route("unknown.domain.com", "/api/v1")
+		}
+	})
+}
+
+func BenchmarkNoMatch(b *testing.B) {
+	b.Run("SingleRoute", func(b *testing.B) {
+		httpso := &httpv1alpha1.HTTPScaledObject{
+			ObjectMeta: metav1.ObjectMeta{Name: "exact"},
+			Spec:       httpv1alpha1.HTTPScaledObjectSpec{Hosts: []string{"foo.example.com"}},
+		}
+		tm := NewTableMemory().Remember(httpso)
+
+		for b.Loop() {
+			tm.Route("other.domain.com", "/api/v1")
+		}
+	})
+
+	b.Run("Among100Routes", func(b *testing.B) {
+		tm := setup100ExactRoutes()
+
+		for b.Loop() {
+			tm.Route("unknown.domain.com", "/api/v1")
+		}
+	})
+}
+
+func setup100ExactRoutes() TableMemory {
+	tm := NewTableMemory()
+	for i := range 100 {
+		httpso := &httpv1alpha1.HTTPScaledObject{
+			ObjectMeta: metav1.ObjectMeta{Name: "exact-" + strconv.Itoa(i)},
+			Spec:       httpv1alpha1.HTTPScaledObjectSpec{Hosts: []string{"host" + strconv.Itoa(i) + ".example.com"}},
+		}
+		tm = tm.Remember(httpso)
+	}
+	return tm
+}


### PR DESCRIPTION
Implement wildcard host matching that allows HTTPScaledObjects to use patterns like `*.example.com` to match any subdomain. When an exact host match is not found, the routing table falls back to wildcard matching.

I considered two approaches:
- `*.foo` catches `bar.foo` but not `baz.bar.foo`
	- this is the behavior of a wildcard host in an Ingress rule
- `*.foo` catches `bar.foo`, `baz.bar.foo` and all other nested domains
	- this approach is chosen by Gateway API and others -> this is the way I chose
	- Quote: `The wildcard character will match any number of characters and dots to the left, however, so "*.example.com" will match both "foo.bar.example.com" and "bar.example.com".`
	- Source: https://gateway-api.sigs.k8s.io/reference/spec/


There is also the case of no hosts being specified but this case was currently not really handled as it never matched (host is set to `""`). Kubernetes ingresses etc do interpret an empty/missing host as wildcard which is what I am also doing now.

There will also be a followup PR just with a refactor of the table memory as the `index` was only used in tests.

### Quick Benchmark

I added a benchmark (see changed files) to compare the before and after, this is the summary:
- keep in mind: these are nanoseconds
- reduced allocations and preallocating reduced the exact case from 116ns to 38ns
- the new most simple wildcard case takes now 135ns (almost the exact case duration from before)
- more complex wildcard case `a.b.c.d.e.example.com` for `*.example.com` takes 415ns as every next subdomain is tried in sequence

Linear scaling for long wildcard domains is of course not optimal but:
- this is not really common
- 0.0004ms for a long wildcard is not noticable
- there are likely more major bottlenecks we should focus on

```plain
❯ benchstat before.txt after.txt
goos: darwin
goarch: arm64
pkg: github.com/kedacore/http-add-on/pkg/routing
cpu: Apple M4 Pro
                             │  before.txt  │               after.txt               │
                             │    sec/op    │    sec/op     vs base                 │
ExactMatch/SingleRoute-14      116.70n ± 1%   38.60n ±  1%   -66.92% (p=0.000 n=10)
ExactMatch/Among100Routes-14   139.40n ± 1%   69.41n ±  0%   -50.21% (p=0.000 n=10)
Wildcard/1Subdomain-14          111.8n ± 1%   135.2n ±  1%   +20.97% (p=0.000 n=10)
Wildcard/3Subdomains-14         111.8n ± 1%   279.6n ±  1%  +150.09% (p=0.000 n=10)
Wildcard/5Subdomains-14         113.8n ± 1%   415.2n ±  2%  +264.81% (p=0.000 n=10)
Wildcard/Among100Routes-14      116.1n ± 0%   134.6n ±  1%   +15.93% (p=0.000 n=10)
CatchAll/SingleRoute-14         112.8n ± 1%   231.7n ±  1%  +105.32% (p=0.000 n=10)
CatchAll/Among100Routes-14      116.2n ± 2%   237.5n ±  1%  +104.43% (p=0.000 n=10)
NoMatch/SingleRoute-14          112.3n ± 1%   229.4n ± 22%  +104.37% (p=0.000 n=10)
NoMatch/Among100Routes-14       112.7n ± 1%   256.0n ± 16%  +127.15% (p=0.000 n=10)
geomean                         116.1n        168.4n         +44.99%
```

### Changes 
- Update Route() to try wildcard match when exact match fails
- Simplify key format from "//{host}/{path}/" to "{host}/{path}/"
  - I found no reason for the `//` prefix to exist, all tests also still pass. Seems like this was the most simple key received after removing the protocol
- Update docs to reference wildcard usage

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #281 
