### PR TITLE
chore: automate kind version updates via Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -69,6 +69,12 @@
       groupName: "Pre-commit Hooks",
     },
     {
+      matchManagers: ["custom.regex"],
+      matchDepNames: ["/@only-patch/"],
+      matchUpdateTypes: ["minor", "major"],
+      enabled: false,
+    },
+    {
       matchFileNames: [".devcontainer/**"],
       pinDigests: false,
     },
@@ -79,6 +85,13 @@
       managerFilePatterns: ["**/*.go"],
       matchStrings: [
         '// renovate: datasource=(?<datasource>.+?)\\s+\\S+\\s*=\\s*"(?<depName>.+?):(?<currentValue>.+?)"',
+      ],
+    },
+    {
+      customType: "regex",
+      managerFilePatterns: [".github/workflows/**"],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?:\\s+packageName=(?<packageName>\\S+))?\\n\\s+- (?<currentValue>\\S+)',
       ],
     },
   ],

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -23,8 +23,11 @@ jobs:
           - AMD64
           - ARM64
         kindVersion:
+          # renovate: datasource=docker depName=kindest/node
           - v1.35.0
+          # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node
           - v1.34.3
+          # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node
           - v1.33.7
         include:
           - arch: AMD64
@@ -81,8 +84,11 @@ jobs:
           - AMD64
           - ARM64
         kindVersion:
+          # renovate: datasource=docker depName=kindest/node
           - v1.35.0
+          # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node
           - v1.34.3
+          # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node
           - v1.33.7
         include:
           - arch: AMD64


### PR DESCRIPTION
Adds Renovate custom regex manager to keep kind versions in the e2e workflow up to date. The latest track gets all updates, while older tracks use the @only-patch convention to receive only patch updates automatically.

This is similar to how kong does this: https://github.com/search?q=repo%3AKong%2Fkubernetes-ingress-controller+only-patch&type=code

Changes:
- Add Renovate annotations to kindest/node versions in e2e-tests.yaml
- Add custom regex manager for e2e-tests.yaml in renovate.json5
- Add package rule to disable minor/major updates for @only-patch deps


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

