### PR TITLE
fix: increase default connection pool sizes for higher throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Improvements
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Interceptor**: Increase default connection pool sizes for higher throughput ([#1469](https://github.com/kedacore/http-add-on/pull/1469))
 
 ### Fixes
 

--- a/interceptor/config/timeouts.go
+++ b/interceptor/config/timeouts.go
@@ -23,10 +23,10 @@ type Timeouts struct {
 	// MaxIdleConns is the max number of idle connections to keep in the
 	// interceptor's internal connection pool across all backend services.
 	// Increase this if you proxy to many unique backend services.
-	MaxIdleConns int `envconfig:"KEDA_HTTP_MAX_IDLE_CONNS" default:"100"`
+	MaxIdleConns int `envconfig:"KEDA_HTTP_MAX_IDLE_CONNS" default:"1000"`
 	// MaxIdleConnsPerHost is the max number of idle connections to keep per backend service.
 	// Increase this if you observe many new connection establishments under load.
-	MaxIdleConnsPerHost int `envconfig:"KEDA_HTTP_MAX_IDLE_CONNS_PER_HOST" default:"20"`
+	MaxIdleConnsPerHost int `envconfig:"KEDA_HTTP_MAX_IDLE_CONNS_PER_HOST" default:"200"`
 	// IdleConnTimeout is the timeout after which a connection in the interceptor's
 	// internal connection pool will be closed
 	IdleConnTimeout time.Duration `envconfig:"KEDA_HTTP_IDLE_CONN_TIMEOUT" default:"90s"`


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

Increase MaxIdleConns from 100 to 1000 and MaxIdleConnsPerHost from 20 to 200. Benchmarking showed these defaults were the primary bottleneck under load, causing excessive new connection establishments. With the higher defaults the interceptor achieves ~80k RPS on the same hardware.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
