### PR TITLE
feat: add direct pod routing via proxyMode on InterceptorRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 - **General**: Add `InterceptorRoute` CRD to separate routing/interceptor config from scaling config; `HTTPScaledObject` remains supported but will be deprecated in a future release ([#1501](https://github.com/kedacore/http-add-on/issues/1501))
 - **Interceptor**: Add per-route timeout configuration via InterceptorRoute `timeouts` spec with `request`, `responseHeader`, and `readiness` fields. When unset, global env var defaults are used. When a fallback service is configured and no readiness timeout is set, it defaults to 30s. ([#1474](https://github.com/kedacore/http-add-on/issues/1474))
+- **Interceptor**: Add direct pod routing via `spec.proxyMode: Endpoint` on InterceptorRoute. When enabled, the interceptor forwards requests directly to pod IPs discovered from EndpointSlices, bypassing kube-proxy for lower latency. The default (`Service`) routes through Kubernetes Service DNS for service mesh compatibility. ([#TODO](https://github.com/kedacore/http-add-on/pull/1578))
 
 ### Improvements
 

--- a/config/crd/bases/http.keda.sh_interceptorroutes.yaml
+++ b/config/crd/bases/http.keda.sh_interceptorroutes.yaml
@@ -86,6 +86,16 @@ spec:
                 x-kubernetes-validations:
                 - message: '''fallback'' must be set'
                   rule: has(self.fallback)
+              proxyMode:
+                default: Service
+                description: |-
+                  How traffic is forwarded to the backend.
+                  "Service" (default): route via Kubernetes Service DNS (service mesh compatible).
+                  "Endpoint": route directly to pod IPs from EndpointSlices.
+                enum:
+                - Service
+                - Endpoint
+                type: string
               rules:
                 description: Routing rules that define how requests are matched to
                   this target.

--- a/interceptor/middleware/endpoint_resolver.go
+++ b/interceptor/middleware/endpoint_resolver.go
@@ -3,11 +3,19 @@ package middleware
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/kedacore/http-add-on/interceptor/handler"
+	httpv1beta "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
 	kedahttp "github.com/kedacore/http-add-on/pkg/http"
 	"github.com/kedacore/http-add-on/pkg/k8s"
 	"github.com/kedacore/http-add-on/pkg/util"
@@ -18,6 +26,8 @@ const defaultFallbackReadinessTimeout = 30 * time.Second
 type EndpointResolverConfig struct {
 	ReadinessTimeout      time.Duration
 	EnableColdStartHeader bool
+	Reader                client.Reader
+	TLSEnabled            bool
 }
 
 type EndpointResolver struct {
@@ -30,6 +40,8 @@ type EndpointResolver struct {
 // endpoint for each request. It waits for at least one endpoint to become
 // ready (handling cold starts) and optionally falls back to an alternate
 // upstream when the backend does not become ready in time.
+// When the InterceptorRoute's ProxyMode is "Endpoint", it also resolves
+// the upstream URL to a specific pod IP after readiness is confirmed.
 func NewEndpointResolver(next http.Handler, readyCache *k8s.ReadyEndpointsCache, cfg EndpointResolverConfig) *EndpointResolver {
 	return &EndpointResolver{
 		next:       next,
@@ -93,10 +105,91 @@ func (er *EndpointResolver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r = r.WithContext(ctx)
 	}
 
+	// When backend is ready and ProxyMode is Endpoint, override the upstream
+	// URL with a direct pod IP picked from the endpoint cache.
+	if err == nil && ir.Spec.ProxyMode == httpv1beta.ProxyModeEndpoint {
+		endpointURL, resolveErr := er.resolveEndpointURL(ctx, ir)
+		if resolveErr != nil {
+			handler.NewStatic(http.StatusInternalServerError, resolveErr).ServeHTTP(w, r)
+			return
+		}
+		ctx = util.ContextWithUpstreamURL(ctx, endpointURL)
+		r = r.WithContext(ctx)
+	}
+
 	// isColdStart is only meaningful when the backend resolved without errors
 	if err == nil && er.cfg.EnableColdStartHeader {
 		w.Header().Set(kedahttp.HeaderColdStart, strconv.FormatBool(isColdStart))
 	}
 
 	er.next.ServeHTTP(w, r)
+}
+
+// resolveEndpointURL picks a random ready pod from the endpoint cache and
+// returns a URL pointing directly at that pod's IP and container port.
+func (er *EndpointResolver) resolveEndpointURL(ctx context.Context, ir *httpv1beta.InterceptorRoute) (*url.URL, error) {
+	serviceKey := ir.Namespace + "/" + ir.Spec.Target.Service
+	se := er.readyCache.GetEndpoints(serviceKey)
+	if se == nil || len(se.Addresses) == 0 {
+		return nil, fmt.Errorf("no ready endpoints for %s", serviceKey)
+	}
+
+	addr := se.Addresses[rand.IntN(len(se.Addresses))]
+
+	port, err := er.resolveTargetPort(ctx, ir.Spec.Target, ir.Namespace, se)
+	if err != nil {
+		return nil, err
+	}
+
+	scheme := "http"
+	if er.cfg.TLSEnabled {
+		scheme = "https"
+	}
+
+	return &url.URL{
+		Scheme: scheme,
+		Host:   fmt.Sprintf("%s:%d", addr, port),
+	}, nil
+}
+
+// resolveTargetPort determines the container port for direct pod routing.
+// For portName, it looks up the name directly in the cached EndpointSlice ports.
+// For a numeric service port, it reads the Service to find the corresponding targetPort.
+func (er *EndpointResolver) resolveTargetPort(ctx context.Context, target httpv1beta.TargetRef, namespace string, se *k8s.ServiceEndpoints) (int32, error) {
+	if target.PortName != "" {
+		port, ok := se.Ports[target.PortName]
+		if !ok {
+			return 0, fmt.Errorf("port name %q not found in endpoint slices", target.PortName)
+		}
+		return port, nil
+	}
+
+	if target.Port == 0 {
+		return 0, fmt.Errorf(`must specify either "port" or "portName"`)
+	}
+
+	var svc corev1.Service
+	if err := er.cfg.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: target.Service}, &svc); err != nil {
+		return 0, fmt.Errorf("failed to get Service: %w", err)
+	}
+
+	for _, p := range svc.Spec.Ports {
+		if p.Port != target.Port {
+			continue
+		}
+		switch p.TargetPort.Type {
+		case intstr.Int:
+			if p.TargetPort.IntVal > 0 {
+				return p.TargetPort.IntVal, nil
+			}
+			return p.Port, nil
+		case intstr.String:
+			port, ok := se.Ports[p.TargetPort.StrVal]
+			if !ok {
+				return 0, fmt.Errorf("target port name %q not found in endpoint slices", p.TargetPort.StrVal)
+			}
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("port %d not found in Service %s/%s", target.Port, namespace, target.Service)
 }

--- a/interceptor/middleware/endpoint_resolver_test.go
+++ b/interceptor/middleware/endpoint_resolver_test.go
@@ -10,10 +10,14 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	discov1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
+	pkgcache "github.com/kedacore/http-add-on/pkg/cache"
 	kedahttp "github.com/kedacore/http-add-on/pkg/http"
 	"github.com/kedacore/http-add-on/pkg/k8s"
 	"github.com/kedacore/http-add-on/pkg/util"
@@ -400,6 +404,222 @@ func TestEndpointResolver_PerRouteZeroReadinessDisablesGlobal(t *testing.T) {
 	})
 }
 
+// --- Endpoint proxy mode tests ---
+
+func TestEndpointResolver_EndpointMode_ResolvesToPodIP(t *testing.T) {
+	readyCache := k8s.NewReadyEndpointsCache(logr.Discard())
+	addReadyEndpointWithPorts(readyCache)
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewEndpointResolver(next, readyCache, EndpointResolverConfig{
+		ReadinessTimeout: 5 * time.Second,
+	})
+
+	ir := endpointIR()
+	ir.Spec.Target.PortName = "http"
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("expected upstream URL to be set")
+	}
+	if capturedUpstream.Scheme != "http" {
+		t.Fatalf("scheme = %q, want %q", capturedUpstream.Scheme, "http")
+	}
+	// Should be a pod IP, not the Service DNS name
+	if capturedUpstream.Host != "10.0.0.1:8080" && capturedUpstream.Host != "10.0.0.2:8080" {
+		t.Fatalf("host = %q, want one of 10.0.0.1:8080 or 10.0.0.2:8080", capturedUpstream.Host)
+	}
+}
+
+func TestEndpointResolver_EndpointMode_TLS(t *testing.T) {
+	readyCache := k8s.NewReadyEndpointsCache(logr.Discard())
+	addReadyEndpointWithPorts(readyCache)
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewEndpointResolver(next, readyCache, EndpointResolverConfig{
+		ReadinessTimeout: 5 * time.Second,
+		TLSEnabled:       true,
+	})
+
+	ir := endpointIR()
+	ir.Spec.Target.PortName = "http"
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+	mw.ServeHTTP(rec, req)
+
+	if capturedUpstream == nil {
+		t.Fatal("expected upstream URL to be set")
+	}
+	if capturedUpstream.Scheme != "https" {
+		t.Fatalf("scheme = %q, want %q", capturedUpstream.Scheme, "https")
+	}
+}
+
+func TestEndpointResolver_EndpointMode_NumericPort(t *testing.T) {
+	readyCache := k8s.NewReadyEndpointsCache(logr.Discard())
+	addReadyEndpointWithPorts(readyCache)
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testService,
+			Namespace: testNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt32(8080),
+				},
+			},
+		},
+	}
+	fakeReader := fake.NewClientBuilder().WithScheme(pkgcache.NewScheme()).WithObjects(svc).Build()
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewEndpointResolver(next, readyCache, EndpointResolverConfig{
+		ReadinessTimeout: 5 * time.Second,
+		Reader:           fakeReader,
+	})
+
+	ir := endpointIR()
+	ir.Spec.Target.Port = 80
+	ir.Spec.Target.PortName = ""
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("expected upstream URL to be set")
+	}
+	if capturedUpstream.Host != "10.0.0.1:8080" && capturedUpstream.Host != "10.0.0.2:8080" {
+		t.Fatalf("host = %q, want one of 10.0.0.1:8080 or 10.0.0.2:8080", capturedUpstream.Host)
+	}
+}
+
+func TestEndpointResolver_EndpointMode_PortNameNotFound(t *testing.T) {
+	readyCache := k8s.NewReadyEndpointsCache(logr.Discard())
+	addReadyEndpointWithPorts(readyCache)
+
+	var nextCalled bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	})
+
+	mw := NewEndpointResolver(next, readyCache, EndpointResolverConfig{
+		ReadinessTimeout: 5 * time.Second,
+	})
+
+	ir := endpointIR()
+	ir.Spec.Target.PortName = "nonexistent"
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+	mw.ServeHTTP(rec, req)
+
+	if nextCalled {
+		t.Fatal("expected next not to be called when port name is missing")
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestEndpointResolver_ServiceMode_UpstreamUnchanged(t *testing.T) {
+	readyCache := k8s.NewReadyEndpointsCache(logr.Discard())
+	addReadyEndpointWithPorts(readyCache)
+
+	originalURL := &url.URL{Scheme: "http", Host: "testservice.test-namespace:80"}
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewEndpointResolver(next, readyCache, EndpointResolverConfig{
+		ReadinessTimeout: 5 * time.Second,
+	})
+
+	ir := defaultIR()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/test", nil)
+	ctx := util.ContextWithLogger(req.Context(), logr.Discard())
+	ctx = util.ContextWithInterceptorRoute(ctx, ir)
+	ctx = util.ContextWithUpstreamURL(ctx, originalURL)
+	req = req.WithContext(ctx)
+
+	mw.ServeHTTP(rec, req)
+
+	if capturedUpstream == nil {
+		t.Fatal("expected upstream URL to be set")
+	}
+	if *capturedUpstream != *originalURL {
+		t.Fatalf("upstream = %v, want %v (Service mode should not override)", capturedUpstream, originalURL)
+	}
+}
+
+func TestEndpointResolver_EndpointMode_FallbackStillWorks(t *testing.T) {
+	readyCache := k8s.NewReadyEndpointsCache(logr.Discard())
+	// Do not mark ready — simulates backend with no replicas.
+
+	fallbackURL := &url.URL{Host: "fallback"}
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ir := endpointIR()
+	ir.Spec.Target.PortName = "http"
+	ir.Spec.ColdStart = &httpv1beta1.ColdStartSpec{
+		Fallback: &httpv1beta1.TargetRef{Service: "fallback"},
+	}
+
+	mw := NewEndpointResolver(next, readyCache, EndpointResolverConfig{
+		ReadinessTimeout: 25 * time.Millisecond,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+	ctx := util.ContextWithFallbackURL(req.Context(), fallbackURL)
+	req = req.WithContext(ctx)
+
+	mw.ServeHTTP(rec, req)
+
+	if capturedUpstream == nil || *capturedUpstream != *fallbackURL {
+		t.Fatalf("upstream = %v, want fallback %v", capturedUpstream, fallbackURL)
+	}
+}
+
+// --- helpers ---
+
 func newRequest(t *testing.T, ir *httpv1beta1.InterceptorRoute) *http.Request {
 	t.Helper()
 	req := httptest.NewRequest("GET", "/test", nil)
@@ -419,8 +639,35 @@ func defaultIR() *httpv1beta1.InterceptorRoute {
 	}
 }
 
+func endpointIR() *httpv1beta1.InterceptorRoute {
+	return &httpv1beta1.InterceptorRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace},
+		Spec: httpv1beta1.InterceptorRouteSpec{
+			Target:    httpv1beta1.TargetRef{Service: testService, PortName: "http"},
+			ProxyMode: httpv1beta1.ProxyModeEndpoint,
+		},
+	}
+}
+
 func addReadyEndpoint(cache *k8s.ReadyEndpointsCache) {
 	cache.Update(testNamespace+"/"+testService, []*discov1.EndpointSlice{
 		{Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}}},
 	})
 }
+
+func addReadyEndpointWithPorts(cache *k8s.ReadyEndpointsCache) {
+	cache.Update(testNamespace+"/"+testService, []*discov1.EndpointSlice{
+		{
+			Ports: []discov1.EndpointPort{
+				{Name: strPtr("http"), Port: int32Ptr(8080)},
+			},
+			Endpoints: []discov1.Endpoint{
+				{Addresses: []string{"10.0.0.1"}},
+				{Addresses: []string{"10.0.0.2"}},
+			},
+		},
+	})
+}
+
+func strPtr(s string) *string   { return &s }
+func int32Ptr(i int32) *int32   { return &i }

--- a/interceptor/proxy.go
+++ b/interceptor/proxy.go
@@ -79,6 +79,8 @@ func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
 	h = middleware.NewEndpointResolver(h, cfg.ReadyCache, middleware.EndpointResolverConfig{
 		ReadinessTimeout:      cfg.Timeouts.Readiness,
 		EnableColdStartHeader: cfg.Serving.EnableColdStartHeader,
+		Reader:                cfg.Reader,
+		TLSEnabled:            cfg.TLSConfig != nil,
 	})
 
 	h = middleware.NewCounting(h, cfg.Queue, cfg.Instruments)

--- a/operator/apis/http/v1beta1/interceptorroute_types.go
+++ b/operator/apis/http/v1beta1/interceptorroute_types.go
@@ -118,6 +118,19 @@ type TargetRef struct {
 	PortName string `json:"portName,omitzero"`
 }
 
+// ProxyMode controls how the interceptor forwards traffic to the backend.
+// +kubebuilder:validation:Enum=Service;Endpoint
+type ProxyMode string
+
+const (
+	// ProxyModeService routes through the Kubernetes Service ClusterIP / DNS.
+	// This is the default and is compatible with service meshes (Istio, Linkerd, etc.).
+	ProxyModeService ProxyMode = "Service"
+	// ProxyModeEndpoint routes directly to a ready pod IP discovered from EndpointSlices,
+	// bypassing kube-proxy for lower latency.
+	ProxyModeEndpoint ProxyMode = "Endpoint"
+)
+
 // ColdStartSpec configures behavior while the target is not ready.
 // +kubebuilder:validation:XValidation:rule="has(self.fallback)",message="'fallback' must be set"
 type ColdStartSpec struct {
@@ -156,6 +169,12 @@ type InterceptorRouteTimeouts struct {
 type InterceptorRouteSpec struct {
 	// Backend service to route traffic to.
 	Target TargetRef `json:"target"`
+	// How traffic is forwarded to the backend.
+	// "Service" (default): route via Kubernetes Service DNS (service mesh compatible).
+	// "Endpoint": route directly to pod IPs from EndpointSlices.
+	// +optional
+	// +kubebuilder:default="Service"
+	ProxyMode ProxyMode `json:"proxyMode,omitzero"`
 	// Cold start behavior when scaling from zero.
 	// +optional
 	ColdStart *ColdStartSpec `json:"coldStart,omitzero"`

--- a/pkg/k8s/ready_endpoints_cache.go
+++ b/pkg/k8s/ready_endpoints_cache.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -14,14 +13,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ReadyEndpointsCache maintains a derived map of service -> ready (bool)
+// ServiceEndpoints holds the set of ready pod addresses and their port
+// mappings for a single Kubernetes Service. Instances are immutable after
+// creation; updates produce a new snapshot that is atomically swapped in.
+type ServiceEndpoints struct {
+	Addresses []string         // deduplicated ready pod IPs
+	Ports     map[string]int32 // portName -> containerPort ("" for unnamed)
+}
+
+// ReadyEndpointsCache maintains a derived map of service -> ServiceEndpoints
 // for O(1) hot-path lookups, plus a broadcast mechanism so the cold-start
 // wait function can block until a service becomes ready.
 type ReadyEndpointsCache struct {
 	lggr logr.Logger
 
-	// "namespace/service" -> *atomic.Bool
-	ready sync.Map
+	// "namespace/service" -> *atomic.Pointer[ServiceEndpoints]
+	endpoints sync.Map
 
 	// Broadcast mechanism: the channel is closed on any change,
 	// then replaced with a fresh one. Waiters select on the channel.
@@ -40,10 +47,20 @@ func NewReadyEndpointsCache(lggr logr.Logger) *ReadyEndpointsCache {
 // HasReadyEndpoints returns true if the service has at least one ready endpoint.
 // This is the fast hot-path check (one atomic load).
 func (c *ReadyEndpointsCache) HasReadyEndpoints(serviceKey string) bool {
-	if v, ok := c.ready.Load(serviceKey); ok {
-		return v.(*atomic.Bool).Load()
+	if v, ok := c.endpoints.Load(serviceKey); ok {
+		se := v.(*atomic.Pointer[ServiceEndpoints]).Load()
+		return se != nil && len(se.Addresses) > 0
 	}
 	return false
+}
+
+// GetEndpoints returns the current endpoint snapshot for the given service,
+// or nil if the service is unknown or has no endpoint slices.
+func (c *ReadyEndpointsCache) GetEndpoints(serviceKey string) *ServiceEndpoints {
+	if v, ok := c.endpoints.Load(serviceKey); ok {
+		return v.(*atomic.Pointer[ServiceEndpoints]).Load()
+	}
+	return nil
 }
 
 // WaitForReady waits until the service has at least one ready endpoint or
@@ -98,21 +115,28 @@ func (c *ReadyEndpointsCache) WaitForReady(ctx context.Context, serviceKey strin
 	}
 }
 
-// Update checks whether the given service has at least one ready,
-// non-terminating endpoint and stores the result. Short-circuits on
-// the first ready endpoint found. If no slices remain for the service,
-// the key is removed to avoid unbounded map growth.
+// Update rebuilds the endpoint snapshot for the given service from the
+// supplied EndpointSlices. If no slices remain, the key is removed to
+// avoid unbounded map growth.
 func (c *ReadyEndpointsCache) Update(serviceKey string, endpointSlices []*discov1.EndpointSlice) {
 	if len(endpointSlices) == 0 {
-		c.ready.Delete(serviceKey)
+		c.endpoints.Delete(serviceKey)
 		c.broadcast()
 		return
 	}
 
-	hasReady := slices.ContainsFunc(endpointSlices, hasAnyReadyEndpoint)
+	se := buildServiceEndpoints(endpointSlices)
 
-	v, _ := c.ready.LoadOrStore(serviceKey, &atomic.Bool{})
-	if old := v.(*atomic.Bool).Swap(hasReady); old != hasReady {
+	p := &atomic.Pointer[ServiceEndpoints]{}
+	v, loaded := c.endpoints.LoadOrStore(serviceKey, p)
+	if loaded {
+		p = v.(*atomic.Pointer[ServiceEndpoints])
+	}
+
+	old := p.Swap(se)
+	oldReady := old != nil && len(old.Addresses) > 0
+	newReady := len(se.Addresses) > 0
+	if oldReady != newReady {
 		c.broadcast()
 	}
 }
@@ -125,6 +149,44 @@ func (c *ReadyEndpointsCache) broadcast() {
 	c.notifyCh = make(chan struct{})
 	c.mu.Unlock()
 	close(old)
+}
+
+// buildServiceEndpoints collects all ready endpoint addresses and port
+// mappings from the given EndpointSlices into an immutable snapshot.
+func buildServiceEndpoints(slices []*discov1.EndpointSlice) *ServiceEndpoints {
+	addrSet := make(map[string]struct{})
+	ports := make(map[string]int32)
+
+	for _, slice := range slices {
+		for _, p := range slice.Ports {
+			name := ""
+			if p.Name != nil {
+				name = *p.Name
+			}
+			if p.Port != nil {
+				ports[name] = *p.Port
+			}
+		}
+
+		for i := range slice.Endpoints {
+			ep := &slice.Endpoints[i]
+			if (ep.Conditions.Ready == nil || *ep.Conditions.Ready) && len(ep.Addresses) > 0 {
+				for _, addr := range ep.Addresses {
+					addrSet[addr] = struct{}{}
+				}
+			}
+		}
+	}
+
+	addresses := make([]string, 0, len(addrSet))
+	for addr := range addrSet {
+		addresses = append(addresses, addr)
+	}
+
+	return &ServiceEndpoints{
+		Addresses: addresses,
+		Ports:     ports,
+	}
 }
 
 // hasAnyReadyEndpoint returns true if the slice contains at least one

--- a/pkg/k8s/ready_endpoints_cache_test.go
+++ b/pkg/k8s/ready_endpoints_cache_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -122,13 +123,13 @@ func TestUpdateDeletesKeyWhenNoSlices(t *testing.T) {
 	})
 
 	r.True(cache.HasReadyEndpoints(key))
-	_, ok := cache.ready.Load(key)
+	_, ok := cache.endpoints.Load(key)
 	r.True(ok, "key should exist after update with slices")
 
 	cache.Update(key, nil)
 
 	r.False(cache.HasReadyEndpoints(key))
-	_, ok = cache.ready.Load(key)
+	_, ok = cache.endpoints.Load(key)
 	r.False(ok, "key should be removed when service has no slices")
 }
 
@@ -142,7 +143,7 @@ func TestUpdateRetainsKeyForNonReadySlices(t *testing.T) {
 	})
 
 	r.False(cache.HasReadyEndpoints(key))
-	_, ok := cache.ready.Load(key)
+	_, ok := cache.endpoints.Load(key)
 	r.True(ok, "key should remain when slices exist but none are ready")
 }
 
@@ -266,9 +267,138 @@ func TestEndpointSliceFromDeleteObj_InvalidTombstonePayload(t *testing.T) {
 	r.Error(err)
 }
 
+// --- GetEndpoints tests ---
+
+func TestGetEndpoints_Unknown(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	r.Nil(c.GetEndpoints("testns/unknown"))
+}
+
+func TestGetEndpoints_ReturnsSnapshot(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	const key = "testns/testsvc"
+
+	c.Update(key, []*discov1.EndpointSlice{
+		newReadySliceWithPorts("testns", "testsvc",
+			[]discov1.EndpointPort{{Name: ptr.To("http"), Port: ptr.To(int32(8080))}},
+			"10.0.0.1", "10.0.0.2"),
+	})
+
+	se := c.GetEndpoints(key)
+	r.NotNil(se)
+	sort.Strings(se.Addresses)
+	r.Equal([]string{"10.0.0.1", "10.0.0.2"}, se.Addresses)
+	r.Equal(map[string]int32{"http": 8080}, se.Ports)
+}
+
+func TestGetEndpoints_DeduplicatesAddresses(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	const key = "testns/testsvc"
+
+	c.Update(key, []*discov1.EndpointSlice{
+		newReadySliceWithPorts("testns", "testsvc",
+			[]discov1.EndpointPort{{Name: ptr.To("http"), Port: ptr.To(int32(8080))}},
+			"10.0.0.1", "10.0.0.2"),
+		newReadySliceWithPorts("testns", "testsvc",
+			[]discov1.EndpointPort{{Name: ptr.To("http"), Port: ptr.To(int32(8080))}},
+			"10.0.0.2", "10.0.0.3"),
+	})
+
+	se := c.GetEndpoints(key)
+	r.NotNil(se)
+	sort.Strings(se.Addresses)
+	r.Equal([]string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}, se.Addresses)
+}
+
+func TestGetEndpoints_ExcludesNotReady(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	const key = "testns/testsvc"
+
+	slice := &discov1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testsvc-slice", Namespace: "testns",
+			Labels: map[string]string{discov1.LabelServiceName: "testsvc"},
+		},
+		Ports: []discov1.EndpointPort{{Name: ptr.To("http"), Port: ptr.To(int32(8080))}},
+		Endpoints: []discov1.Endpoint{
+			{Addresses: []string{"10.0.0.1"}, Conditions: discov1.EndpointConditions{Ready: ptr.To(true)}},
+			{Addresses: []string{"10.0.0.2"}, Conditions: discov1.EndpointConditions{Ready: ptr.To(false)}},
+		},
+	}
+	c.Update(key, []*discov1.EndpointSlice{slice})
+
+	se := c.GetEndpoints(key)
+	r.NotNil(se)
+	r.Equal([]string{"10.0.0.1"}, se.Addresses)
+}
+
+func TestGetEndpoints_UnnamedPort(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	const key = "testns/testsvc"
+
+	c.Update(key, []*discov1.EndpointSlice{
+		newReadySliceWithPorts("testns", "testsvc",
+			[]discov1.EndpointPort{{Port: ptr.To(int32(9090))}},
+			"10.0.0.1"),
+	})
+
+	se := c.GetEndpoints(key)
+	r.NotNil(se)
+	r.Equal(map[string]int32{"": 9090}, se.Ports)
+}
+
+// --- buildServiceEndpoints tests ---
+
+func TestBuildServiceEndpoints_MultiplePorts(t *testing.T) {
+	r := require.New(t)
+	slices := []*discov1.EndpointSlice{{
+		Ports: []discov1.EndpointPort{
+			{Name: ptr.To("http"), Port: ptr.To(int32(8080))},
+			{Name: ptr.To("grpc"), Port: ptr.To(int32(9090))},
+		},
+		Endpoints: []discov1.Endpoint{
+			{Addresses: []string{"10.0.0.1"}},
+		},
+	}}
+
+	se := buildServiceEndpoints(slices)
+	r.Equal(map[string]int32{"http": 8080, "grpc": 9090}, se.Ports)
+	r.Equal([]string{"10.0.0.1"}, se.Addresses)
+}
+
+func TestBuildServiceEndpoints_EmptySlices(t *testing.T) {
+	r := require.New(t)
+	se := buildServiceEndpoints(nil)
+	r.Empty(se.Addresses)
+	r.Empty(se.Ports)
+}
+
+func TestBuildServiceEndpoints_OnlyNotReadyEndpoints(t *testing.T) {
+	r := require.New(t)
+	slices := []*discov1.EndpointSlice{{
+		Ports: []discov1.EndpointPort{{Name: ptr.To("http"), Port: ptr.To(int32(8080))}},
+		Endpoints: []discov1.Endpoint{
+			{Addresses: []string{"10.0.0.1"}, Conditions: discov1.EndpointConditions{Ready: ptr.To(false)}},
+		},
+	}}
+
+	se := buildServiceEndpoints(slices)
+	r.Empty(se.Addresses)
+	r.Equal(map[string]int32{"http": 8080}, se.Ports)
+}
+
 // --- helpers ---
 
 func newReadySlice(namespace, service string, addresses ...string) *discov1.EndpointSlice {
+	return newReadySliceWithPorts(namespace, service, nil, addresses...)
+}
+
+func newReadySliceWithPorts(namespace, service string, ports []discov1.EndpointPort, addresses ...string) *discov1.EndpointSlice {
 	endpoints := make([]discov1.Endpoint, 0, len(addresses))
 	for _, addr := range addresses {
 		endpoints = append(endpoints, discov1.Endpoint{
@@ -284,6 +414,7 @@ func newReadySlice(namespace, service string, addresses ...string) *discov1.Endp
 				discov1.LabelServiceName: service,
 			},
 		},
+		Ports:     ports,
 		Endpoints: endpoints,
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

When `spec.proxyMode: Endpoint` is set on an InterceptorRoute, the interceptor forwards requests directly to pod IPs discovered from EndpointSlices, bypassing kube-proxy for lower latency and better load balancing control. The default (`Service`) routes through Kubernetes Service DNS, preserving service mesh compatibility.

Key changes:
- Add ProxyMode enum and field to InterceptorRouteSpec CRD
- Rework ReadyEndpointsCache to store pod addresses and port mappings (ServiceEndpoints) instead of a boolean, using atomic.Pointer for lock-free hot-path reads
- Resolve pod URLs in EndpointResolver middleware after WaitForReady succeeds, guaranteeing endpoints exist when one is picked
- Support both portName (direct cache lookup) and numeric port (Service targetPort resolution) for container port discovery

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #
