### PR TITLE
refactor(scaler): use WaitGroup.Go for queue pinger goroutines

### DIFF
--- a/scaler/queue_pinger.go
+++ b/scaler/queue_pinger.go
@@ -161,7 +161,6 @@ func fetchCounts(ctx context.Context, lggr logr.Logger, endpointsFn k8s.GetEndpo
 		// a "private" goroutine, which we'll
 		// then forward on to countsCh
 		ch := make(chan *queue.Counts)
-		wg.Add(1)
 		fetchGrp.Go(func() error {
 			counts, err := queue.GetCounts(http.DefaultClient, u)
 			if err != nil {
@@ -173,11 +172,10 @@ func fetchCounts(ctx context.Context, lggr logr.Logger, endpointsFn k8s.GetEndpo
 		})
 		// forward the "private" goroutine
 		// on to countsCh separately
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			res := <-ch
 			countsCh <- res
-		}()
+		})
 	}
 
 	// close countsCh after all goroutines are done sending


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

Replaces the manual `wg.Add(1)` and `defer wg.Done()` pattern in the scaler's queue_pinger with the cleaner `wg.Go()` method.

This simplifies the concurrent fetch counts logic by letting the standard library handle the wait group synchronization automatically.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
