### PR TITLE
fix: handle health checks in admin not proxy handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Fixes
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Interceptor**: Fix health probes failing when HTTPScaledObject has no hosts configured ([#1447](https://github.com/kedacore/http-add-on/issues/1447))
 
 ### Deprecations
 

--- a/config/interceptor/deployment.yaml
+++ b/config/interceptor/deployment.yaml
@@ -64,11 +64,11 @@ spec:
         livenessProbe:
           httpGet:
             path: /livez
-            port: proxy
+            port: admin
         readinessProbe:
           httpGet:
             path: /readyz
-            port: proxy
+            port: admin
         # TODO(pedrotorres): set better default values avoiding overcommitment
         resources:
           requests:

--- a/interceptor/admin.go
+++ b/interceptor/admin.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	"github.com/kedacore/http-add-on/pkg/queue"
+)
+
+// BuildAdminHandler creates the handler for the admin endpoint.
+func BuildAdminHandler(logger logr.Logger, counter queue.Counter, probeHandler http.Handler) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.Handle("/readyz", probeHandler)
+	mux.Handle("/livez", probeHandler)
+
+	queue.AddCountsRoute(
+		logger,
+		mux,
+		counter,
+	)
+
+	return mux
+}

--- a/interceptor/admin_test.go
+++ b/interceptor/admin_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestAdminHandler(t *testing.T) {
+	tests := map[string]struct {
+		path            string
+		wantProbeCalled bool
+		wantStatus      int
+	}{
+		"livez": {
+			path:            "/livez",
+			wantProbeCalled: true,
+			wantStatus:      http.StatusOK,
+		},
+		"readyz": {
+			path:            "/readyz",
+			wantProbeCalled: true,
+			wantStatus:      http.StatusOK,
+		},
+		"other": {
+			path:            "/other",
+			wantProbeCalled: false,
+			wantStatus:      http.StatusNotFound,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			probeCalled := false
+			probeHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				probeCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			handler := BuildAdminHandler(logr.Discard(), nil, probeHandler)
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if probeCalled != tt.wantProbeCalled {
+				t.Error("expected probe to be called")
+			}
+			if rec.Code != tt.wantStatus {
+				t.Errorf("got status = %d, want %d", rec.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/interceptor/handler/probe.go
+++ b/interceptor/handler/probe.go
@@ -14,7 +14,7 @@ type Probe struct {
 	healthy        atomic.Bool
 }
 
-func NewProbe(healthChecks []util.HealthChecker) *Probe {
+func NewProbe(healthChecks ...util.HealthChecker) *Probe {
 	return &Probe{
 		healthCheckers: healthChecks,
 	}

--- a/interceptor/handler/probe_test.go
+++ b/interceptor/handler/probe_test.go
@@ -24,13 +24,11 @@ var _ = Describe("ProbeHandler", func() {
 			)
 
 			var b bool
-			healthCheckers := []util.HealthChecker{
-				util.HealthCheckerFunc(func(_ context.Context) error {
-					b = true
+			healthCheckers := util.HealthCheckerFunc(func(_ context.Context) error {
+				b = true
 
-					return ret
-				}),
-			}
+				return ret
+			})
 
 			ph := NewProbe(healthCheckers)
 			Expect(ph).NotTo(BeNil())

--- a/interceptor/proxy.go
+++ b/interceptor/proxy.go
@@ -23,7 +23,6 @@ type ProxyHandlerConfig struct {
 	Queue        queue.Counter
 	WaitFunc     forwardWaitFunc
 	RoutingTable routing.Table
-	ProbeHandler http.Handler
 	Reader       client.Reader
 	Timeouts     config.Timeouts
 	Serving      config.Serving
@@ -83,7 +82,6 @@ func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
 
 	handler = middleware.NewRouting(
 		cfg.RoutingTable,
-		cfg.ProbeHandler,
 		handler,
 		cfg.Reader,
 		cfg.TLSConfig != nil,

--- a/interceptor/proxy_handlers_integration_test.go
+++ b/interceptor/proxy_handlers_integration_test.go
@@ -301,7 +301,7 @@ func newHarness(
 		return nil, err
 	}
 
-	proxyHdl := middleware.NewRouting(routingTable, nil, newForwardingHandler(
+	proxyHdl := middleware.NewRouting(routingTable, newForwardingHandler(
 		lggr,
 		testTransport(testDialerToOrigin(originSrvURL), &tls.Config{}),
 		waitFunc,

--- a/interceptor/proxy_test.go
+++ b/interceptor/proxy_test.go
@@ -361,7 +361,6 @@ func newProxyTestHarness(t *testing.T, cfg harnessConfig) *proxyTestHarness {
 		Queue:        queueCounter,
 		WaitFunc:     waitFunc,
 		RoutingTable: routingTable,
-		ProbeHandler: nil,
 		Reader:       fake.NewClientBuilder().WithScheme(kedacache.NewScheme()).Build(),
 		Timeouts: config.Timeouts{
 			WorkloadReplicas: 5 * time.Second,


### PR DESCRIPTION
A fix in 0.12.0 that made empty hosts wildcard matchers triggered a bug forwarding health check probes to user applications. This forward caused the kubernetes health checks to fail restarting the interceptor.

The smart health check detection logic in the proxy handler was replaced by having the admin handler respond to health check requests. In theory there is a behavioral change as only headers were used before to detect health check probes, we now rely on the configured /healthz and /readyz endpoints.

**We definitely need to update the helm chart afterwards.**

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #1447 
