### PR TITLE
feat: add env-based TLS version, cipher suite, and curve configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
 - **Docs**: Update design doc to use `scalingMetric`/`targetValue` instead of deprecated `targetPendingRequests` ([#1536](https://github.com/kedacore/http-add-on/pull/1536))
+- **Interceptor**: Add env-based TLS configuration for min/max version, cipher suites, and curve preferences ([#1530](https://github.com/kedacore/http-add-on/pull/1530))
 - **Interceptor**: Reduce interceptor latency and memory usage under high concurrency ([#1482](https://github.com/kedacore/http-add-on/pull/1482))
 - **Interceptor**: Speed up endpoint readiness checks with a fast lookup cache ([#1472](https://github.com/kedacore/http-add-on/pull/1472))
 

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -34,6 +34,19 @@ type Serving struct {
 	TLSSkipVerify bool `env:"KEDA_HTTP_PROXY_TLS_SKIP_VERIFY" envDefault:"false"`
 	// TLSPort is the port that the server should serve on if TLS is enabled
 	TLSPort int `env:"KEDA_HTTP_PROXY_TLS_PORT" envDefault:"8443"`
+	// TLSMinVersion is the minimum TLS version to accept ("1.2" or "1.3").
+	// If empty, the Go default is used (currently TLS 1.2).
+	TLSMinVersion string `env:"KEDA_HTTP_PROXY_TLS_MIN_VERSION" envDefault:""`
+	// TLSMaxVersion is the maximum TLS version to accept ("1.2" or "1.3").
+	// Defaults to the highest version supported by crypto/tls if empty.
+	TLSMaxVersion string `env:"KEDA_HTTP_PROXY_TLS_MAX_VERSION" envDefault:""`
+	// TLSCipherSuites is a comma-separated list of TLS cipher suite names
+	// (e.g. "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384").
+	// If empty, the default Go cipher suites are used.
+	TLSCipherSuites string `env:"KEDA_HTTP_PROXY_TLS_CIPHER_SUITES" envDefault:""`
+	// TLSCurvePreferences is a comma-separated list of elliptic curve names
+	// (e.g. "X25519,CurveP256"). If empty, the default Go curve preferences are used.
+	TLSCurvePreferences string `env:"KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES" envDefault:""`
 	// ProfilingAddr if not empty, pprof will be available on this address, assuming host:port here
 	ProfilingAddr string `env:"PROFILING_BIND_ADDRESS" envDefault:""`
 	// EnableColdStartHeader enables/disables the X-KEDA-HTTP-Cold-Start response header

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -202,6 +202,10 @@ func main() {
 				KeyPath:            servingCfg.TLSKeyPath,
 				CertStorePaths:     servingCfg.TLSCertStorePaths,
 				InsecureSkipVerify: servingCfg.TLSSkipVerify,
+				MinTLSVersion:      servingCfg.TLSMinVersion,
+				MaxTLSVersion:      servingCfg.TLSMaxVersion,
+				CipherSuites:       servingCfg.TLSCipherSuites,
+				CurvePreferences:   servingCfg.TLSCurvePreferences,
 			}, setupLog)
 			if err != nil {
 				setupLog.Error(err, "failed to configure TLS")

--- a/interceptor/proxy.go
+++ b/interceptor/proxy.go
@@ -53,6 +53,10 @@ func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
 			RootCAs:            cfg.TLSConfig.RootCAs,
 			Certificates:       cfg.TLSConfig.Certificates,
 			InsecureSkipVerify: cfg.TLSConfig.InsecureSkipVerify, //nolint:gosec // G402: user-configurable
+			MinVersion:         cfg.TLSConfig.MinVersion,
+			MaxVersion:         cfg.TLSConfig.MaxVersion,
+			CipherSuites:       cfg.TLSConfig.CipherSuites,
+			CurvePreferences:   cfg.TLSConfig.CurvePreferences,
 		}
 	}
 	transport := &http.Transport{

--- a/interceptor/tls_config.go
+++ b/interceptor/tls_config.go
@@ -19,6 +19,10 @@ type TLSOptions struct {
 	KeyPath            string
 	CertStorePaths     string
 	InsecureSkipVerify bool
+	MinTLSVersion      string
+	MaxTLSVersion      string
+	CipherSuites       string
+	CurvePreferences   string
 }
 
 // BuildTLSConfig creates a tls.Config from the given TLS options.
@@ -27,6 +31,35 @@ func BuildTLSConfig(opts TLSOptions, logger logr.Logger) (*tls.Config, error) {
 	servingTLS := &tls.Config{
 		RootCAs:            defaultCertPool(logger),
 		InsecureSkipVerify: opts.InsecureSkipVerify, //nolint:gosec // G402: user-configurable
+	}
+
+	if opts.MinTLSVersion != "" {
+		v, err := parseTLSVersion(opts.MinTLSVersion)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TLS min version %q: %w", opts.MinTLSVersion, err)
+		}
+		servingTLS.MinVersion = v
+	}
+	if opts.MaxTLSVersion != "" {
+		v, err := parseTLSVersion(opts.MaxTLSVersion)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TLS max version %q: %w", opts.MaxTLSVersion, err)
+		}
+		servingTLS.MaxVersion = v
+	}
+	if opts.CipherSuites != "" {
+		suites, err := parseCipherSuites(opts.CipherSuites)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TLS cipher suites: %w", err)
+		}
+		servingTLS.CipherSuites = suites
+	}
+	if opts.CurvePreferences != "" {
+		curves, err := parseCurvePreferences(opts.CurvePreferences)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TLS curve preferences: %w", err)
+		}
+		servingTLS.CurvePreferences = curves
 	}
 	var defaultCert *tls.Certificate
 
@@ -156,4 +189,74 @@ func defaultCertPool(logger logr.Logger) *x509.CertPool {
 
 	logger.Error(err, "error loading system CA pool, using empty pool")
 	return x509.NewCertPool()
+}
+
+// parseTLSVersion converts a version string ("1.2" or "1.3") to the
+// corresponding crypto/tls constant.
+func parseTLSVersion(v string) (uint16, error) {
+	switch v {
+	case "1.2":
+		return tls.VersionTLS12, nil
+	case "1.3":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("unsupported TLS version %q: must be %q or %q", v, "1.2", "1.3")
+	}
+}
+
+// parseCipherSuites parses a comma-separated list of TLS cipher-suite names
+// into a slice of cipher-suite IDs. Returns nil when no valid names are present
+// so that Go's default cipher suites remain in effect.
+func parseCipherSuites(s string) ([]uint16, error) {
+	lookup := make(map[string]uint16)
+	for _, cs := range tls.CipherSuites() {
+		lookup[cs.Name] = cs.ID
+	}
+
+	parts := strings.Split(s, ",")
+	var suites []uint16
+	for _, name := range parts {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		id, ok := lookup[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown cipher suite %q", name)
+		}
+		suites = append(suites, id)
+	}
+	return suites, nil
+}
+
+// parseCurvePreferences parses a comma-separated list of elliptic-curve names
+// into a slice of tls.CurveID values. Both Go constant names (CurveP256)
+// and standard names (P-256) are accepted. Returns nil when no valid names
+// are present so that Go's default curve preferences remain in effect.
+func parseCurvePreferences(s string) ([]tls.CurveID, error) {
+	parts := strings.Split(s, ",")
+	var curves []tls.CurveID
+	for _, name := range parts {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		id, ok := curvesByName[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown curve %q", name)
+		}
+		curves = append(curves, id)
+	}
+	return curves, nil
+}
+
+var curvesByName = map[string]tls.CurveID{
+	"CurveP256":      tls.CurveP256,
+	"CurveP384":      tls.CurveP384,
+	"CurveP521":      tls.CurveP521,
+	"X25519":         tls.X25519,
+	"X25519MLKEM768": tls.X25519MLKEM768,
+	"P-256":          tls.CurveP256,
+	"P-384":          tls.CurveP384,
+	"P-521":          tls.CurveP521,
 }

--- a/interceptor/tls_config_test.go
+++ b/interceptor/tls_config_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -183,6 +184,100 @@ func TestBuildTLSConfig_NonExistentCertStorePath(t *testing.T) {
 	_, err := BuildTLSConfig(opts, logr.Discard())
 	if err == nil {
 		t.Error("expected error for non-existent cert store path")
+	}
+}
+
+func TestBuildTLSConfig_TLSOptions(t *testing.T) {
+	tests := map[string]struct {
+		opts             TLSOptions
+		wantErr          bool
+		wantMinVersion   uint16
+		wantMaxVersion   uint16
+		wantCipherSuites []uint16
+		wantCurves       []tls.CurveID
+	}{
+		"default min version": {
+			opts:           TLSOptions{},
+			wantMinVersion: 0,
+		},
+		"min version 1.3": {
+			opts:           TLSOptions{MinTLSVersion: "1.3"},
+			wantMinVersion: tls.VersionTLS13,
+		},
+		"min version 1.2": {
+			opts:           TLSOptions{MinTLSVersion: "1.2"},
+			wantMinVersion: tls.VersionTLS12,
+		},
+		"max version 1.2": {
+			opts:           TLSOptions{MaxTLSVersion: "1.2"},
+			wantMaxVersion: tls.VersionTLS12,
+		},
+		"invalid min version": {
+			opts:    TLSOptions{MinTLSVersion: "1.1"},
+			wantErr: true,
+		},
+		"invalid max version": {
+			opts:    TLSOptions{MaxTLSVersion: "1.0"},
+			wantErr: true,
+		},
+		"cipher suites": {
+			opts: TLSOptions{CipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+			wantCipherSuites: []uint16{
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			},
+		},
+		"cipher suites whitespace only": {
+			opts:             TLSOptions{CipherSuites: " , "},
+			wantCipherSuites: nil,
+		},
+		"invalid cipher suite": {
+			opts:    TLSOptions{CipherSuites: "INVALID_SUITE"},
+			wantErr: true,
+		},
+		"curve preferences go names": {
+			opts:       TLSOptions{CurvePreferences: "X25519,CurveP256"},
+			wantCurves: []tls.CurveID{tls.X25519, tls.CurveP256},
+		},
+		"curve preferences standard names": {
+			opts:       TLSOptions{CurvePreferences: "P-256, P-384"},
+			wantCurves: []tls.CurveID{tls.CurveP256, tls.CurveP384},
+		},
+		"curve preferences whitespace only": {
+			opts:       TLSOptions{CurvePreferences: " , "},
+			wantCurves: nil,
+		},
+		"invalid curve preference": {
+			opts:    TLSOptions{CurvePreferences: "INVALID_CURVE"},
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			tlsCfg, err := BuildTLSConfig(tt.opts, logr.Discard())
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tlsCfg.MinVersion != tt.wantMinVersion {
+				t.Errorf("MinVersion = %d, want %d", tlsCfg.MinVersion, tt.wantMinVersion)
+			}
+			if tlsCfg.MaxVersion != tt.wantMaxVersion {
+				t.Errorf("MaxVersion = %d, want %d", tlsCfg.MaxVersion, tt.wantMaxVersion)
+			}
+			if !slices.Equal(tlsCfg.CipherSuites, tt.wantCipherSuites) {
+				t.Errorf("CipherSuites = %v, want %v", tlsCfg.CipherSuites, tt.wantCipherSuites)
+			}
+			if !slices.Equal(tlsCfg.CurvePreferences, tt.wantCurves) {
+				t.Errorf("CurvePreferences = %v, want %v", tlsCfg.CurvePreferences, tt.wantCurves)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

Allow operators to fine-tune the interceptor's TLS server via environment variables, similar to knative/pkg's TLS config helper:

- KEDA_HTTP_PROXY_TLS_MIN_VERSION / _MAX_VERSION ("1.2" or "1.3")
- KEDA_HTTP_PROXY_TLS_CIPHER_SUITES (comma-separated suite names)
- KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES (comma-separated curve names)

When unset, the defaults are TLS 1.2+ with Go's standard cipher and curve selections.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
