### PR TITLE
chore: extend k8s renovate group with more related pkgs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,7 +33,12 @@
     // Group tightly coupled k8s packages updates for controlled K8s version support
     {
       matchManagers: ["gomod"],
-      matchPackageNames: ["k8s.io/**", "sigs.k8s.io/controller-runtime"],
+      matchPackageNames: [
+        "k8s.io/**",
+        "sigs.k8s.io/controller-runtime",
+        "sigs.k8s.io/controller-tools",
+        "sigs.k8s.io/gateway-api", // independently versioned but depends on k8s.io/*
+      ],
       // Patch updates are safe to be merged regularly in the catch-all group
       matchUpdateTypes: ["minor", "major"],
       groupName: "Kubernetes Dependencies",


### PR DESCRIPTION
controller-tools also has a hard dependency on the k8s.io packages we group for controlled k8s version support.
gateway-api uses a different versioning scheme but still depends on some k8s.io packages and bumped these deps e.g. from 0.34 to 0.35 on their 1.4 -> 1.5 release.

Related to #1511 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

