### PR TITLE
refactor: modernize code with go fix

### DIFF
--- a/interceptor/handler/static_test.go
+++ b/interceptor/handler/static_test.go
@@ -42,7 +42,7 @@ var _ = Describe("ServeHTTP", func() {
 		var b bool
 		r = r.WithContext(util.ContextWithLogger(r.Context(), funcr.NewJSON(
 			func(obj string) {
-				var m map[string]interface{}
+				var m map[string]any
 
 				err := json.Unmarshal([]byte(obj), &m)
 				Expect(err).NotTo(HaveOccurred())

--- a/interceptor/middleware/counting_test.go
+++ b/interceptor/middleware/counting_test.go
@@ -115,7 +115,7 @@ func expectUpdates(
 	agg := 0
 	grp.Go(func() error {
 		// we expect the queue to be resized nResizes times
-		for i := 0; i < nResizes; i++ {
+		for i := range nResizes {
 			select {
 			case hostAndCount := <-fakeCounter.ResizedCh:
 				agg += hostAndCount.Count

--- a/pkg/http/transport_pool_test.go
+++ b/pkg/http/transport_pool_test.go
@@ -49,11 +49,9 @@ func TestTransportPool_ConcurrentAccess(t *testing.T) {
 	transports := make(chan *http.Transport, numGoroutines)
 
 	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			transports <- pool.Get(timeout)
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/pkg/k8s/endpoints_cache_fake.go
+++ b/pkg/k8s/endpoints_cache_fake.go
@@ -100,7 +100,7 @@ func (f *FakeEndpointsCache) SetEndpoints(ns, name string, num int) error {
 	if err != nil {
 		return fmt.Errorf("no endpoints %s found", name)
 	}
-	for i := 0; i < num; i++ {
+	for range num {
 		endpoint := discov1.Endpoint{
 			Addresses: []string{
 				"1.2.3.4",

--- a/pkg/k8s/endpoints_cache_informer.go
+++ b/pkg/k8s/endpoints_cache_informer.go
@@ -73,7 +73,7 @@ func (i *InformerBackedEndpointsCache) Watch(
 	}), nil
 }
 
-func (i *InformerBackedEndpointsCache) addEvtHandler(obj interface{}) {
+func (i *InformerBackedEndpointsCache) addEvtHandler(obj any) {
 	depl, ok := obj.(*discov1.EndpointSlice)
 	if !ok {
 		i.lggr.Error(
@@ -88,7 +88,7 @@ func (i *InformerBackedEndpointsCache) addEvtHandler(obj interface{}) {
 	}
 }
 
-func (i *InformerBackedEndpointsCache) updateEvtHandler(_, newObj interface{}) {
+func (i *InformerBackedEndpointsCache) updateEvtHandler(_, newObj any) {
 	depl, ok := newObj.(*discov1.EndpointSlice)
 	if !ok {
 		i.lggr.Error(
@@ -103,7 +103,7 @@ func (i *InformerBackedEndpointsCache) updateEvtHandler(_, newObj interface{}) {
 	}
 }
 
-func (i *InformerBackedEndpointsCache) deleteEvtHandler(obj interface{}) {
+func (i *InformerBackedEndpointsCache) deleteEvtHandler(obj any) {
 	depl, ok := obj.(*discov1.EndpointSlice)
 	if !ok {
 		i.lggr.Error(

--- a/pkg/k8s/fake_endpoints.go
+++ b/pkg/k8s/fake_endpoints.go
@@ -15,7 +15,7 @@ import (
 // equal to u.Hostname()
 func FakeEndpointsForURL(u *url.URL, namespace, name string, num int) (*discov1.EndpointSliceList, error) {
 	urls := make([]*url.URL, num)
-	for i := 0; i < num; i++ {
+	for i := range num {
 		urls[i] = u
 	}
 	return FakeEndpointsForURLs(urls, namespace, name)

--- a/pkg/queue/bucketing_test.go
+++ b/pkg/queue/bucketing_test.go
@@ -89,9 +89,9 @@ func TestRequestsBucketsSimple(t *testing.T) {
 func TestRequestsBucketsManyReps(t *testing.T) {
 	trunc1 := time.Now().Truncate(granularity)
 	buckets := NewRequestsBuckets(time.Minute*5, granularity)
-	for p := 0; p < 5; p++ {
+	for p := range 5 {
 		trunc1 = trunc1.Add(granularity)
-		for t := 0; t < 5; t++ {
+		for t := range 5 {
 			buckets.Record(trunc1, t+p)
 		}
 	}
@@ -125,9 +125,9 @@ func TestRequestsBucketsManyRepsWithNonMonotonicalOrder(t *testing.T) {
 	buckets := NewRequestsBuckets(time.Minute, granularity)
 
 	d := []int{0, 3, 2, 1, 4}
-	for p := 0; p < 5; p++ {
+	for p := range 5 {
 		end = start.Add(time.Duration(d[p]) * granularity)
-		for t := 0; t < 5; t++ {
+		for t := range 5 {
 			buckets.Record(end, p+t)
 		}
 	}
@@ -338,7 +338,7 @@ func TestRequestsBucketsHoles(t *testing.T) {
 	now := time.Now()
 	buckets := NewRequestsBuckets(5*time.Second, granularity)
 
-	for i := time.Duration(0); i < 5; i++ {
+	for i := range time.Duration(5) {
 		buckets.Record(now.Add(i*time.Second), int(i+1))
 	}
 
@@ -378,7 +378,7 @@ func BenchmarkWindowAverage(b *testing.B) {
 			buckets := NewRequestsBuckets(time.Duration(wl)*time.Second,
 				time.Second /*granularity*/)
 			// Populate with some random data.
-			for i := 0; i < wl; i++ {
+			for i := range wl {
 				buckets.Record(tn.Add(time.Duration(i)*time.Second), rand.Int()*100)
 			}
 			for i := 0; i < b.N; i++ {
@@ -419,7 +419,7 @@ func (t *RequestsBuckets) forEachBucket(now time.Time, acc func(time time.Time, 
 	numBuckets := len(t.buckets) - int(now.Sub(t.lastWrite)/t.granularity)
 	bucketTime := t.lastWrite // Always aligned with granularity.
 	si := t.timeToIndex(bucketTime)
-	for i := 0; i < numBuckets; i++ {
+	for range numBuckets {
 		tIdx := si % len(t.buckets)
 		acc(bucketTime, t.buckets[tIdx])
 		si--

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -84,10 +84,7 @@ func (r *Memory) Decrease(host string, delta int) error {
 	}
 
 	// Decrement and clamp concurrency to zero
-	newVal := current - delta
-	if newVal < 0 {
-		newVal = 0
-	}
+	newVal := max(current-delta, 0)
 	r.concurrentMap[host] = newVal
 
 	return nil

--- a/pkg/util/reflect.go
+++ b/pkg/util/reflect.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 )
 
-func IsNil(i interface{}) bool {
+func IsNil(i any) bool {
 	if i == nil {
 		return true
 	}

--- a/scaler/handlers_test.go
+++ b/scaler/handlers_test.go
@@ -806,10 +806,7 @@ func TestGetMetrics(t *testing.T) {
 		name := fmt.Sprintf("test case %d: %s", i, tc.name)
 		t.Run(name, func(t *testing.T) {
 			r := require.New(t)
-			ctx, done := context.WithCancel(
-				context.Background(),
-			)
-			defer done()
+			ctx := t.Context()
 			lggr := logr.Discard()
 			fakeClient, pinger, cleanup, err := tc.setupFn(t, ctx, lggr)
 			r.NoError(err)

--- a/scaler/queue_pinger_test.go
+++ b/scaler/queue_pinger_test.go
@@ -98,8 +98,7 @@ func TestCounts(t *testing.T) {
 
 func TestFetchAndSaveCounts(t *testing.T) {
 	r := require.New(t)
-	ctx, done := context.WithCancel(context.Background())
-	defer done()
+	ctx := t.Context()
 	const (
 		ns           = "testns"
 		svcName      = "testsvc"
@@ -163,8 +162,7 @@ func TestFetchAndSaveCounts(t *testing.T) {
 
 func TestFetchCounts(t *testing.T) {
 	r := require.New(t)
-	ctx, done := context.WithCancel(context.Background())
-	defer done()
+	ctx := t.Context()
 	const (
 		ns           = "testns"
 		svcName      = "testsvc"


### PR DESCRIPTION
Apply go fix and manual modernizations across the codebase.

Except the following ones, all changes come from running `go fix ./...` (even the context "changes"):
- `go fix` called `slices.Contains` in the `contains` function -> I inlined that
- I manually noticed the deletion helper and replaced it with `slices.DeleteFunc`

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
