### PR TITLE
fix: reorder Renovate packageRules so specific groups override catch-all

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,11 @@
       matchManagers: ["github-actions"],
       groupName: "GitHub Actions",
     },
+    {
+      matchManagers: ["gomod"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "Go Dependencies (non-major)",
+    },
     // keda's go.mod conflicts with several direct dependencies -> isolate
     {
       matchManagers: ["gomod"],
@@ -32,11 +37,6 @@
       // Patch updates are safe to be merged regularly in the catch-all group
       matchUpdateTypes: ["minor", "major"],
       groupName: "Kubernetes Dependencies",
-    },
-    {
-      matchManagers: ["gomod"],
-      matchUpdateTypes: ["minor", "patch"],
-      groupName: "Go Dependencies (non-major)",
     },
     {
       matchManagers: ["pre-commit"],


### PR DESCRIPTION
Renovate applies all matching packageRules in order, with later rules overriding earlier ones. The catch-all group was last, overriding the keda and Kubernetes group names back to "Go Dependencies (non-major)".

Fixes my previous PR #1507 .

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)