### PR TITLE
chore: remove archived pre-commit-golang hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,6 @@
 default_stages: [pre-commit, pre-push]
 minimum_pre_commit_version: "1.20.0"
 repos:
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.3.5
-    hooks:
-      - id: go-fmt
-        name: Run go fmt against the code
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:


### PR DESCRIPTION
The go-fmt hook from https://github.com/dnephin/pre-commit-golang is redundant with the local golangci-lint hook, which already runs gofmt as a formatter.


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Related to #1489 
