### PR TITLE
chore: enable Renovate kubernetes manager for config/ and examples/

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,9 @@
     ":gitSignOff",
   ],
   "commitBodyTable": true,
+  "kubernetes": {
+    "fileMatch": ["(config|examples)/.+\\.ya?ml$"],
+  },
   "labels": ["dependencies"],
   // Experimental: OSV-based vulnerability alerts for direct dependencies
   "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
The kubernetes manager has an empty default fileMatch, so it wasn't detecting any Kubernetes resources in the repository.

### Changes
- Add kubernetes manager with fileMatch for config/ and examples/ YAML files

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

