### PR TITLE
fix: drop semconv version-pinned import in favor of schemaless resources

### DIFF
--- a/interceptor/metrics/otelmetrics.go
+++ b/interceptor/metrics/otelmetrics.go
@@ -9,7 +9,6 @@ import (
 	api "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 
 	"github.com/kedacore/http-add-on/pkg/build"
 )
@@ -29,10 +28,9 @@ func NewOtelMetrics(options ...metric.Option) *OtelMetrics {
 	}
 
 	if options == nil {
-		res := resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName("interceptor-proxy"),
-			semconv.ServiceVersion(build.Version()),
+		res := resource.NewSchemaless(
+			attribute.String("service.name", "interceptor-proxy"),
+			attribute.String("service.version", build.Version()),
 		)
 
 		options = []metric.Option{

--- a/interceptor/metrics/prommetrics.go
+++ b/interceptor/metrics/prommetrics.go
@@ -9,7 +9,6 @@ import (
 	api "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 
 	"github.com/kedacore/http-add-on/pkg/build"
 )
@@ -32,10 +31,9 @@ func NewPrometheusMetrics(options ...prometheus.Option) *PrometheusMetrics {
 		log.Fatalf("could not create Prometheus exporter: %v", err)
 	}
 
-	res := resource.NewWithAttributes(
-		semconv.SchemaURL,
-		semconv.ServiceName("interceptor-proxy"),
-		semconv.ServiceVersion(build.Version()),
+	res := resource.NewSchemaless(
+		attribute.String("service.name", "interceptor-proxy"),
+		attribute.String("service.version", build.Version()),
 	)
 
 	provider := metric.NewMeterProvider(

--- a/interceptor/tracing/tracing.go
+++ b/interceptor/tracing/tracing.go
@@ -7,13 +7,13 @@ import (
 
 	"go.opentelemetry.io/contrib/propagators/b3"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 
 	"github.com/kedacore/http-add-on/interceptor/config"
 )
@@ -61,8 +61,8 @@ func SetupOTelSDK(ctx context.Context, tCfg config.Tracing) (shutdown func(conte
 
 func newResource(serviceName string) (*resource.Resource, error) {
 	return resource.Merge(resource.Default(),
-		resource.NewWithAttributes(semconv.SchemaURL,
-			semconv.ServiceName(serviceName),
+		resource.NewSchemaless(
+			attribute.String("service.name", serviceName),
 		))
 }
 


### PR DESCRIPTION
The semconv package uses versioned import paths (e.g. semconv/v1.40.0) that must be manually updated whenever OTel SDK dependencies are bumped. This causes friction with automated dependency updates (Renovate) since each OTel SDK version requires a matching semconv version.

Use resource.NewSchemaless with plain attribute strings instead, which is a widely-used workaround for this known issue
(open-telemetry/opentelemetry-go#4886) as `service.name` and `service.version` basically never change (at least very likely not in otel v1).

### Changes
- Replace resource.NewWithAttributes(semconv.SchemaURL, ...) with resource.NewSchemaless(attribute.String(...), ...)
- Remove semconv import from otelmetrics, prommetrics, and tracing


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)