### PR TITLE
refactor: simplify TableMemory and remove dead code

### DIFF
--- a/pkg/routing/table.go
+++ b/pkg/routing/table.go
@@ -39,7 +39,7 @@ type table struct {
 	httpScaledObjectEventHandlerRegistration cache.ResourceEventHandlerRegistration
 	httpScaledObjects                        map[types.NamespacedName]*httpv1alpha1.HTTPScaledObject
 	httpScaledObjectsMutex                   sync.RWMutex
-	memoryHolder                             util.AtomicValue[TableMemory]
+	memoryHolder                             util.AtomicValue[*TableMemory]
 	memorySignaler                           util.Signaler
 	queueCounter                             queue.Counter
 }
@@ -103,7 +103,7 @@ func (t *table) refreshMemory(ctx context.Context) error {
 	}
 }
 
-func (t *table) newMemoryFromHTTPSOs() TableMemory {
+func (t *table) newMemoryFromHTTPSOs() *TableMemory {
 	t.httpScaledObjectsMutex.RLock()
 	defer t.httpScaledObjectsMutex.RUnlock()
 

--- a/pkg/routing/table_test.go
+++ b/pkg/routing/table_test.go
@@ -203,8 +203,7 @@ var _ = Describe("Table", func() {
 			Expect(tm).NotTo(BeNil())
 
 			for _, httpso := range httpsoList.Items {
-				namespacedName := k8s.NamespacedNameFromObject(&httpso)
-				ret := tm.Recall(namespacedName)
+				ret := tm.Route(httpso.Spec.Hosts[0], "")
 				Expect(ret).To(Equal(&httpso))
 			}
 		})
@@ -250,13 +249,12 @@ var _ = Describe("Table", func() {
 			Expect(tm).NotTo(BeNil())
 
 			for _, httpso := range append(httpsoList.Items[1:], httpso) {
-				namespacedName := k8s.NamespacedNameFromObject(&httpso)
-				ret := tm.Recall(namespacedName)
+				ret := tm.Route(httpso.Spec.Hosts[0], "")
 				Expect(ret).To(Equal(&httpso))
 			}
 
-			namespacedName := k8s.NamespacedNameFromObject(&first)
-			ret := tm.Recall(namespacedName)
+			// First item was deleted, should not be routable
+			ret := tm.Route(first.Spec.Hosts[0], "")
 			Expect(ret).To(BeNil())
 		})
 
@@ -288,9 +286,7 @@ var _ = Describe("Table", func() {
 			tm := t.newMemoryFromHTTPSOs()
 
 			for _, httpso := range httpsoList.Items {
-				namespacedName := k8s.NamespacedNameFromObject(&httpso)
-
-				ret := tm.Recall(namespacedName)
+				ret := tm.Route(httpso.Spec.Hosts[0], "")
 				Expect(ret).To(Equal(&httpso))
 			}
 		})

--- a/pkg/routing/tablememory_benchmark_test.go
+++ b/pkg/routing/tablememory_benchmark_test.go
@@ -131,7 +131,7 @@ func BenchmarkNoMatch(b *testing.B) {
 	})
 }
 
-func setup100ExactRoutes() TableMemory {
+func setup100ExactRoutes() *TableMemory {
 	tm := NewTableMemory()
 	for i := range 100 {
 		httpso := &httpv1alpha1.HTTPScaledObject{


### PR DESCRIPTION
Convert `TableMemory` from interface to concrete `*TableMemory` type. The interface added indirection without benefit.

Remove the index tree and Recall/Forget methods which were never used outside tests, reducing complexity and memory usage.

I decided to mostly rewrite the test as:
- a good chunk was testing unused functions like Recall or Forget
- a good chunk was testing internal functionality accessing the store directly instead of using Route
- parts of it were quite redundant like the checks in `forgets only when namespaced names match on conflict`
- ginkgo/gomega are not needed for simple unit tests like this
	- they also don't support e.g. `go test -count N` and are a bit slower
	- go stdlib testing supports everything we need here

Afterwards I also let AI check the tests to make sure no test case was forgotten.

### Changes
- Convert TableMemory from interface to concrete type
- Remove index tree from TableMemory struct
- Remove unused Recall and Forget methods
- Convert tablememory_test.go to Go standard library tests
- Update table_test.go to use Route instead of Recall

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

