### PR TITLE
fix: handle HTTPScaledObject not found gracefully in scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Fixes
 
 - **General**: Fix `roundToNDigits` using `math.Round` instead of `math.Floor` to correctly round small negative floating-point errors to zero ([#1483](https://github.com/kedacore/http-add-on/pull/1483))
+- **Scaler**: Handle HTTPScaledObject not found gracefully in `GetMetrics` to avoid error storms during rapid deployments ([#1487](https://github.com/kedacore/http-add-on/issues/1487))
 
 ### Deprecations
 

--- a/scaler/handlers.go
+++ b/scaler/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
 	"google.golang.org/protobuf/types/known/emptypb"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -200,15 +201,26 @@ func (e *impl) GetMetrics(ctx context.Context, metricRequest *externalscaler.Get
 		return nil, err
 	}
 
-	httpso := &httpv1alpha1.HTTPScaledObject{}
-	if err := e.reader.Get(ctx, types.NamespacedName{Namespace: sor.Namespace, Name: httpScaledObjectName}, httpso); err != nil {
-		lggr.Error(err, "unable to get HTTPScaledObject", "name", httpScaledObjectName, "namespace", sor.Namespace, "httpScaledObjectName", httpScaledObjectName)
-		return nil, err
-	}
-
 	// generated the metric name for HTTPScaledObject
 	namespacedName := k8s.NamespacedNameFromNameAndNamespace(httpScaledObjectName, sor.Namespace)
 	metricName := MetricName(namespacedName)
+
+	httpso := &httpv1alpha1.HTTPScaledObject{}
+	if err := e.reader.Get(ctx, types.NamespacedName{Namespace: sor.Namespace, Name: httpScaledObjectName}, httpso); err != nil {
+		if apierrors.IsNotFound(err) {
+			lggr.V(1).Info("HTTPScaledObject not yet available in cache, returning 0", "httpScaledObjectName", httpScaledObjectName, "namespace", sor.Namespace)
+			return &externalscaler.GetMetricsResponse{
+				MetricValues: []*externalscaler.MetricValue{
+					{
+						MetricName:  metricName,
+						MetricValue: 0,
+					},
+				},
+			}, nil
+		}
+		lggr.Error(err, "unable to get HTTPScaledObject", "name", httpScaledObjectName, "namespace", sor.Namespace, "httpScaledObjectName", httpScaledObjectName)
+		return nil, err
+	}
 
 	key := namespacedName.String()
 	count := e.pinger.counts()[key]


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

This PR fixes the race condition by handling the `IsNotFound` case in `GetMetrics` gracefully: instead of returning an error, it returns metric value `0` (not active) and logs at debug level. Once the cache syncs (typically within a second), subsequent calls return real values. The gRPC stream stays alive, avoiding the reconnection storm.


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/keda/blob/main/CONTRIBUTING.md#Changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #1487 
