### PR TITLE
refactor: modernize golangci-lint config and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,104 +1,107 @@
 version: "2"
 run:
-  concurrency: 4
   build-tags:
     - e2e
 linters:
   default: none
   enable:
-    - bodyclose
-    - unconvert
-    - ineffassign
-    - staticcheck
-    - copyloopvar
-    #- depguard #https://github.com/kedacore/keda/issues/4980
-    - dogsled
-    - dupl
-    - errcheck
-    #- funlen
-    - goconst
-    - gocritic
-    - gocyclo
-    - goprintffuncname
-    - govet
-    - ineffassign
-    - misspell
-    - nolintlint
-    - revive
-    - staticcheck
-    - unconvert
-    - unparam
-    - unused
-    - whitespace
-  settings:
-    funlen:
-      lines: 80
-      statements: 40
+    - bodyclose # checks HTTP response body is closed
+    - copyloopvar # detects loop variable copies (Go 1.22+)
+    - dogsled # finds too many blank identifiers (x, _, _, _ := f())
+    - dupl # detects duplicate code fragments
+    - errcheck # checks for unchecked errors
+    - errorlint # checks for proper error wrapping and comparison
+    - goconst # finds repeated strings replaceable by constants
+    - gocritic # catches common pitfalls: nil checks, type assertions, slicing
+    - gocyclo # checks cyclomatic complexity
+    - goprintffuncname # checks printf-like funcs end with 'f'
+    - gosec # inspects source code for security problems
+    - govet # catches format-string mismatches, struct tag errors, lock copies
+    - ineffassign # detects unused assignments
+    - misspell # finds common spelling mistakes
+    - modernize # suggests modern Go idioms and stdlib usage
+    - nolintlint # enforces well-formed nolint directives
+    - revive # enforces naming, imports, error returns, and style rules
+    - staticcheck # finds bugs, deprecated APIs, and unnecessary code
+    - testifylint # correctness checks for testify usage
+    - unconvert # removes unnecessary type conversions
+    - unparam # reports unused function parameters
+    - unused # checks for unused code
+    - whitespace # checks for unnecessary newlines
   exclusions:
-    generated: lax
+    generated: lax # exclude generated files
     presets:
+      # suppress "exported X should have comment" — not all exports are documented
       - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
     rules:
+      # test files: relax duplicate detection and unused params
       - linters:
           - dupl
-          - revive
           - unparam
         path: _test\.go
-      - path: pkg/http/
-        linters:
+      - linters:
           - revive
-        text: "var-naming: avoid package names that conflict with Go standard library"
+        path: _test\.go
+        text: unused-parameter
+      # test files: unchecked Close/Remove in deferred cleanup
+      - linters:
+          - errcheck
+        path: _test\.go|tests/
+        text: "Close|Remove"
+      # var-naming: packages that intentionally shadow stdlib names
       - linters:
           - revive
         text: "var-naming: avoid package names that conflict with Go standard library"
-        path: pkg/net/
-      - linters:
-          - revive
-        text: "var-naming: avoid package names that conflict with Go standard library"
-        path: operator/controllers/http
-      - linters:
-          - revive
-        text: "var-naming: avoid package names that conflict with Go standard library"
-        path: interceptor/metrics/
-      - linters:
-          - revive
-        text: "var-naming: avoid package names that conflict with Go standard library"
-        path: pkg/build/
-      # Exclude for utils packages with meaningful package names
+        path: interceptor/metrics/|operator/controllers/http/|pkg/build/|pkg/http/|pkg/net/
+      # var-naming: util packages with meaningful names
       - linters:
           - revive
         text: "var-naming: avoid meaningless package names"
-        path: operator/controllers/util/predicate.go
+        path: pkg/util/|operator/controllers/util/|tests/utils/
+      # revive: dot imports are standard for ginkgo/gomega
       - linters:
           - revive
-        text: "var-naming: avoid meaningless package names"
-        path: pkg/util/
-    paths:
-      - vendor
-      - third_party$
-      - builtin$
-      - examples$
+        text: "dot-imports"
+        path: _test\.go
+      # gosec: relaxed TLS settings in tests
+      - linters:
+          - gosec
+        text: "G402"
+        path: _test\.go
+      # gosec: ignore impossible integer overflow on port/replica conversions
+      - linters:
+          - gosec
+        text: "G109|G115"
+        path: _test\.go|tests/|pkg/k8s/fake_
+      # gosec: weak RNG is fine for test data
+      - linters:
+          - gosec
+        text: "G404"
+        path: _test\.go|tests/
+      # gosec: test helpers invoke subprocesses with known inputs
+      - linters:
+          - gosec
+        text: "G204|G702"
+        path: tests/
+      # gosec: test HTTP requests target local test servers, not user-controlled URLs
+      - linters:
+          - gosec
+        text: "G704"
+        path: _test\.go
 formatters:
   enable:
-    - gci
-    - gofmt
-    - goimports
+    - gci # import grouping and ordering
+    - gofumpt # stricter superset of gofmt
+    - goimports # adds/removes imports, formats code
   settings:
     gci:
       sections:
         - standard
         - default
-        - prefix(github.com/kedacore/http-add-on)
+        - localmodule
   exclusions:
-    generated: lax
+    generated: lax # exclude generated files
     paths:
-      - third_party$
-      - builtin$
-      - examples$
-      # Exclude gci check for //+kubebuilder:scaffold:imports comments. Waiting to
-      # resolve https://github.com/kedacore/keda/issues/4379
+      # gci would strip kubebuilder scaffold markers from import blocks
       - operator/controllers/http/suite_test.go
       - operator/main.go

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,9 @@ verify-manifests: ## Verify manifests are up to date.
 # Linting & static checks                        #
 ##################################################
 
+fmt:
+	golangci-lint fmt
+
 lint:
 	golangci-lint run
 

--- a/interceptor/handler/static.go
+++ b/interceptor/handler/static.go
@@ -36,6 +36,8 @@ func (sh *Static) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger.Error(sh.err, statusText, "routingKey", routingKey, "namespacedName", namespacedName, "stream", stream)
 
 	w.WriteHeader(sh.statusCode)
+
+	//nolint:gosec // G705: statusText is from http.StatusText(), not user input
 	if _, err := w.Write([]byte(statusText)); err != nil {
 		logger.Error(err, "write failed")
 	}

--- a/interceptor/handler/upstream.go
+++ b/interceptor/handler/upstream.go
@@ -91,5 +91,6 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
+	//nolint:gosec // G704: reverse proxy forwards requests by design
 	proxy.ServeHTTP(w, r)
 }

--- a/interceptor/metrics/metricscollector.go
+++ b/interceptor/metrics/metricscollector.go
@@ -4,9 +4,7 @@ import (
 	"github.com/kedacore/http-add-on/interceptor/config"
 )
 
