### PR TITLE
chore: fix changelog validation to run on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ None
 
 ### Breaking Changes
 
-- **General**: Migrate from deprecated `v1.Endpoints` to `discoveryv1.EndpointSlices` ([#1297](https://github.com/kedacore/http-add-on/issues/1297)).
+- **General**: Migrate from deprecated `v1.Endpoints` to `discoveryv1.EndpointSlices` ([#1297](https://github.com/kedacore/http-add-on/issues/1297))
 
 ### New
 


### PR DESCRIPTION
The previous changelog validation script did not run on macOS due bash v3 being the default or a grep perl regex not being supported.
I'm not a fan of bash scripts in general but I guess this also works 🤷 

I used AI to rewrite the validation script and let it test the following cases:
1. Valid changelog → OK, exit 0                                               
2. Invalid format (bad links) → errors shown, exit 1                          
3. Empty History section → error message, exit 1                              
4. Unsorted entries → shows expected order, exit 1                            
5. Missing file → "not found", exit 1                                         
6. Multiple errors across versions → all errors reported, exit 1              
7. Mismatched link numbers ([#123] vs /pull/456) → error with details, exit 1 
8. Matching link numbers ([#123] vs /pull/123) → OK                           
9. Multiple links with one mismatch → error detected                          
10. TODO links ([#TODO]) → skipped, OK                                        


We could also use it in the keda repo with minor modifications:
1. Fix colon position in changelog (line 450, v2.15.0)
   - **Authentication:** → **Authentication**:
2. Accept #XXX placeholder in script
   - Unreleased template uses #XXX instead of #TODO
3. Skip v1 versions in script
   - v1.5.0 uses legacy format with category subheaders (- **Scalers**, - **Secret Providers**, - **Other**) that don't match current entry format
4. Fix 15 sorting errors in changelog
   - Various sections in v2.6.0 - v2.15.0 have entries not sorted alphabetically


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

