### PR TITLE
refactor: simplify probe handler and rewrite tests

### DIFF
--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -170,9 +170,8 @@ func main() {
 		return nil
 	})
 
-	// start the update loop that updates the routing table from
-	// the ConfigMap that the operator updates as HTTPScaledObjects
-	// enter and exit the system
+	// Start the update loop that refreshes the routing table
+	// when HTTPScaledObjects are added, updated, or removed
 	eg.Go(func() error {
 		setupLog.Info("starting the routing table")
 

--- a/pkg/routing/table.go
+++ b/pkg/routing/table.go
@@ -119,6 +119,7 @@ func (t *table) HasSynced() bool {
 var _ util.HealthChecker = (*table)(nil)
 
 func (t *table) HealthCheck(_ context.Context) error {
+	// TODO: HasSynced never fails after passing once, it is not testing health over time
 	if !t.HasSynced() {
 		return errNotSyncedTable
 	}


### PR DESCRIPTION
Improve probe logging during startup by changing initial warmup log level to INFO instead of using ERROR.
Due to the recent change to use the controller-runtime cache in #1446 this error shouldn't basically appear anymore, I haven't seen it locally using the main branch version after multiple attempts.

The health probe is anyways not really checking health over time as it will always pass after it has passed the first time. I guess this is a future enhancement.

Rewrite probe tests using standard library testing, dropping Ginkgo/Gomega and removing tests for internal methods.
Existing tests were testing:
- go struct initialization - nothing we really need
- modifying internal vars, e.g. by setting `health.Store(...)`
- tested logging

### Changes
- Add a flag to suppress error logs during initial startup
- Rewrite probe_test.go with table-driven stdlib tests
- Drop flaky 10-second timing test and brittle log-assertion test
- Clean up comment in main.go


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)


Fixes #1452