-var (
-	collectors []Collector
-)
+var collectors []Collector
 
 const meterName = "keda-interceptor-proxy"
 

--- a/interceptor/metrics/otelmetrics_test.go
+++ b/interceptor/metrics/otelmetrics_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
@@ -25,13 +26,13 @@ func TestRequestCounter(t *testing.T) {
 	got := metricdata.ResourceMetrics{}
 	err := testReader.Collect(context.Background(), &got)
 
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	scopeMetrics := got.ScopeMetrics[0]
-	assert.NotEqual(t, len(scopeMetrics.Metrics), 0)
+	assert.NotEmpty(t, scopeMetrics.Metrics)
 
 	metricInfo := retrieveMetric(scopeMetrics.Metrics, "interceptor_request_count")
 	data := metricInfo.Data.(metricdata.Sum[int64]).DataPoints[0]
-	assert.Equal(t, data.Value, int64(1))
+	assert.Equal(t, int64(1), data.Value)
 }
 
 func TestPendingRequestCounter(t *testing.T) {
@@ -39,13 +40,13 @@ func TestPendingRequestCounter(t *testing.T) {
 	got := metricdata.ResourceMetrics{}
 	err := testReader.Collect(context.Background(), &got)
 
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	scopeMetrics := got.ScopeMetrics[0]
-	assert.NotEqual(t, len(scopeMetrics.Metrics), 0)
+	assert.NotEmpty(t, scopeMetrics.Metrics)
 
 	metricInfo := retrieveMetric(scopeMetrics.Metrics, "interceptor_pending_request_count")
 	data := metricInfo.Data.(metricdata.Sum[int64]).DataPoints[0]
-	assert.Equal(t, data.Value, int64(5))
+	assert.Equal(t, int64(5), data.Value)
 }
 
 func retrieveMetric(metrics []metricdata.Metrics, metricname string) *metricdata.Metrics {

--- a/interceptor/metrics/prommetrics_test.go
+++ b/interceptor/metrics/prommetrics_test.go
@@ -27,7 +27,7 @@ func TestPromRequestCountMetric(t *testing.T) {
 	testPrometheus.RecordRequestCount("post", "/test", 500, "test-host")
 	testPrometheus.RecordRequestCount("post", "/test", 200, "test-host")
 	err := testutil.CollectAndCompare(testRegistry, expectedOutputReader)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPromPendingRequestCountMetric(t *testing.T) {
@@ -45,5 +45,5 @@ func TestPromPendingRequestCountMetric(t *testing.T) {
 	expectedOutputReader := strings.NewReader(expectedOutput)
 	testPrometheus.RecordPendingRequestCount("test-host", 10)
 	err := testutil.CollectAndCompare(testRegistry, expectedOutputReader)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/interceptor/middleware/counting.go
+++ b/interceptor/middleware/counting.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/go-logr/logr"
@@ -55,7 +56,7 @@ func (cm *Counting) count(ctx context.Context, signaler util.Signaler) {
 		return
 	}
 
-	if err := signaler.Wait(ctx); err != nil && err != context.Canceled {
+	if err := signaler.Wait(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		logger.Error(err, "failed to wait signal")
 	}
 

--- a/interceptor/middleware/counting_test.go
+++ b/interceptor/middleware/counting_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,7 +51,7 @@ func TestCountMiddleware(t *testing.T) {
 		http.HandlerFunc(func(wr http.ResponseWriter, req *http.Request) {
 			wr.WriteHeader(200)
 			_, err := wr.Write([]byte("OK"))
-			r.NoError(err)
+			assert.NoError(t, err)
 		}),
 	)
 
@@ -79,7 +80,7 @@ func TestCountMiddleware(t *testing.T) {
 		func(t *testing.T, hostAndCount queue.HostAndCount) {
 			t.Helper()
 			r := require.New(t)
-			r.Equal(float64(1), math.Abs(float64(hostAndCount.Count)))
+			r.InDelta(float64(1), math.Abs(float64(hostAndCount.Count)), 0)
 			r.Equal(namespacedName, hostAndCount.Host)
 		},
 	)

--- a/interceptor/middleware/responsewriter.go
+++ b/interceptor/middleware/responsewriter.go
@@ -27,8 +27,10 @@ func (rw *responseWriter) StatusCode() int {
 	return rw.statusCode
 }
 
-var _ http.ResponseWriter = (*responseWriter)(nil)
-var _ http.Hijacker = (*responseWriter)(nil)
+var (
+	_ http.ResponseWriter = (*responseWriter)(nil)
+	_ http.Hijacker       = (*responseWriter)(nil)
+)
 
 func (rw *responseWriter) Header() http.Header {
 	return rw.downstreamResponseWriter.Header()

--- a/interceptor/middleware/responsewriter_test.go
+++ b/interceptor/middleware/responsewriter_test.go
@@ -26,9 +26,7 @@ var _ = Describe("responseWriter", func() {
 
 	Context("New", func() {
 		It("returns new object with expected field values set", func() {
-			var (
-				w = httptest.NewRecorder()
-			)
+			w := httptest.NewRecorder()
 
 			rw := newResponseWriter(w)
 			Expect(rw).NotTo(BeNil())
@@ -70,9 +68,7 @@ var _ = Describe("responseWriter", func() {
 
 	Context("Header", func() {
 		It("returns downstream method call", func() {
-			var (
-				w = httptest.NewRecorder()
-			)
+			w := httptest.NewRecorder()
 
 			rw := &responseWriter{
 				downstreamResponseWriter: w,
@@ -94,9 +90,7 @@ var _ = Describe("responseWriter", func() {
 				initialBW = 60
 			)
 
-			var (
-				w = httptest.NewRecorder()
-			)
+			w := httptest.NewRecorder()
 
 			rw := &responseWriter{
 				bytesWritten:             initialBW,
@@ -119,9 +113,7 @@ var _ = Describe("responseWriter", func() {
 				sc = http.StatusTeapot
 			)
 
-			var (
-				w = httptest.NewRecorder()
-			)
+			w := httptest.NewRecorder()
 
 			rw := &responseWriter{
 				statusCode:               http.StatusOK,
@@ -167,9 +159,7 @@ var _ = Describe("responseWriter", func() {
 		})
 
 		It("returns error when downstream ResponseWriter does not implement http.Hijacker", func() {
-			var (
-				w = httptest.NewRecorder()
-			)
+			w := httptest.NewRecorder()
 
 			rw := &responseWriter{
 				downstreamResponseWriter: w,
@@ -231,9 +221,7 @@ var _ = Describe("responseWriter", func() {
 		})
 
 		It("returns error when downstream ResponseWriter does not support full duplex", func() {
-			var (
-				w = httptest.NewRecorder()
-			)
+			w := httptest.NewRecorder()
 
 			rw := &responseWriter{
 				downstreamResponseWriter: w,

--- a/interceptor/middleware/routing_test.go
+++ b/interceptor/middleware/routing_test.go
@@ -205,5 +205,4 @@ var _ = Describe("RoutingMiddleware", func() {
 			})
 		})
 	})
-
 })

--- a/interceptor/proxy.go
+++ b/interceptor/proxy.go
@@ -52,7 +52,7 @@ func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
 		forwardingTLSCfg = &tls.Config{
 			RootCAs:            cfg.TLSConfig.RootCAs,
 			Certificates:       cfg.TLSConfig.Certificates,
-			InsecureSkipVerify: cfg.TLSConfig.InsecureSkipVerify,
+			InsecureSkipVerify: cfg.TLSConfig.InsecureSkipVerify, //nolint:gosec // G402: user-configurable
 		}
 	}
 	transport := &http.Transport{

--- a/interceptor/proxy_handlers_integration_test.go
+++ b/interceptor/proxy_handlers_integration_test.go
@@ -75,7 +75,7 @@ func TestIntegrationHappyPath(t *testing.T) {
 	)
 	r.NoError(err)
 	r.Equal(200, res.StatusCode)
-	res.Body.Close()
+	_ = res.Body.Close()
 }
 
 // deployment scaled to 1 but host not in routing table
@@ -96,10 +96,10 @@ func TestIntegrationNoRoutingTableEntry(t *testing.T) {
 		h.proxyURL.String(),
 		"not-in-the-table",
 	)
-	res.Body.Close()
+	_ = res.Body.Close()
 	r.NoError(err)
 	r.Equal(404, res.StatusCode)
-	res.Body.Close()
+	_ = res.Body.Close()
 }
 
 // host in the routing table but deployment has no replicas
@@ -135,7 +135,7 @@ func TestIntegrationNoReplicas(t *testing.T) {
 	)
 	r.NoError(err)
 	r.Equal(502, res.StatusCode)
-	res.Body.Close()
+	_ = res.Body.Close()
 	elapsed := time.Since(start)
 	// we should have slept more than the active endpoints wait timeout
 	r.GreaterOrEqual(elapsed, activeEndpointsTimeout)
@@ -184,7 +184,7 @@ func TestIntegrationWaitReplicas(t *testing.T) {
 			return err
 		}
 		response = resp
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return nil
 	})
 	const sleepDur = activeEndpointsTimeout / 4

--- a/interceptor/proxy_handlers_test.go
+++ b/interceptor/proxy_handlers_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -36,7 +37,6 @@ func init() {
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
 	cert, err := tls.LoadX509KeyPair("../certs/tls.crt", "../certs/tls.key")
-
 	if err != nil {
 		log.Fatalf("Error getting tests certs - make sure to run make test to generate them %v", err)
 	}
@@ -54,7 +54,7 @@ func TestImmediatelySuccessfulProxy(t *testing.T) {
 		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(200)
 			_, err := w.Write([]byte("test response"))
-			r.NoError(err)
+			assert.NoError(t, err)
 		}),
 	)
 	srv, originURL, err := kedanet.StartTestServer(originHdl)
@@ -106,7 +106,7 @@ func TestImmediatelySuccessfulProxyTLS(t *testing.T) {
 		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(200)
 			_, err := w.Write([]byte("test response"))
-			r.NoError(err)
+			assert.NoError(t, err)
 		}),
 	)
 	srv, originURL, err := kedanet.StartTestServer(originHdl)
@@ -162,7 +162,7 @@ func TestImmediatelySuccessfulFailoverProxy(t *testing.T) {
 		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(200)
 			_, err := w.Write([]byte("test response"))
-			r.NoError(err)
+			assert.NoError(t, err)
 		}),
 	)
 	srv, failoverURL, err := kedanet.StartTestServer(failoverHdl)
@@ -377,7 +377,7 @@ func TestTimesOutOnWaitFunc(t *testing.T) {
 	// to a timeout from a waitFunc or earlier in the pipeline,
 	// for example, if we cannot reach the Kubernetes control
 	// plane.
-	r.Equal("", res.Header().Get("X-KEDA-HTTP-Cold-Start"), "expected X-KEDA-HTTP-Cold-Start to be empty")
+	r.Empty(res.Header().Get("X-KEDA-HTTP-Cold-Start"), "expected X-KEDA-HTTP-Cold-Start to be empty")
 
 	// waitFunc should have been called, even though it timed out
 	waitFuncCalled := false
@@ -451,7 +451,7 @@ func TestTimesOutOnWaitFuncTLS(t *testing.T) {
 	// to a timeout from a waitFunc or earlier in the pipeline,
 	// for example, if we cannot reach the Kubernetes control
 	// plane.
-	r.Equal("", res.Header().Get("X-KEDA-HTTP-Cold-Start"), "expected X-KEDA-HTTP-Cold-Start to be empty")
+	r.Empty(res.Header().Get("X-KEDA-HTTP-Cold-Start"), "expected X-KEDA-HTTP-Cold-Start to be empty")
 
 	// waitFunc should have been called, even though it timed out
 	waitFuncCalled := false
@@ -612,7 +612,7 @@ func TestWaitHeaderTimeout(t *testing.T) {
 			<-originHdlCh
 			w.WriteHeader(200)
 			_, err := w.Write([]byte("test response"))
-			r.NoError(err)
+			assert.NoError(t, err)
 		}),
 	)
 	srv, originURL, err := kedanet.StartTestServer(originHdl)
@@ -671,7 +671,7 @@ func TestWaitHeaderTimeoutTLS(t *testing.T) {
 			<-originHdlCh
 			w.WriteHeader(200)
 			_, err := w.Write([]byte("test response"))
-			r.NoError(err)
+			assert.NoError(t, err)
 		}),
 	)
 	srv, originURL, err := kedanet.StartTestServer(originHdl)

--- a/interceptor/proxy_test.go
+++ b/interceptor/proxy_test.go
@@ -193,7 +193,7 @@ func TestProxyHandler_QueueCounting(t *testing.T) {
 	go func() {
 		defer close(done)
 		resp := h.doRequest(t, http.MethodGet, "/", testHost)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}()
 
 	// Wait for queue increment (blocking send from Increase)

--- a/interceptor/tls_config.go
+++ b/interceptor/tls_config.go
@@ -26,7 +26,7 @@ type TLSOptions struct {
 func BuildTLSConfig(opts TLSOptions, logger logr.Logger) (*tls.Config, error) {
 	servingTLS := &tls.Config{
 		RootCAs:            defaultCertPool(logger),
-		InsecureSkipVerify: opts.InsecureSkipVerify,
+		InsecureSkipVerify: opts.InsecureSkipVerify, //nolint:gosec // G402: user-configurable
 	}
 	var defaultCert *tls.Certificate
 
@@ -107,7 +107,7 @@ func loadCertStorePaths(certStorePaths string, certs map[string]tls.Certificate,
 		if _, err := addCert(certs, certPath, keyPath, logger); err != nil {
 			return fmt.Errorf("error adding certificate %s: %w", certPath, err)
 		}
-		rawCert, err := os.ReadFile(certPath)
+		rawCert, err := os.ReadFile(certPath) //nolint:gosec // G304: path from configured cert directory
 		if err != nil {
 			return fmt.Errorf("error reading certificate: %w", err)
 		}

--- a/interceptor/tls_config_test.go
+++ b/interceptor/tls_config_test.go
@@ -206,7 +206,7 @@ func writeCert(t *testing.T, dir, name, dnsName string) {
 
 func writeFile(t *testing.T, path string, data []byte) {
 	t.Helper()
-	if err := os.WriteFile(path, data, 0600); err != nil {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("writing %s: %v", path, err)
 	}
 }

--- a/interceptor/tracing/tracing_test.go
+++ b/interceptor/tracing/tracing_test.go
@@ -14,5 +14,5 @@ func TestTracingConfig(t *testing.T) {
 
 	// check defaults are set correctly
 	assert.Equal(t, "console", tracingCfg.Exporter)
-	assert.Equal(t, true, tracingCfg.Enabled)
+	assert.True(t, tracingCfg.Enabled)
 }

--- a/operator/controllers/http/app.go
+++ b/operator/controllers/http/app.go
@@ -13,9 +13,7 @@ import (
 	"github.com/kedacore/http-add-on/operator/controllers/http/config"
 )
 
-var (
-	SkipScaledObjectCreationAnnotation = "httpscaledobject.keda.sh/skip-scaledobject-creation"
-)
+var SkipScaledObjectCreationAnnotation = "httpscaledobject.keda.sh/skip-scaledobject-creation"
 
 func (r *HTTPScaledObjectReconciler) createOrUpdateApplicationResources(
 	ctx context.Context,

--- a/operator/controllers/http/config/config_test.go
+++ b/operator/controllers/http/config/config_test.go
@@ -17,7 +17,7 @@ func TestExternalScalerHostName(t *testing.T) {
 	const ns = "testns"
 	hst := sc.HostName(ns)
 	spl := strings.Split(hst, ".")
-	r.Equal(2, len(spl), "HostName should return a hostname with 2 parts")
+	r.Len(spl, 2, "HostName should return a hostname with 2 parts")
 	r.Equal(sc.ServiceName, spl[0])
 	r.Equal(fmt.Sprintf("%s:%d", ns, sc.Port), spl[1])
 }

--- a/operator/controllers/http/finalizer.go
+++ b/operator/controllers/http/finalizer.go
@@ -44,7 +44,8 @@ func finalizeScaledObject(
 	ctx context.Context,
 	logger logr.Logger,
 	client client.Client,
-	httpso *httpv1alpha1.HTTPScaledObject) error {
+	httpso *httpv1alpha1.HTTPScaledObject,
+) error {
 	if slices.Contains(httpso.GetFinalizers(), httpScaledObjectFinalizer) {
 		httpso.SetFinalizers(slices.DeleteFunc(httpso.GetFinalizers(), func(s string) bool {
 			return s == httpScaledObjectFinalizer

--- a/operator/controllers/http/scaled_object_test.go
+++ b/operator/controllers/http/scaled_object_test.go
@@ -52,12 +52,12 @@ func TestCreateOrUpdateScaledObject(t *testing.T) {
 		metadata.Name,
 	)
 
-	r.EqualValues(
+	r.Equal(
 		testInfra.httpso.Labels,
 		metadata.Labels,
 	)
 
-	r.EqualValues(
+	r.Equal(
 		testInfra.httpso.Annotations,
 		metadata.Annotations,
 	)
@@ -69,19 +69,18 @@ func TestCreateOrUpdateScaledObject(t *testing.T) {
 		maxReplicaCount = replicas.Max
 	}
 
-	r.EqualValues(
+	r.Equal(
 		minReplicaCount,
 		spec.MinReplicaCount,
 	)
-	r.EqualValues(
+	r.Equal(
 		maxReplicaCount,
 		spec.MaxReplicaCount,
 	)
 
 	// get hosts from spec and ensure all the hosts are there
-	r.Equal(
-		2,
-		len(testInfra.httpso.Spec.Hosts),
+	r.Len(
+		testInfra.httpso.Spec.Hosts, 2,
 	)
 
 	// now update the min and max replicas on the httpso
@@ -113,12 +112,12 @@ func TestCreateOrUpdateScaledObject(t *testing.T) {
 	)
 	r.NoError(err)
 
-	r.EqualValues(
+	r.Equal(
 		testInfra.httpso.Labels,
 		retSO.Labels,
 	)
 
-	r.EqualValues(
+	r.Equal(
 		testInfra.httpso.Annotations,
 		retSO.Annotations,
 	)

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"crypto/tls"
 	"net/http"
+	"time"
 
 	"github.com/kedacore/http-add-on/pkg/util"
 )
 
 func ServeContext(ctx context.Context, addr string, hdl http.Handler, tlsConfig *tls.Config) error {
 	srv := &http.Server{
-		Handler:   hdl,
-		Addr:      addr,
-		TLSConfig: tlsConfig,
+		Handler:           hdl,
+		Addr:              addr,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: time.Minute, // mitigate Slowloris attacks
 	}
 
 	go func() {

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -3,7 +3,6 @@ package http
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -50,7 +49,7 @@ func TestServeContext(t *testing.T) {
 	elapsed := time.Since(start)
 
 	r.Error(err)
-	r.True(errors.Is(err, http.ErrServerClosed), "error is not a http.ErrServerClosed (%w)", err)
+	r.ErrorIs(err, http.ErrServerClosed, "error is not a http.ErrServerClosed (%w)", err)
 	r.Greater(elapsed, cancelDur)
 	r.Less(elapsed, cancelDur*4)
 }
@@ -84,7 +83,7 @@ func TestServeContextWithTLS(t *testing.T) {
 	elapsed := time.Since(start)
 
 	r.Error(err)
-	r.True(errors.Is(err, http.ErrServerClosed), "error is not a http.ErrServerClosed (%w)", err)
+	r.ErrorIs(err, http.ErrServerClosed, "error is not a http.ErrServerClosed (%w)", err)
 	r.Greater(elapsed, cancelDur)
 	r.Less(elapsed, cancelDur*4)
 }

--- a/pkg/k8s/endpoints_cache_informer.go
+++ b/pkg/k8s/endpoints_cache_informer.go
@@ -155,7 +155,7 @@ func (i *InformerBackedEndpointsCache) deleteEvtHandler(obj any) {
 
 // endpointSliceFromDeleteObj unwraps EndpointSlice delete events from either
 // a direct object or a DeletedFinalStateUnknown tombstone.
-func endpointSliceFromDeleteObj(obj interface{}) (*discov1.EndpointSlice, error) {
+func endpointSliceFromDeleteObj(obj any) (*discov1.EndpointSlice, error) {
 	switch t := obj.(type) {
 	case *discov1.EndpointSlice:
 		return t, nil

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -62,7 +62,7 @@ func TestGetEndpoints(t *testing.T) {
 			addrLookup[key] = &addr
 		}
 	}
-	r.Equal(len(addrLookup), len(urls))
+	r.Len(urls, len(addrLookup))
 	for _, url := range urls {
 		_, ok := addrLookup[url.String()]
 		r.True(ok, "address %s was returned but not expected", url)
@@ -115,7 +115,7 @@ func TestEndpointsFuncForControllerClient(t *testing.T) {
 	fn := EndpointsFuncForControllerClient(cl)
 	ret, err := fn(ctx, ns, svcName)
 	r.NoError(err)
-	r.Equal(len(endpoints.Items[0].Endpoints), len(ret.ReadyAddresses))
+	r.Len(ret.ReadyAddresses, len(endpoints.Items[0].Endpoints))
 	// we don't need to introspect the return value, because we
 	// do so in depth in the above TestGetEndpoints test
 }

--- a/pkg/net/dial_context_test.go
+++ b/pkg/net/dial_context_test.go
@@ -18,7 +18,7 @@ func getUnreachableAddr(t *testing.T) string {
 		t.Fatalf("failed to listen: %v", err)
 	}
 	addr := listener.Addr().String()
-	listener.Close()
+	_ = listener.Close()
 	return addr
 }
 
@@ -46,7 +46,7 @@ func TestDialContextWithRetry_SucceedsImmediately(t *testing.T) {
 	if conn == nil {
 		t.Fatal("expected non-nil connection")
 	}
-	conn.Close()
+	_ = conn.Close()
 
 	// Should connect well before the retry interval fires.
 	if elapsed >= 50*time.Millisecond {
@@ -68,11 +68,11 @@ func TestDialContextWithRetry_RetriesUntilReachable(t *testing.T) {
 		close(ready)
 		conn, err := ln.Accept()
 		if err != nil {
-			ln.Close()
+			_ = ln.Close()
 			return
 		}
-		conn.Close()
-		ln.Close()
+		_ = conn.Close()
+		_ = ln.Close()
 	}()
 
 	dialer := NewNetDialer(50*time.Millisecond, 1*time.Second)
@@ -82,7 +82,7 @@ func TestDialContextWithRetry_RetriesUntilReachable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected success after target becomes reachable: %v", err)
 	}
-	conn.Close()
+	_ = conn.Close()
 	<-ready
 }
 

--- a/pkg/queue/bucketing_test.go
+++ b/pkg/queue/bucketing_test.go
@@ -2,7 +2,7 @@ package queue
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -41,8 +41,10 @@ type Counter interface {
 }
 
 // Memory implements Counter and CountReader
-var _ Counter = (*Memory)(nil)
-var _ CountReader = (*Memory)(nil)
+var (
+	_ Counter     = (*Memory)(nil)
+	_ CountReader = (*Memory)(nil)
+)
 
 // Memory is a Counter implementation that
 // holds the HTTP queue in memory only. Always use

--- a/pkg/queue/queue_counts_test.go
+++ b/pkg/queue/queue_counts_test.go
@@ -35,5 +35,5 @@ func TestAggregate(t *testing.T) {
 	}
 	agg := counts.Aggregate()
 	r.Equal(expectedConcurrency, agg.Concurrency)
-	r.Equal(expectedRPS, agg.RPS)
+	r.InDelta(expectedRPS, agg.RPS, 0)
 }

--- a/pkg/queue/queue_rpc.go
+++ b/pkg/queue/queue_rpc.go
@@ -67,7 +67,7 @@ func GetCounts(
 	if err != nil {
 		return nil, fmt.Errorf("requesting the queue counts from %s: %w", interceptorURL.String(), err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	counts := NewCounts()
 	if err := json.NewDecoder(resp.Body).Decode(counts); err != nil {
 		return nil, fmt.Errorf("decoding response from the interceptor at %s: %w", interceptorURL.String(), err)

--- a/pkg/queue/queue_rpc_test.go
+++ b/pkg/queue/queue_rpc_test.go
@@ -28,11 +28,11 @@ func TestQueueSizeHandlerSuccess(t *testing.T) {
 	respMap := map[string]Count{}
 	decodeErr := json.NewDecoder(rec.Body).Decode(&respMap)
 	r.NoError(decodeErr)
-	r.Equalf(1, len(respMap), "response JSON length was not 1")
+	r.Lenf(respMap, 1, "response JSON length was not 1")
 	sizeVal, ok := respMap["sample.com"]
 	r.Truef(ok, "'sample.com' entry not available in return JSON")
 	r.Equalf(reader.concurrency, sizeVal.Concurrency, "returned JSON concurrent size was wrong")
-	r.Equalf(reader.rps, sizeVal.RPS, "returned JSON rps size was wrong")
+	r.InDeltaf(reader.rps, sizeVal.RPS, 0, "returned JSON rps size was wrong")
 
 	reader.err = errors.New("test error")
 	req, rec = pkghttp.NewTestCtx("GET", "/queue")
@@ -71,11 +71,11 @@ func TestQueueSizeHandlerIntegration(t *testing.T) {
 	httpCl := srv.Client()
 	counts, err := GetCounts(httpCl, *url)
 	r.NoError(err)
-	r.Equal(1, len(counts.Counts))
+	r.Len(counts.Counts, 1)
 	for _, val := range counts.Counts {
 		r.Equal(reader.concurrency, val.Concurrency)
-		r.Equal(reader.rps, val.RPS)
+		r.InDelta(reader.rps, val.RPS, 0)
 	}
 	reqs := hdl.IncomingRequests()
-	r.Equal(1, len(reqs))
+	r.Len(reqs, 1)
 }

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -18,7 +18,7 @@ func TestCurrent(t *testing.T) {
 	current, err := memory.Current()
 	r.NoError(err)
 	r.Equal(current.Counts[host].Concurrency, memory.concurrentMap[host])
-	r.Equal(current.Counts[host].RPS, memory.rpsMap[host].WindowAverage(now))
+	r.InDelta(current.Counts[host].RPS, memory.rpsMap[host].WindowAverage(now), 0)
 
 	err = memory.Increase(host, 1)
 	r.NoError(err)

--- a/pkg/routing/key.go
+++ b/pkg/routing/key.go
@@ -13,8 +13,10 @@ import (
 // catchAllHostKey is the internal routing key for catch-all host matching.
 const catchAllHostKey = "*"
 
-type Key []byte
-type Keys []Key
+type (
+	Key  []byte
+	Keys []Key
+)
 
 var _ fmt.Stringer = (*Key)(nil)
 

--- a/pkg/routing/table.go
+++ b/pkg/routing/table.go
@@ -14,9 +14,7 @@ import (
 	"github.com/kedacore/http-add-on/pkg/util"
 )
 
-var (
-	errNotSyncedTable = errors.New("table has not synced")
-)
+var errNotSyncedTable = errors.New("table has not synced")
 
 type Table interface {
 	util.HealthChecker

--- a/pkg/routing/table_test.go
+++ b/pkg/routing/table_test.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -130,7 +131,7 @@ func TestTableHealthCheck(t *testing.T) {
 	if err == nil {
 		t.Error("expected error when not synced")
 	}
-	if err != errNotSyncedTable {
+	if !errors.Is(err, errNotSyncedTable) {
 		t.Errorf("expected errNotSyncedTable, got: %v", err)
 	}
 
@@ -230,7 +231,7 @@ func TestTableRefreshMemory_CancelsOnContextDone(t *testing.T) {
 
 	select {
 	case err := <-done:
-		if err != context.Canceled {
+		if !errors.Is(err, context.Canceled) {
 			t.Errorf("expected context.Canceled, got: %v", err)
 		}
 	case <-time.After(5 * time.Second):

--- a/pkg/util/atomicvalue_test.go
+++ b/pkg/util/atomicvalue_test.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sync/atomic"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -9,9 +9,7 @@ import (
 )
 
 var _ = Describe("AtomicValue", func() {
-	var (
-		i int
-	)
+	var i int
 
 	BeforeEach(func() {
 		i = rand.Int()

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -6,13 +6,11 @@ import (
 	"net/http"
 )
 
-var (
-	ignoredErrs = []error{
-		nil,
-		context.Canceled,
-		http.ErrServerClosed,
-	}
-)
+var ignoredErrs = []error{
+	nil,
+	context.Canceled,
+	http.ErrServerClosed,
+}
 
 func IsIgnoredErr(err error) bool {
 	for _, ignoredErr := range ignoredErrs {

--- a/scaler/handlers_test.go
+++ b/scaler/handlers_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/kedacore/keda/v2/pkg/scalers/externalscaler"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -283,7 +284,7 @@ func TestStreamIsActive(t *testing.T) {
 				hdl,
 			)
 			go func() {
-				r.NoError(grpcServer.Serve(lis))
+				assert.NoError(t, grpcServer.Serve(lis))
 			}()
 
 			bufDialFunc := func(context.Context, string) (net.Conn, error) {

--- a/scaler/naming.go
+++ b/scaler/naming.go
@@ -7,9 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var (
-	unsafeChars = regexp.MustCompile(`[^-.0-9A-Za-z]`)
-)
+var unsafeChars = regexp.MustCompile(`[^-.0-9A-Za-z]`)
 
 func escapeRune(r string) string {
 	return fmt.Sprintf("_%04X", r)

--- a/scaler/queue_pinger_test.go
+++ b/scaler/queue_pinger_test.go
@@ -84,7 +84,7 @@ func TestCounts(t *testing.T) {
 	retCounts := pinger.counts()
 	expectedCounts, err := q.Current()
 	r.NoError(err)
-	r.Equal(len(expectedCounts.Counts), len(retCounts))
+	r.Len(retCounts, len(expectedCounts.Counts))
 	for host, count := range expectedCounts.Counts {
 		retCount, ok := retCounts[host]
 		r.True(ok, "returned count not found for host %s", host)
@@ -92,7 +92,7 @@ func TestCounts(t *testing.T) {
 		// note that the returned value should be:
 		// (queue_count * num_endpoints)
 		r.Equal(count.Concurrency*3, retCount.Concurrency)
-		r.Equal(count.RPS*3, retCount.RPS)
+		r.InDelta(count.RPS*3, retCount.RPS, 0)
 	}
 }
 

--- a/tests/checks/headers/headers_test.go
+++ b/tests/checks/headers/headers_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package headerstest
 

--- a/tests/checks/httproute_in_app_namespace/httproute_in_app_namespace_test.go
+++ b/tests/checks/httproute_in_app_namespace/httproute_in_app_namespace_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package httproute_in_app_namespace_test
 

--- a/tests/checks/ingress_in_app_namespace/ingress_in_app_namespace_test.go
+++ b/tests/checks/ingress_in_app_namespace/ingress_in_app_namespace_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package ingress_in_app_namespace_test
 

--- a/tests/checks/ingress_in_keda_namespace/ingress_in_keda_namespace_test.go
+++ b/tests/checks/ingress_in_keda_namespace/ingress_in_keda_namespace_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package ingress_in_keda_namespace_test
 

--- a/tests/checks/interceptor_otel_metrics/interceptor_otel_metrics_test.go
+++ b/tests/checks/interceptor_otel_metrics/interceptor_otel_metrics_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package interceptor_otel_metrics_test
 
@@ -13,6 +12,7 @@ import (
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
 
 	. "github.com/kedacore/http-add-on/tests/helper"
@@ -197,13 +197,13 @@ func sendLoad(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 func fetchAndParsePrometheusMetrics(t *testing.T, cmd string) map[string]*prommodel.MetricFamily {
 	out, _, err := ExecCommandOnSpecificPod(t, clientName, testNamespace, cmd)
-	assert.NoErrorf(t, err, "cannot execute command - %s", err)
+	require.NoErrorf(t, err, "cannot execute command - %s", err)
 
 	parser := expfmt.NewTextParser(model.UTF8Validation)
 	// Ensure EOL
 	reader := strings.NewReader(strings.ReplaceAll(out, "\r\n", "\n"))
 	families, err := parser.TextToMetricFamilies(reader)
-	assert.NoErrorf(t, err, "cannot parse metrics - %s", err)
+	require.NoErrorf(t, err, "cannot parse metrics - %s", err)
 
 	return families
 }

--- a/tests/checks/interceptor_otel_tracing/interceptor_otel_tracing_test.go
+++ b/tests/checks/interceptor_otel_tracing/interceptor_otel_tracing_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package interceptor_otel_tracing_test
 
@@ -205,7 +204,7 @@ func TestTraceGeneration(t *testing.T) {
 	t.Logf("found %d trace(s) from Jaeger", len(traces))
 
 	traceStatus := findSpanStatusCode(traces)
-	assert.EqualValues(t, "200", traceStatus)
+	assert.Equal(t, "200", traceStatus)
 
 	// cleanup
 	DeleteKubernetesResources(t, testNamespace, data, templates)

--- a/tests/checks/interceptor_prometheus_metrics/interceptor_prometheus_metrics_test.go
+++ b/tests/checks/interceptor_prometheus_metrics/interceptor_prometheus_metrics_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package interceptor_prometheus_metrics_test
 
@@ -12,6 +11,7 @@ import (
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
 
 	. "github.com/kedacore/http-add-on/tests/helper"
@@ -188,13 +188,13 @@ func sendLoad(t *testing.T, kc *kubernetes.Clientset, data templateData) {
 
 func fetchAndParsePrometheusMetrics(t *testing.T, cmd string) map[string]*prommodel.MetricFamily {
 	out, _, err := ExecCommandOnSpecificPod(t, clientName, testNamespace, cmd)
-	assert.NoErrorf(t, err, "cannot execute command - %s", err)
+	require.NoErrorf(t, err, "cannot execute command - %s", err)
 
 	parser := expfmt.NewTextParser(model.UTF8Validation)
 	// Ensure EOL
 	reader := strings.NewReader(strings.ReplaceAll(out, "\r\n", "\n"))
 	families, err := parser.TextToMetricFamilies(reader)
-	assert.NoErrorf(t, err, "cannot parse metrics - %s", err)
+	require.NoErrorf(t, err, "cannot parse metrics - %s", err)
 
 	return families
 }

--- a/tests/checks/interceptor_scaledobject/interceptor_scaledobject_test.go
+++ b/tests/checks/interceptor_scaledobject/interceptor_scaledobject_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package interceptor_scaledobject_test
 
@@ -22,7 +21,7 @@ func TestCheck(t *testing.T) {
 	predicate := `-o jsonpath="{.status.conditions[?(@.type=="Ready")].status}"`
 	expectedResult := "True"
 	result := "False"
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		result = KubectlGetResult(t, scaledObject, interceptorScaledObjectName, kedaNamespace, predicate)
 		if result == expectedResult {
 			break

--- a/tests/checks/interceptor_timeouts/interceptor_timeouts_test.go
+++ b/tests/checks/interceptor_timeouts/interceptor_timeouts_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package interceptor_timeouts_test
 

--- a/tests/checks/interceptor_tls/interceptor_tls_test.go
+++ b/tests/checks/interceptor_tls/interceptor_tls_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package interceptor_tls_test
 
@@ -179,7 +178,7 @@ func sendRequest(t *testing.T) {
 	stdout, _, err := ExecCommandOnSpecificPod(t, clientName, testNamespace, fmt.Sprintf("curl -k -H 'Host: %s' https://keda-add-ons-http-interceptor-proxy.keda:8443/echo?msg=tls_test", host))
 	require.NoErrorf(t, err, "could not run command on test client pod - %s", err)
 
-	assert.Equal(t, "tls_test", stdout, fmt.Sprintf("incorrect response body from test request: expected %s, got %s", "tls_test", stdout))
+	assert.Equal(t, "tls_test", stdout, "incorrect response body from test request: expected %s, got %s", "tls_test", stdout)
 }
 
 func getTemplateData() (templateData, []Template) {

--- a/tests/checks/interceptor_websocket/interceptor_websocket_test.go
+++ b/tests/checks/interceptor_websocket/interceptor_websocket_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package interceptor_websocket_test
 

--- a/tests/checks/internal_service/internal_service_test.go
+++ b/tests/checks/internal_service/internal_service_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package internal_service_test
 

--- a/tests/checks/internal_service_port_name/internal_service_port_name_test.go
+++ b/tests/checks/internal_service_port_name/internal_service_port_name_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package internal_service_port_name_test
 

--- a/tests/checks/multiple_hosts/multiple_hosts_test.go
+++ b/tests/checks/multiple_hosts/multiple_hosts_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package multiple_hosts_test
 

--- a/tests/checks/operator_metrics/operator_metrics_test.go
+++ b/tests/checks/operator_metrics/operator_metrics_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package operator_metrics_test
 
@@ -9,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/kedacore/http-add-on/tests/helper"
 )
@@ -121,13 +121,12 @@ func testMetricsContent(t *testing.T) {
 	// Get the ServiceAccount token to authenticate
 	cmd := fmt.Sprintf("curl -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" --max-time 10 %s", kedaOperatorMetricsURL)
 	out, errOut, err := ExecCommandOnSpecificPod(t, clientName, testNamespace, cmd)
-
 	if err != nil {
 		t.Logf("Metrics content test - Output: %s, Error output: %s, Error: %v", out, errOut, err)
 	}
 
 	// Verify that metrics are returned in Prometheus format
-	assert.NoError(t, err, "should be able to access metrics from client pod with RBAC permissions. Output: %s, Error: %s", out, errOut)
+	require.NoError(t, err, "should be able to access metrics from client pod with RBAC permissions. Output: %s, Error: %s", out, errOut)
 	assert.True(t, strings.Contains(out, "# HELP") || strings.Contains(out, "# TYPE"),
 		"metrics should contain Prometheus format. Output: %s", out)
 }

--- a/tests/checks/path_prefix/path_prefix_test.go
+++ b/tests/checks/path_prefix/path_prefix_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package path_prefix_test
 

--- a/tests/checks/scaling_phase_custom_resource/scaling_phase_custom_resource_test.go
+++ b/tests/checks/scaling_phase_custom_resource/scaling_phase_custom_resource_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package scaling_phase_test
 
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/kedacore/http-add-on/tests/helper"
 )
@@ -201,16 +201,17 @@ func getTemplateData() (templateData, []Template) {
 }
 
 func waitForArgoRolloutReplicaCount(t *testing.T, name, namespace string,
-	target, iterations, intervalSeconds int) bool {
-	for i := 0; i < iterations; i++ {
+	target, iterations, intervalSeconds int,
+) bool {
+	for range iterations {
 		kctlGetCmd := fmt.Sprintf(`kubectl get rollouts.argoproj.io/%s -n %s -o jsonpath="{.spec.replicas}"`, name, namespace)
 		output, err := ExecuteCommand(kctlGetCmd)
 
-		assert.NoErrorf(t, err, "cannot get rollout info - %s", err)
+		require.NoErrorf(t, err, "cannot get rollout info - %s", err)
 
 		unqoutedOutput := strings.ReplaceAll(string(output), "\"", "")
 		replicas, err := strconv.ParseInt(unqoutedOutput, 10, 64)
-		assert.NoErrorf(t, err, "cannot convert rollout count to int - %s", err)
+		require.NoErrorf(t, err, "cannot convert rollout count to int - %s", err)
 
 		t.Logf("Waiting for rollout replicas to hit target. Deployment - %s, Current  - %d, Target - %d",
 			name, replicas, target)

--- a/tests/checks/scaling_phase_deployment/scaling_phase_deployment_test.go
+++ b/tests/checks/scaling_phase_deployment/scaling_phase_deployment_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package scaling_phase_test
 

--- a/tests/checks/scaling_phase_deployment_with_skip_so_creation/scaling_phase_deployment_with_skip_so_creation_test.go
+++ b/tests/checks/scaling_phase_deployment_with_skip_so_creation/scaling_phase_deployment_with_skip_so_creation_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package scaling_phase_test
 

--- a/tests/checks/scaling_phase_statefulset/scaling_phase_statefulset_test.go
+++ b/tests/checks/scaling_phase_statefulset/scaling_phase_statefulset_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package scaling_phase_test
 

--- a/tests/run-all.go
+++ b/tests/run-all.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package main
 
@@ -7,14 +6,13 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
-	"time"
 
 	"golang.org/x/sync/semaphore"
 	"k8s.io/client-go/kubernetes"
@@ -88,7 +86,7 @@ func executeTest(ctx context.Context, file string, timeout string, tries int) Te
 		cmd := exec.CommandContext(ctx, "go", "test", "-v", "-tags", "e2e", "-timeout", timeout, file)
 		stdout, err := cmd.CombinedOutput()
 		logFile := fmt.Sprintf("%s.%d.log", file, i)
-		fileError := os.WriteFile(logFile, stdout, 0644)
+		fileError := os.WriteFile(logFile, stdout, 0o600)
 		if fileError != nil {
 			fmt.Printf("Execution of %s, try '%d' has failed writing the logs : %s\n", file, i, fileError)
 		}
@@ -129,13 +127,11 @@ func getTestFiles() []string {
 			}
 			return nil
 		})
-
 	if err != nil {
 		return []string{}
 	}
 
 	// We randomize the executions
-	rand.New(rand.NewSource(time.Now().UnixNano()))
 	rand.Shuffle(len(testFiles), func(i, j int) {
 		testFiles[i], testFiles[j] = testFiles[j], testFiles[i]
 	})

--- a/tests/utils/cleanup_test.go
+++ b/tests/utils/cleanup_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package utils
 

--- a/tests/utils/setup_test.go
+++ b/tests/utils/setup_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 package utils
 
@@ -301,11 +300,11 @@ func TestSetupOpentelemetryComponents(t *testing.T) {
 	otlpServiceTempFileName := "otlpServicePatch.yml"
 	defer os.Remove(otlpTempFileName)
 	defer os.Remove(otlpServiceTempFileName)
-	err := os.WriteFile(otlpTempFileName, []byte(OtlpConfig), 0755)
-	assert.NoErrorf(t, err, "cannot create otlp config file - %s", err)
+	err := os.WriteFile(otlpTempFileName, []byte(OtlpConfig), 0o600)
+	require.NoErrorf(t, err, "cannot create otlp config file - %s", err)
 
-	err = os.WriteFile(otlpServiceTempFileName, []byte(OtlpServicePatch), 0755)
-	assert.NoErrorf(t, err, "cannot create otlp service patch file - %s", err)
+	err = os.WriteFile(otlpServiceTempFileName, []byte(OtlpServicePatch), 0o600)
+	require.NoErrorf(t, err, "cannot create otlp service patch file - %s", err)
 
 	_, err = ExecuteCommand("helm version")
 	require.NoErrorf(t, err, "helm is not installed - %s", err)
@@ -332,8 +331,8 @@ func TestDeployJaeger(t *testing.T) {
 
 	jaegerTemplateFileName := "jaeger.yml"
 	defer os.Remove(jaegerTemplateFileName)
-	err := os.WriteFile(jaegerTemplateFileName, []byte(jaegerTemplate), 0755)
-	assert.NoErrorf(t, err, "cannot create jaeger config file - %s", err)
+	err := os.WriteFile(jaegerTemplateFileName, []byte(jaegerTemplate), 0o600)
+	require.NoErrorf(t, err, "cannot create jaeger config file - %s", err)
 
 	_, err = ExecuteCommand(fmt.Sprintf("kubectl apply -f %s -n %s", jaegerTemplateFileName, "jaeger"))
 	require.NoErrorf(t, err, "cannot deploy jaeger - %s", err)


### PR DESCRIPTION
Simplify and extend golangci config and fix related issues - all changes are related to findings or are dead code removals I didn't catch in #1493 as it was in test files.
Add gosec, modernize, testifylint, and errorlint and remove the broad exclusion presets.

Also use gofumpt which is a superset of gofmt which is IMO really useful, check https://github.com/mvdan/gofumpt#added-rules 

### golangci-lint Performance: `main` vs `golangci-lint-overhaul`
I let claude compare the performance of the previous and current config a few times with the a warm and cold golangci-lint cache.
IMO gosec is worth it considering we are in the request path of potentially critical applications, the other ones are also useful and don't cost that much more time - but I'm happy to discuss this!


| | **main** | **overhaul** | **delta** |
|---|---|---|---|
| **Cold (wall)** | 19.6s | 15.8s | **-19%** |
| **Cold (CPU)** | 54.7s | 74.0s | **+35%** |
| **Cached** | 1.6s | 2.1s | **+0.5s** |

**Faster wall time, higher CPU usage.** The old config capped parallelism with `concurrency: 4` (362% CPU). Removing that cap lets golangci-lint use all available cores (712% CPU), which more than compensates for adding 4 new linters.

**Per-linter cost of the new additions** (cold, measured by disabling each individually):

| Linter | Wall time added |
|---|---|
| `errorlint` | ~2.0s |
| `gosec` | ~1.6s |
| `modernize` | ~1.3s |
| `testifylint` | ~1.1s |

These overlap due to parallel execution — total isn't additive.


### Changes
- Add gosec, modernize, testifylint, errorlint linters
- Remove legacy/common-false-positives/std-error-handling presets
- Replace gofmt with gofumpt, use gci localmodule
- Add ReadHeaderTimeout to all http.Server instances against findings of [Slowloris attacks](https://en.wikipedia.org/wiki/Slowloris_(cyber_attack))
  - This means that requesters have to read all of our headers within 1min which is IMO acceptable, knative uses the same default
  - We don't need this in theory for our pprof endpoint but it is not wrong either to add it
- Fix error comparisons to use errors.Is/errors.As (errorlint)
- Fix testify misuse: require in goroutines, float equality, require-error
  - require shouldn't be used in nested goroutines inside of tests as the test doesnt exit cleanly (at least not guaranteed)
- Explicitly discard Close errors with _ = pattern
  - IMO the cleaner pattern than simply ignoring errors completely, we have also many checks that these errors are nil in other tests but didn't want to change test behavior.
- Remove dead code from test helpers (confirmed via deadcode)
- Apply modernize fixes: any, range-over-int, +build removal

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

