### PR TITLE
chore: switch whoami test image to ghcr.io

### DIFF
--- a/test/helpers/app.go
+++ b/test/helpers/app.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// renovate: datasource=docker
-	defaultImage = "traefik/whoami:v1.11.0"
+	defaultImage = "ghcr.io/traefik/whoami:v1.11.0"
 	defaultPort  = int32(8080)
 )
 


### PR DESCRIPTION
Docker Hub rate limits cause pull timeouts in CI pipelines.

See https://github.com/kedacore/http-add-on/actions/runs/24193279638/job/70616207571?pr=1562 :
```console
Warning: o:147:   13:52:06 [Warning] Pod/app-a-c8c97595b-hslf2: Failed to pull image "traefik/whoami:v1.11.0": failed to pull and unpack image "docker.io/traefik/whoami:v1.11.0": failed to copy: httpReadSeeker: failed open: unexpected status from GET request to https://registry-1.docker.io/v2/traefik/whoami/manifests/sha256:200689790a0a0ea48ca45992e0450bc26ccab5307375b41c84dfc4f2475937ab: 429 Too Many Requests
        toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit (reason=Failed, count=3)
Warning: o:147:   13:52:06 [Warning] Pod/app-a-c8c97595b-hslf2: Error: ErrImagePull (reason=Failed, count=3)
    env.go:147:   13:52:18 [Normal] Pod/app-a-c8c97595b-hslf2: Back-off pulling image "traefik/whoami:v1.11.0" (reason=BackOff, count=3)
Warning: o:147:   13:52:18 [Warning] Pod/app-a-c8c97595b-hslf2: Error: ImagePullBackOff (reason=Failed, count=3)
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
