### PR TITLE
chore: group regex-managed action versions with GitHub Actions updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,7 +17,8 @@
   osvVulnerabilityAlerts: true,
   packageRules: [
     {
-      matchManagers: ["github-actions"],
+      matchManagers: ["github-actions", "regex"],
+      matchFileNames: [".github/workflows/**"],
       groupName: "GitHub Actions",
     },
     {


### PR DESCRIPTION
PR #1537 tracked golangci-lint via renovate, it would be a separate PR though as shown in the dashboard issue.
To reduce PR noise we should group all GHA related changes.

<img width="749" height="242" alt="image" src="https://github.com/user-attachments/assets/18f0c73c-f99f-490f-9555-3bc9bedc5d4a" />


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
