### PR TITLE
fix: update roundToNDigits to use Round instead of Floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Fixes
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **General**: Fix `roundToNDigits` using `math.Round` instead of `math.Floor` to correctly round small negative floating-point errors to zero ([#1483](https://github.com/kedacore/http-add-on/pull/1483))
 
 ### Deprecations
 

--- a/pkg/queue/bucketing.go
+++ b/pkg/queue/bucketing.go
@@ -70,7 +70,7 @@ func (t *RequestsBuckets) isEmptyLocked(now time.Time) bool {
 
 func roundToNDigits(n int, f float64) float64 {
 	p := math.Pow10(n)
-	return math.Floor(f*p) / p
+	return math.Round(f*p) / p
 }
 
 // WindowAverage returns the average bucket value over the window.

--- a/pkg/queue/bucketing_test.go
+++ b/pkg/queue/bucketing_test.go
@@ -392,10 +392,13 @@ func TestRoundToNDigits(t *testing.T) {
 	if got, want := roundToNDigits(6, 3.6e-17), 0.; got != want {
 		t.Errorf("Rounding = %v, want: %v", got, want)
 	}
+	if got, want := roundToNDigits(3, -3.6e-17), 0.; got != want {
+		t.Errorf("Rounding = %v, want: %v", got, want)
+	}
 	if got, want := roundToNDigits(3, 0.0004), 0.; got != want {
 		t.Errorf("Rounding = %v, want: %v", got, want)
 	}
-	if got, want := roundToNDigits(3, 1.2345), 1.234; got != want {
+	if got, want := roundToNDigits(3, 1.2345), 1.235; got != want {
 		t.Errorf("Rounding = %v, want: %v", got, want)
 	}
 	if got, want := roundToNDigits(4, 1.2345), 1.2345; got != want {


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

Currently `roundToNDigits` uses math.Floor which always rounds down. This caused incorrect behavior for small negative numbers, where values like -3.6e-17 would round to a negative number instead of 0.

Since this function is used to calculate an average value of non-negative numbers, getting a negative result can be surprising.

Using math.Round ensures proper rounding to the nearest integer, which correctly rounds very small negative values to 0 when appropriate.

This fix is important for the autoscaler's aggregation calculations where small floating-point errors near zero should not produce negative results.

Related to https://github.com/knative/serving/pull/15940

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
