### PR TITLE
ci: replace keda-tools container with setup-go in CodeQL workflow

### DIFF
--- a/.github/workflows/static-analysis-codeql.yml
+++ b/.github/workflows/static-analysis-codeql.yml
@@ -17,13 +17,13 @@ jobs:
   codeQl:
     name: Analyze CodeQL Go
     runs-on: ubuntu-latest
-    container: ghcr.io/kedacore/keda-tools:1.25.6
     if: (github.actor != 'dependabot[bot]')
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Register workspace path
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: 'stable'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9


### PR DESCRIPTION
Aligns the CodeQL workflow with all other CI workflows, which use actions/setup-go with go-version: 'stable'. Removes an extra container dependency to maintain.

### Changes
- Drop container: ghcr.io/kedacore/keda-tools and the workspace path workaround
- Add actions/setup-go with go-version: 'stable'

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
