### PR TITLE
chore: improve Renovate dependency grouping

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,51 +1,41 @@
 {
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    'config:best-practices',
-    'schedule:weekly',
-    ':gitSignOff',
+    // See https://docs.renovatebot.com/presets-config/#configbest-practices
+    "config:best-practices",
+    "schedule:weekly",
+    ":gitSignOff",
+    ":prHourlyLimitNone",
   ],
   commitBodyTable: true,
   kubernetes: {
-    managerFilePatterns: [
-      '/(config|examples)/.+\\.ya?ml$/',
-    ],
+    managerFilePatterns: ["/(config|examples)/.+\\.ya?ml$/"],
   },
-  labels: [
-    'dependencies',
-  ],
+  labels: ["dependencies"],
+  // Experimental: OSV-based vulnerability alerts for direct dependencies
   osvVulnerabilityAlerts: true,
   packageRules: [
     {
-      matchManagers: [
-        'github-actions',
-      ],
-      groupName: 'GitHub Actions',
+      matchManagers: ["github-actions"],
+      groupName: "GitHub Actions",
     },
     {
-      matchManagers: [
-        'gomod',
-      ],
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-      ],
-      groupName: 'Go Dependencies (non-major)',
+      // Group minor/patch together; major updates get individual PRs
+      matchManagers: ["gomod"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "Go Dependencies (non-major)",
     },
     {
-      matchManagers: [
-        'pre-commit',
-      ],
-      groupName: 'Pre-commit Hooks',
+      matchManagers: ["pre-commit"],
+      groupName: "Pre-commit Hooks",
     },
   ],
-  'pre-commit': {
+  // Experimental: pre-commit manager is in beta and disabled by default
+  "pre-commit": {
     enabled: true,
   },
   vulnerabilityAlerts: {
     enabled: true,
-    addLabels: [
-      'security',
-    ],
+    addLabels: ["security"],
   },
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,8 +19,21 @@
       matchManagers: ["github-actions"],
       groupName: "GitHub Actions",
     },
+    // keda's go.mod conflicts with several direct dependencies -> isolate
     {
-      // Group minor/patch together; major updates get individual PRs
+      matchManagers: ["gomod"],
+      matchPackageNames: ["github.com/kedacore/keda/v2"],
+      groupName: "keda",
+    },
+    // Group tightly coupled k8s packages updates for controlled K8s version support
+    {
+      matchManagers: ["gomod"],
+      matchPackageNames: ["k8s.io/**", "sigs.k8s.io/controller-runtime"],
+      // Patch updates are safe to be merged regularly in the catch-all group
+      matchUpdateTypes: ["minor", "major"],
+      groupName: "Kubernetes Dependencies",
+    },
+    {
       matchManagers: ["gomod"],
       matchUpdateTypes: ["minor", "patch"],
       groupName: "Go Dependencies (non-major)",


### PR DESCRIPTION
### Changes
#### Hourly PR Limit

This is currently capped to 2, see https://docs.renovatebot.com/configuration-options/#prhourlylimit . There is also a concurrent limit of 10 which is IMO OK to avoid conflicts, PRs can always be triggered manually.

#### Grouping
keda and k8s.io packages cause conflicts when bumped together because keda's go.mod has broken transitive dependencies.
Splitting them into separate groups isolates these conflicts and gives control over Kubernetes version support timing.

Changes:
- Isolate keda into its own Renovate group
- Group k8s.io and controller-runtime minor/major updates separately
- Keep catch-all group for routine updates including k8s patches

#### Other

It was a bit unfortunate that renovate chose another formatting when migrating the config field in #1504 , I used `prettier` again. Will need to think about this in the future.
Comments are also added again as renovate stripped them.

I will also manually trigger the creation of the PRs that weren't created.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
