### PR TITLE
chore: remove unused CurrentNamespace from interceptor config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Other
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Interceptor**: Remove unused `CurrentNamespace` field and `KEDA_HTTP_CURRENT_NAMESPACE` env var from interceptor config([#1484](https://github.com/kedacore/http-add-on/pull/1484))
 
 ## v0.12.2
 

--- a/config/interceptor/deployment.yaml
+++ b/config/interceptor/deployment.yaml
@@ -28,8 +28,6 @@ spec:
         - --zap-encoder=console
         - --zap-time-encoding=rfc3339
         env:
-        - name: KEDA_HTTP_CURRENT_NAMESPACE
-          value: "keda"
         - name: KEDA_HTTP_PROXY_PORT
           value: "8080"
         - name: KEDA_HTTP_ADMIN_PORT

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -9,9 +9,6 @@ import (
 // Serving is configuration for how the interceptor serves the proxy
 // and admin server
 type Serving struct {
-	// CurrentNamespace is the namespace that the interceptor is
-	// currently running in
-	CurrentNamespace string `envconfig:"KEDA_HTTP_CURRENT_NAMESPACE" required:"true"`
 	// WatchNamespace is the namespace to watch for new HTTPScaledObjects.
 	// Leave this empty to watch HTTPScaledObjects in all namespaces.
 	WatchNamespace string `envconfig:"KEDA_HTTP_WATCH_NAMESPACE" default:""`


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

The `CurrentNamespace` field was defined in the Serving struct but never referenced anywhere in the interceptor codebase. Remove the dead config field and its corresponding `KEDA_HTTP_CURRENT_NAMESPACE` env var from the deployment manifest.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
