### PR TITLE
perf: replace global queue lock with per-host atomics and eliminate counting goroutines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Improvements
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
-- **Interceptor**: Add atomic endpoint readiness cache for O(1) hot-path checks ([#1472](https://github.com/kedacore/http-add-on/pull/1472))
+- **Interceptor**: Reduce interceptor latency and memory usage under high concurrency ([#1482](https://github.com/kedacore/http-add-on/pull/1482))
+- **Interceptor**: Speed up endpoint readiness checks with a fast lookup cache ([#1472](https://github.com/kedacore/http-add-on/pull/1472))
 
 ### Fixes
 

--- a/interceptor/middleware/counting.go
+++ b/interceptor/middleware/counting.go
@@ -1,11 +1,7 @@
 package middleware
 
 import (
-	"context"
-	"errors"
 	"net/http"
-
-	"github.com/go-logr/logr"
 
 	"github.com/kedacore/http-add-on/interceptor/metrics"
 	"github.com/kedacore/http-add-on/pkg/k8s"
@@ -30,59 +26,23 @@ var _ http.Handler = (*Counting)(nil)
 func (cm *Counting) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r = util.RequestWithLoggerWithName(r, "CountingMiddleware")
 	ctx := r.Context()
-
-	defer cm.countAsync(ctx)()
-
-	cm.upstreamHandler.ServeHTTP(w, r)
-}
-
-func (cm *Counting) countAsync(ctx context.Context) func() {
-	signaler := util.NewSignaler()
-
-	go cm.count(ctx, signaler)
-
-	return func() {
-		go signaler.Signal()
-	}
-}
-
-func (cm *Counting) count(ctx context.Context, signaler util.Signaler) {
-	logger := util.LoggerFromContext(ctx)
 	httpso := util.HTTPSOFromContext(ctx)
 
 	key := k8s.NamespacedNameFromObject(httpso).String()
 
-	if !cm.inc(logger, key) {
+	if err := cm.queueCounter.Increase(key, 1); err != nil {
+		util.LoggerFromContext(ctx).Error(err, "error incrementing queue counter", "key", key)
+		cm.upstreamHandler.ServeHTTP(w, r)
 		return
 	}
+	metrics.RecordPendingRequestCount(key, 1)
 
-	if err := signaler.Wait(ctx); err != nil && !errors.Is(err, context.Canceled) {
-		logger.Error(err, "failed to wait signal")
-	}
+	defer func() {
+		if err := cm.queueCounter.Decrease(key, 1); err != nil {
+			util.LoggerFromContext(ctx).Error(err, "error decrementing queue counter", "key", key)
+		}
+		metrics.RecordPendingRequestCount(key, -1)
+	}()
 
-	cm.dec(logger, key)
-}
-
-func (cm *Counting) inc(logger logr.Logger, key string) bool {
-	if err := cm.queueCounter.Increase(key, 1); err != nil {
-		logger.Error(err, "error incrementing queue counter", "key", key)
-
-		return false
-	}
-
-	metrics.RecordPendingRequestCount(key, int64(1))
-
-	return true
-}
-
-func (cm *Counting) dec(logger logr.Logger, key string) bool {
-	if err := cm.queueCounter.Decrease(key, 1); err != nil {
-		logger.Error(err, "error decrementing queue counter", "key", key)
-
-		return false
-	}
-
-	metrics.RecordPendingRequestCount(key, int64(-1))
-
-	return true
+	cm.upstreamHandler.ServeHTTP(w, r)
 }

--- a/interceptor/middleware/counting_test.go
+++ b/interceptor/middleware/counting_test.go
@@ -1,19 +1,13 @@
 package middleware
 
 import (
-	"context"
-	"fmt"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -44,24 +38,21 @@ func TestCountMiddleware(t *testing.T) {
 	}
 	namespacedName := k8s.NamespacedNameFromObject(httpso).String()
 
-	queueCounter := queue.NewFakeCounter()
+	queueCounter := queue.NewFakeCounterBuffered()
 
+	var concurrencyDuringRequest int
 	middleware := NewCountingMiddleware(
 		queueCounter,
-		http.HandlerFunc(func(wr http.ResponseWriter, req *http.Request) {
+		http.HandlerFunc(func(wr http.ResponseWriter, _ *http.Request) {
+			counts, err := queueCounter.Current()
+			if err == nil {
+				concurrencyDuringRequest = counts.Counts[namespacedName].Concurrency
+			}
 			wr.WriteHeader(200)
-			_, err := wr.Write([]byte("OK"))
-			assert.NoError(t, err)
+			_, _ = wr.Write([]byte("OK"))
 		}),
 	)
 
-	ctx := context.Background()
-
-	// for a valid request, we expect the queue to be modified twice.
-	// once to mark a pending HTTP request, then a second time to remove it.
-	// by the end of both sends, increase1 + decrease1 should be 2
-
-	// run middleware with the host in the request
 	req, err := http.NewRequest("GET", "/something", nil)
 	r.NoError(err)
 	reqCtx := req.Context()
@@ -70,73 +61,17 @@ func TestCountMiddleware(t *testing.T) {
 	req = req.WithContext(reqCtx)
 	req.Host = uri.Host
 
-	agg, respRecorder := expectUpdates(
-		ctx,
-		t,
-		2,
-		middleware,
-		req,
-		queueCounter,
-		func(t *testing.T, hostAndCount queue.HostAndCount) {
-			t.Helper()
-			r := require.New(t)
-			r.InDelta(float64(1), math.Abs(float64(hostAndCount.Count)), 0)
-			r.Equal(namespacedName, hostAndCount.Host)
-		},
-	)
-	r.Equal(http.StatusOK, respRecorder.Code)
-	r.Equal(http.StatusText(respRecorder.Code), respRecorder.Body.String())
-	r.Equal(2, agg)
-}
-
-// expectUpdates creates a new httptest.ResponseRecorder, then passes req through
-// the middleware. every time the middleware calls fakeCounter.Resize(), it calls
-// resizeCheckFn with t and the queue.HostCount that represents the resize call
-// that was made. it also maintains an aggregate delta of the counts passed to
-// Resize. If, for example, the following integers were passed to resize over
-// 4 calls: [-1, 1, 1, 2], the aggregate would be -1+1+1+2=3
-//
-// this function returns the aggregate and the httptest.ResponseRecorder that was
-// created and used with the middleware
-func expectUpdates(
-	ctx context.Context,
-	t *testing.T,
-	nResizes int,
-	middleware http.Handler,
-	req *http.Request,
-	fakeCounter *queue.FakeCounter,
-	resizeCheckFn func(*testing.T, queue.HostAndCount),
-) (int, *httptest.ResponseRecorder) {
-	t.Helper()
-	r := require.New(t)
-	const timeout = 1 * time.Second
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	grp, ctx := errgroup.WithContext(ctx)
-	agg := 0
-	grp.Go(func() error {
-		// we expect the queue to be resized nResizes times
-		for i := range nResizes {
-			select {
-			case hostAndCount := <-fakeCounter.ResizedCh:
-				agg += hostAndCount.Count
-				resizeCheckFn(t, hostAndCount)
-			case <-ctx.Done():
-				return fmt.Errorf(
-					"timed out waiting for the count middleware. expected %d resizes, timeout was %s, iteration %d",
-					nResizes,
-					timeout,
-					i,
-				)
-			}
-		}
-		return nil
-	})
-
 	respRecorder := httptest.NewRecorder()
 	middleware.ServeHTTP(respRecorder, req)
 
-	r.NoError(grp.Wait())
+	r.Equal(http.StatusOK, respRecorder.Code)
+	r.Equal("OK", respRecorder.Body.String())
 
-	return agg, respRecorder
+	// During the request, concurrency should have been 1
+	r.Equal(1, concurrencyDuringRequest)
+
+	// After the request completes, concurrency should be back to 0
+	counts, err := queueCounter.Current()
+	r.NoError(err)
+	r.Equal(0, counts.Counts[namespacedName].Concurrency)
 }

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -1,8 +1,8 @@
 package queue
 
 import (
-	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -46,101 +46,109 @@ var (
 	_ CountReader = (*Memory)(nil)
 )
 
+// hostEntry holds per-host state: an atomic concurrency counter
+// and an atomically-swappable RPS ring-buffer. This eliminates the global
+// lock that previously serialized all Increase/Decrease calls.
+// RequestsBuckets has its own internal mutex, so no outer lock is needed.
+type hostEntry struct {
+	concurrency atomic.Int64
+	buckets     atomic.Pointer[RequestsBuckets]
+}
+
 // Memory is a Counter implementation that
 // holds the HTTP queue in memory only. Always use
 // NewMemory to create one of these.
+//
+// Hot-path guarantees:
+//   - Increase / Decrease: one sync.Map load + one atomic op (no global lock).
+//   - RPS recording uses the RequestsBuckets internal lock only.
 type Memory struct {
-	concurrentMap map[string]int
-	rpsMap        map[string]*RequestsBuckets
-	mut           *sync.RWMutex
+	entries sync.Map // string -> *hostEntry
 }
 
 // NewMemoryQueue creates a new empty in-memory queue
 func NewMemory() *Memory {
-	lock := new(sync.RWMutex)
-	return &Memory{
-		concurrentMap: make(map[string]int),
-		rpsMap:        make(map[string]*RequestsBuckets),
-		mut:           lock,
-	}
+	return &Memory{}
 }
 
-// Increase changes the size of the queue adding delta
+// Increase atomically increments the concurrency counter for host
+// and records an RPS data-point.
 func (r *Memory) Increase(host string, delta int) error {
-	r.mut.Lock()
-	defer r.mut.Unlock()
-	r.concurrentMap[host] += delta
-	r.rpsMap[host].Record(time.Now(), delta)
+	if v, ok := r.entries.Load(host); ok {
+		entry := v.(*hostEntry)
+		entry.concurrency.Add(int64(delta))
+
+		if b := entry.buckets.Load(); b != nil {
+			b.Record(time.Now(), delta)
+		}
+	}
 	return nil
 }
 
-// Decrease changes the size of the queue reducing delta
+// Decrease atomically decrements the concurrency counter for host,
+// clamped to zero.
 func (r *Memory) Decrease(host string, delta int) error {
-	r.mut.Lock()
-	defer r.mut.Unlock()
+	if v, ok := r.entries.Load(host); ok {
+		entry := v.(*hostEntry)
+		for {
+			cur := entry.concurrency.Load()
+			if cur <= 0 {
+				return nil
+			}
+			newVal := max(0, cur-int64(delta))
 
-	current, exists := r.concurrentMap[host]
-	if !exists {
-		// Key doesn't exist; nothing to do
-		return nil
+			if entry.concurrency.CompareAndSwap(cur, newVal) {
+				return nil
+			}
+		}
 	}
-
-	// Decrement and clamp concurrency to zero
-	newVal := max(current-delta, 0)
-	r.concurrentMap[host] = newVal
-
 	return nil
 }
 
 func (r *Memory) EnsureKey(host string, window, granularity time.Duration) {
-	r.mut.Lock()
-	defer r.mut.Unlock()
-	_, ok := r.concurrentMap[host]
-	if !ok {
-		r.concurrentMap[host] = 0
+	if _, ok := r.entries.Load(host); ok {
+		return
 	}
-	_, ok = r.rpsMap[host]
-	if !ok {
-		r.rpsMap[host] = NewRequestsBuckets(window, granularity)
-	}
+	entry := &hostEntry{}
+	entry.buckets.Store(NewRequestsBuckets(window, granularity))
+	r.entries.LoadOrStore(host, entry)
 }
 
 func (r *Memory) UpdateBuckets(host string, window, granularity time.Duration) {
 	r.EnsureKey(host, window, granularity)
-	r.mut.Lock()
-	defer r.mut.Unlock()
-	buckets, ok := r.rpsMap[host]
-	if ok &&
-		(buckets.window != window ||
-			buckets.granularity != granularity) {
-		r.rpsMap[host] = NewRequestsBuckets(window, granularity)
+	if v, ok := r.entries.Load(host); ok {
+		entry := v.(*hostEntry)
+		if b := entry.buckets.Load(); b != nil &&
+			(b.window != window || b.granularity != granularity) {
+			entry.buckets.Store(NewRequestsBuckets(window, granularity))
+		}
 	}
 }
 
 func (r *Memory) RemoveKey(host string) bool {
-	r.mut.Lock()
-	defer r.mut.Unlock()
-	_, concurrentOk := r.concurrentMap[host]
-	delete(r.concurrentMap, host)
-	_, rpsOk := r.rpsMap[host]
-	delete(r.rpsMap, host)
-	return concurrentOk && rpsOk
+	_, existed := r.entries.LoadAndDelete(host)
+	return existed
 }
 
 // Current returns the current size of the queue.
 func (r *Memory) Current() (*Counts, error) {
-	r.mut.RLock()
-	defer r.mut.RUnlock()
+	now := time.Now()
 	cts := NewCounts()
-	for key, concurrency := range r.concurrentMap {
-		rpsItem, ok := r.rpsMap[key]
-		if !ok {
-			return nil, fmt.Errorf("rps map doesn't contain the key '%s'", key)
+	r.entries.Range(func(k, v any) bool {
+		key := k.(string)
+		entry := v.(*hostEntry)
+		concurrency := entry.concurrency.Load()
+
+		rps := 0.0
+		if b := entry.buckets.Load(); b != nil {
+			rps = b.WindowAverage(now)
 		}
+
 		cts.Counts[key] = Count{
-			Concurrency: concurrency,
-			RPS:         rpsItem.WindowAverage(time.Now()),
+			Concurrency: int(concurrency),
+			RPS:         rps,
 		}
-	}
+		return true
+	})
 	return cts, nil
 }

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -7,23 +7,69 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	hostName = "host1"
+)
+
 func TestCurrent(t *testing.T) {
 	r := require.New(t)
 	memory := NewMemory()
-	now := time.Now()
-	host := "host1"
+	host := hostName
 	memory.EnsureKey(host, time.Minute, time.Second)
+
 	err := memory.Increase(host, 1)
 	r.NoError(err)
 	current, err := memory.Current()
 	r.NoError(err)
-	r.Equal(current.Counts[host].Concurrency, memory.concurrentMap[host])
-	r.InDelta(current.Counts[host].RPS, memory.rpsMap[host].WindowAverage(now), 0)
+	r.Equal(1, current.Counts[host].Concurrency)
+	r.Greater(current.Counts[host].RPS, 0.0)
 
 	err = memory.Increase(host, 1)
 	r.NoError(err)
 	err = memory.Increase(host, 1)
 	r.NoError(err)
-	r.NotEqual(current.Counts[host].Concurrency, memory.concurrentMap[host])
-	r.NotEqual(current.Counts[host].RPS, memory.rpsMap[host].WindowAverage(now))
+	current2, err := memory.Current()
+	r.NoError(err)
+	r.Equal(3, current2.Counts[host].Concurrency)
+}
+
+func TestDecreaseClamp(t *testing.T) {
+	r := require.New(t)
+	memory := NewMemory()
+	host := hostName
+	memory.EnsureKey(host, time.Minute, time.Second)
+
+	err := memory.Decrease(host, 1)
+	r.NoError(err)
+	current, err := memory.Current()
+	r.NoError(err)
+	r.Equal(0, current.Counts[host].Concurrency)
+}
+
+func TestRemoveKey(t *testing.T) {
+	r := require.New(t)
+	memory := NewMemory()
+	host := hostName
+	memory.EnsureKey(host, time.Minute, time.Second)
+
+	r.True(memory.RemoveKey(host))
+	r.False(memory.RemoveKey(host))
+
+	current, err := memory.Current()
+	r.NoError(err)
+	r.Empty(current.Counts)
+}
+
+func TestUpdateBuckets(t *testing.T) {
+	r := require.New(t)
+	memory := NewMemory()
+	host := hostName
+	memory.EnsureKey(host, time.Minute, time.Second)
+	memory.UpdateBuckets(host, 2*time.Minute, 2*time.Second)
+
+	err := memory.Increase(host, 1)
+	r.NoError(err)
+	current, err := memory.Current()
+	r.NoError(err)
+	r.Equal(1, current.Counts[host].Concurrency)
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

Replace the single sync.RWMutex in pkg/queue/Memory with a sync.Map of per-host entries using atomic.Int64 for concurrency counters. This removes the global lock that serialized all Increase/Decrease/Current calls across every host.

Simplify the counting middleware from a 2-goroutine-per-request signaler pattern to a synchronous Increase + defer Decrease, eliminating 200k goroutine allocations/sec at 100k RPS.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
