### PR TITLE
chore: improve issue templates and add needs-triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/1_feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request 🧭
 description: Suggest an idea for this project
-labels: "needs-discussion,feature-request"
+labels: "needs-triage,enhancement"
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/2_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report.yml
@@ -1,6 +1,6 @@
 name: Report a bug 🐛
 description: Create a report to help us improve
-labels: "bug"
+labels: "needs-triage,bug"
 body:
   - type: textarea
     attributes:
@@ -41,31 +41,18 @@ body:
         ```
     validations:
       required: false
-  - type: dropdown
+  - type: input
     attributes:
       label: HTTP Add-on Version
       description: What version of the KEDA HTTP Add-on are you running?
-      options:
-        - "0.12.2"
-        - "0.12.1"
-        - "0.12.0"
-        - "0.11.1"
-        - "0.11.0"
-        - "0.10.0"
-        - "Other"
+      placeholder: "e.g., 0.12.2 — check your Helm release, image tag, or deployment manifests"
     validations:
       required: false
-  - type: dropdown
+  - type: input
     attributes:
       label: Kubernetes Version
-      description: What version of Kubernetes that are you running?
-      options:
-        - "1.35"
-        - "1.34"
-        - "1.33"
-        - "1.32"
-        - "< 1.32"
-        - "Other"
+      description: What version of Kubernetes are you running?
+      placeholder: "e.g., 1.35 — run 'kubectl version' to check"
     validations:
       required: false
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/3_release_tracker.md
+++ b/.github/ISSUE_TEMPLATE/3_release_tracker.md
@@ -19,7 +19,6 @@ We aim to release this release in the week of <week range, example March 27-31>.
 
 ## Progress
 
-- [ ] Add the new version to the GitHub Bug report template
 - [ ] Create the KEDA HTTP Add-on release
 - [ ] Prepare & ship the Helm chart
 - [ ] Publish on Artifact Hub ([repo](https://github.com/kedacore/external-scalers))


### PR DESCRIPTION
The labels of feature-request template didn't exist, I created needs-triage and changed the other to enhancement.
Freetext field for versions is IMO good enough and avoids us having to update them with every release.


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

