### PR TITLE
fix: increase default resync period of endpoint informer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Fixes
 
 - **Interceptor**: Fix health probes failing when HTTPScaledObject has no hosts configured ([#1447](https://github.com/kedacore/http-add-on/issues/1447))
+- **Interceptor**: Set endpoint informer resync default to 1s to suppress warning ([#1455](https://github.com/kedacore/http-add-on/issues/1455))
 
 ### Deprecations
 

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -28,7 +28,8 @@ type Serving struct {
 	// of endpoints that is running the servers it forwards to.
 	//
 	// This is the interval (in milliseconds) representing how often to do a fetch
-	EndpointsCachePollIntervalMS int `envconfig:"KEDA_HTTP_ENDPOINTS_CACHE_POLLING_INTERVAL_MS" default:"250"`
+	// TODO: this is actually the informer resync period, not a poll interval, default is too aggressive
+	EndpointsCachePollIntervalMS int `envconfig:"KEDA_HTTP_ENDPOINTS_CACHE_POLLING_INTERVAL_MS" default:"1000"`
 	// ProxyTLSEnabled is a flag to specify whether the interceptor proxy should
 	// be running using a TLS enabled server
 	ProxyTLSEnabled bool `envconfig:"KEDA_HTTP_PROXY_TLS_ENABLED" default:"false"`


### PR DESCRIPTION
This resolves a warning saying that the current default of 250 is automatically increased to 1000 which means, this change is effectively a noop and just removes the warning.

```log
2026-02-10T09:40:46Z    INFO    setup    starting interceptor    {"timeoutConfig": {"Connect":500000000,"KeepAlive":1000000000,"ResponseHeader":30000000000,"WorkloadReplicas":30000000000,"ForceHTTP2":false,"MaxIdleConns":100,"MaxIdleConnsPerHost":20,"IdleConnTimeout":90000000000,"TLSHandshakeTimeout":10000000000,"ExpectContinueTimeout":1000000000}, "servingConfig": {"CurrentNamespace":"keda","WatchNamespace":"","ProxyPort":8080,"AdminPort":9090,"CacheSyncPeriod":3600000000000,"EndpointsCachePollIntervalMS":250,"ProxyTLSEnabled":true,"TLSCertPath":"/certs/tls.crt","TLSKeyPath":"/certs/tls.key","TLSCertStorePaths":"","TLSSkipVerify":true,"TLSPort":8443,"ProfilingAddr":"0.0.0.0:6060","EnableColdStartHeader":true,"LogRequests":false}, "metricsConfig": {"OtelPrometheusExporterEnabled":true,"OtelPrometheusExporterPort":2223,"OtelHTTPExporterEnabled":false}}
I0210 09:40:46.777034       1 shared_informer.go:667] "Warning: resync period is too small. Changing it to the minimum allowed value" resyncPeriod="250ms" minimumResyncPeriod="1s"
2026-02-10T09:40:46Z    INFO    setup    Interceptor starting
...
```

I decided not to fix the actual issue and just get rid of the warning for now.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)

See #1455
