### PR TITLE
fix: increase replica wait timeout to 20s

### DIFF
--- a/interceptor/config/timeouts.go
+++ b/interceptor/config/timeouts.go
@@ -17,7 +17,7 @@ type Timeouts struct {
 	ResponseHeader time.Duration `envconfig:"KEDA_RESPONSE_HEADER_TIMEOUT" default:"500ms"`
 	// WorkloadReplicas is how long to wait for the backing workload
 	// to have 1 or more replicas before connecting and sending the HTTP request.
-	WorkloadReplicas time.Duration `envconfig:"KEDA_CONDITION_WAIT_TIMEOUT" default:"1500ms"`
+	WorkloadReplicas time.Duration `envconfig:"KEDA_CONDITION_WAIT_TIMEOUT" default:"20s"`
 	// ForceHTTP2 toggles whether to try to force HTTP2 for all requests
 	ForceHTTP2 bool `envconfig:"KEDA_HTTP_FORCE_HTTP2" default:"false"`
 	// MaxIdleConns is the max number of idle connections to keep in the


### PR DESCRIPTION
This aligns the value with what is used in the provided release artifacts and in the helm chart, 1.5s is way too low to wait for pods to become ready on a cold start in basically most cases.

I didn't update the changelog as it does not affect the users who use this default already either in the helm chart or the yaml we provide with each release.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

