### PR TITLE
fix: Preserve X-Forwarded-Proto from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Fixes
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Interceptor**: Preserve X-Forwarded-Proto from upstream ([#1432](https://github.com/kedacore/http-add-on/issues/1432))
 
 ### Deprecations
 

--- a/interceptor/handler/upstream.go
+++ b/interceptor/handler/upstream.go
@@ -75,6 +75,8 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// Preserve X-Forwarded-For chain before appending client IP.
 			pr.Out.Header["X-Forwarded-For"] = pr.In.Header["X-Forwarded-For"]
 			pr.SetXForwarded()
+			// Preserve X-Forwarded-Proto to preserve behavior behind TLS teminating proxy
+			pr.Out.Header["X-Forwarded-Proto"] = pr.In.Header["X-Forwarded-Proto"]
 		},
 		BufferPool: bufferPool,
 		Transport:  uh.roundTripper,


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

This changes the interceptor so that it preserves the `X-Forwarded-Proto`

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #1432
