### PR TITLE
ci: use stable Go version in CI workflows

### DIFF
--- a/.github/workflows/build_canary.yml
+++ b/.github/workflows/build_canary.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version-file: "go.mod"
+          go-version: 'stable'
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
       - name: Login to GHCR

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version-file: "go.mod"
+          go-version: 'stable'
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
       - name: Get the version

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version-file: "go.mod"
+          go-version: 'stable'
 
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version-file: 'go.mod'
+          go-version: 'stable'
       - run: go version
       - name: Get branch name
         id: branch-name

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version-file: "go.mod"
+          go-version: 'stable'
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
       - name: Build ${{ matrix.component }}
         run: make ko-build-${{ matrix.component }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version-file: "go.mod"
+          go-version: 'stable'
 
       - name: Manifests
         run: make verify-manifests
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version-file: "go.mod"
+          go-version: 'stable'
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         env:


### PR DESCRIPTION
Use latest stable Go version in CI while keeping the go.mod at the minimum supported version.

Benefits are:
- We release with the latest go features and fixes (e.g. new GC)
- Better compatibility for programmatic users of KHA to use go 1.(n-1)
  - Recommended by Go and also the default since 1.26
- No need to update the Go version in CI workflows

Go guarantees compatibility so no need to overengineer things in my opinion.
On top of that: We build nightly and would detect possible issues very soon.
The very very minor risks are IMO outweighed by the benefits.


### Changes
- Replace go-version-file with go-version: 'stable' in all workflows

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
