### PR TITLE
chore: track golangci-lint version with renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   extends: [
     // See https://docs.renovatebot.com/presets-config/#configbest-practices
     "config:best-practices",
+    "customManagers:githubActionsVersions",
     "schedule:weekly",
     ":gitSignOff",
     ":prHourlyLimitNone",

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,6 +45,9 @@ jobs:
       pull-requests: read # for golangci/golangci-lint-action to fetch pull requests
     name: Static Checks
     runs-on: ubuntu-latest
+    env:
+      # renovate: datasource=github-releases depName=golangci/golangci-lint
+      GOLANGCI_LINT_VERSION: "v2.11.2"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -52,7 +55,7 @@ jobs:
           go-version: 'stable'
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.11.2
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         env:
           SKIP: golangci-lint


### PR DESCRIPTION
Track and update golangci-lint version with renovate. renovate offers many ways to do this, using the existing customManager seemed like the most simple way to achieve this.
The referenced presets contains a regex that matches for # renovate comments with _VERSION env vars, see https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions .

I couldn't test it locally but it seems correct to me, will see this immediately after merge in the renovate dashaboard.


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
