### PR TITLE
fix(interceptor): preserve upstream X-Forwarded headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Fixes
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **General**: Preserve `X-Forwarded-Proto` and `X-Forwarded-Host` headers from upstream proxies ([#1432](https://github.com/kedacore/http-add-on/issues/1432))
 
 ### Deprecations
 

--- a/interceptor/handler/upstream.go
+++ b/interceptor/handler/upstream.go
@@ -72,9 +72,16 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			pr.SetURL(stream)
 			// Preserve original Host header (SetURL rewrites it by default).
 			pr.Out.Host = pr.In.Host
-			// Preserve X-Forwarded-For chain before appending client IP.
+
+			// Preserve and extend X-Forwarded-... headers from upstream proxies
 			pr.Out.Header["X-Forwarded-For"] = pr.In.Header["X-Forwarded-For"]
 			pr.SetXForwarded()
+			if host := pr.In.Header.Get("X-Forwarded-Host"); host != "" {
+				pr.Out.Header.Set("X-Forwarded-Host", host)
+			}
+			if proto := pr.In.Header.Get("X-Forwarded-Proto"); proto != "" {
+				pr.Out.Header.Set("X-Forwarded-Proto", proto)
+			}
 		},
 		BufferPool: bufferPool,
 		Transport:  uh.roundTripper,


### PR DESCRIPTION
The interceptor should preserve X-Forwarded-... headers of upstream requests as these are used to indicate how the client originally connected to the infrastructure.
The goal is not to force infos about requests to the interceptor into these headers.

We always trust X-Forwarded headers as the HTTP Addon expects an ingress controller or such to protect against X-Forwarded-... headers injected from outside of the cluster.
The implementation is now more in line with others, e.g. how [traefik](https://github.com/traefik/traefik/blob/a4a91344edcdd6276c1b766ca19ee3f0e346480f/pkg/proxy/httputil/proxy.go#L122-L139) handles it.
The `X-Forwarded` (without a suffix like `-For`) header is still ignored here as before as there doesn't seem to be a real adoption also indicated by Go not handling it.

Changes:
- Preserve X-Forwarded-Proto from incoming request if present
- Preserve X-Forwarded-Host from incoming request if present

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #1432 
