### PR TITLE
fix: replace deprecated release asset upload actions

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -61,33 +61,12 @@ jobs:
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
 
-      # Get release information to determine id of the current release
-      - name: Get Release
-        id: get-release-info
-        uses: bruceadams/get-release@74c3d60f5a28f358ccf241a00c9021ea16f0569f # v1.3.2
+      - name: Upload release assets
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" \
+            "keda-add-ons-http-${VERSION}.yaml" \
+            "keda-add-ons-http-${VERSION}-crds.yaml" \
+            --clobber
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Upload deployment YAML file to GitHub release
-      - name: Upload Deployment YAML file
-        id: upload-deployment-yaml
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: https://uploads.github.com/repos/kedacore/http-add-on/releases/${{ steps.get-release-info.outputs.id }}/assets?name=keda-add-ons-http-${{ steps.get_version.outputs.VERSION }}.yaml
-          asset_path: keda-add-ons-http-${{ steps.get_version.outputs.VERSION }}.yaml
-          asset_name: keda-add-ons-http-${{ steps.get_version.outputs.VERSION }}.yaml
-          asset_content_type: application/x-yaml
-
-      # Upload CRD deployment YAML file to GitHub release
-      - name: Upload Deployment YAML file
-        id: upload-crd-deployment-yaml
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: https://uploads.github.com/repos/kedacore/http-add-on/releases/${{ steps.get-release-info.outputs.id }}/assets?name=keda-add-ons-http-${{ steps.get_version.outputs.VERSION }}-crds.yaml
-          asset_path: keda-add-ons-http-${{ steps.get_version.outputs.VERSION }}-crds.yaml
-          asset_name: keda-add-ons-http-${{ steps.get_version.outputs.VERSION }}-crds.yaml
-          asset_content_type: application/x-yaml
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
bruceadams/get-release has had no releases since 2022. actions/upload-release-asset has been archived since 2020. Replace all three with a single `gh release upload` call.

I haven't tested these changes yet obviously but the gh cli docs are quite clear about what it does.
The keda-tools image contains the gh cli, #1465 would get rid of the image anyways so quite sure everything is OK.

### Changes
- Remove bruceadams/get-release@v1.3.2 (node16, abandoned)
- Remove 2x actions/upload-release-asset@v1 (archived)
- Add single gh release upload step using the pre-installed CLI


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to #1489 