### PR TITLE
fix: reduce OTEL_METRIC_EXPORT_INTERVAL from 1ms to 5s

### DIFF
--- a/config/e2e/otel/interceptor-deployment.yaml
+++ b/config/e2e/otel/interceptor-deployment.yaml
@@ -19,7 +19,7 @@ spec:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://opentelemetry-collector.open-telemetry-system:4318"
             - name: OTEL_METRIC_EXPORT_INTERVAL
-              value: "1"
+              value: "5000" # milliseconds
             - name: OTEL_EXPORTER_OTLP_TRACES_ENABLED
               value: "true"
             - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL

--- a/docs/operate.md
+++ b/docs/operate.md
@@ -16,7 +16,8 @@ When configured, the interceptor proxy can export metrics to a OTEL HTTP collect
 
 The OTEL exporter can be enabled by setting the `OTEL_EXPORTER_OTLP_METRICS_ENABLED` environment variable to `true` on the interceptor deployment (`false` by default). When enabled the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable must also be configured so the exporter knows what collector to send the metrics to (e.g. http://opentelemetry-collector.open-telemetry-system:4318).
 
-If you need to provide any headers such as authentication details in order to utilise your OTEL collector you can add them into the `OTEL_EXPORTER_OTLP_HEADERS` environment variable. The frequency at which the metrics are exported can be configured by setting `OTEL_METRIC_EXPORT_INTERVAL` to the number of seconds you require between each export interval (`30` by default).
+If you need to provide any headers such as authentication details in order to utilise your OTEL collector you can add them into the `OTEL_EXPORTER_OTLP_HEADERS` environment variable.
+The frequency at which the metrics are exported can be configured via the [`OTEL_METRIC_EXPORT_INTERVAL`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader) environment variable, which expects milliseconds and defaults to 60 seconds.
 
 # Configuring TLS for the KEDA HTTP Add-on interceptor proxy
 

--- a/test/e2e/observability/main_test.go
+++ b/test/e2e/observability/main_test.go
@@ -21,7 +21,7 @@ func TestMain(m *testing.M) {
 		h.WithEnvVar("OTEL_EXPORTER_OTLP_METRICS_ENABLED", "true"),
 		h.WithEnvVar("OTEL_EXPORTER_OTLP_TRACES_ENABLED", "true"),
 		h.WithEnvVar("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "http/protobuf"),
-		h.WithEnvVar("OTEL_METRIC_EXPORT_INTERVAL", "1"),
+		h.WithEnvVar("OTEL_METRIC_EXPORT_INTERVAL", "5000"), // milliseconds
 	)
 
 	os.Exit(testenv.Run(m))


### PR DESCRIPTION
The OTel SDK interprets OTEL_METRIC_EXPORT_INTERVAL in milliseconds, so a value of "1" means 1ms (not 1s), causing ~1000 exports/second and unnecessary CPU load.

A reduced value of 5s is still useful for faster e2e tests, the default is 60s.
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)
