### PR TITLE
refactor: set Content-Type in interceptor queue endpoint handler

### DIFF
--- a/pkg/queue/queue_rpc.go
+++ b/pkg/queue/queue_rpc.go
@@ -28,28 +28,13 @@ func newSizeHandler(
 		cur, err := q.Current()
 		if err != nil {
 			lggr.Error(err, "getting queue size")
-			w.WriteHeader(500)
-			if _, err := w.Write([]byte(
-				"error getting queue size",
-			)); err != nil {
-				lggr.Error(
-					err,
-					"could not send error message to client",
-				)
-			}
+			http.Error(w, "error getting queue size", http.StatusInternalServerError)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(cur); err != nil {
 			lggr.Error(err, "encoding QueueCounts")
-			w.WriteHeader(500)
-			if _, err := w.Write([]byte(
-				"error encoding queue counts",
-			)); err != nil {
-				lggr.Error(
-					err,
-					"could not send error message to client",
-				)
-			}
+			http.Error(w, "error encoding queue counts", http.StatusInternalServerError)
 			return
 		}
 	})


### PR DESCRIPTION
The queue counts endpoint did not set Content-Type: application/json, causing clients to receive text/plain, I noticed this while looking at the queue endpoint in the browser.
The error path for JSON encoding failures also attempted to set a 500 status after the response had already started writing, which was a no-op (headers cant be set once body is written).

This is mostly cosmetic and doesn't change behavior but makes debugging/inspecting this endpoint in the browser easier.

### Changes
- Set Content-Type: application/json before writing JSON response
- Use http.Error() for the Current() error path
- Remove unreachable error handling after partial JSON write

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)


