### PR TITLE
ci: reduce lychee link checker flakiness

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -28,17 +28,5 @@ jobs:
         with:
           args: >
             --root-dir "${{ github.workspace }}"
-            --cache --max-cache-age 1d
-            --max-concurrency 6
-            --max-retries 6
-            --retry-wait-time 2
-            --timeout 30
             --github-token ${{ secrets.GITHUB_TOKEN }}
-            --exclude '^https://github\.com/kedacore/http-add-on/pkgs/container/http-add-on-interceptor$'
-            --exclude '^https://github\.com/kedacore/http-add-on/pkgs/container/http-add-on-operator$'
-            --exclude '^https://github\.com/kedacore/http-add-on/pkgs/container/http-add-on-scaler$'
-            --exclude '^http://opentelemetry-collector\.open-telemetry-system:4318$'
-            --exclude '^http://opentelemetry-collector\.open-telemetry-system:4318/$'
-            --exclude '^http://opentelemetry-collector\.open-telemetry-system:4318/v1/traces$'
-            --exclude '^https://www\.gnu\.org/software/make/$'
             "./**/*.md"

--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,5 @@ admin/Cargo.lock
 /certs/
 
 *.test
+
+.lycheecache

--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,9 @@ lint:
 lint-fix:
 	golangci-lint run --fix
 
+check-links:
+	lychee "./**/*.md"
+
 pre-commit: ## Run static-checks.
 	pre-commit run --all-files
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,9 @@
+cache = true         # default: false
+max_cache_age = "7d" # default: 1d
+max_concurrency = 6  # default: 128
+max_retries = 6      # default: 3
+retry_wait_time = 10 # default: 1s; survive transient network failures
+
+exclude = [
+  '^http://opentelemetry-collector\.open-telemetry-system:4318',
+]


### PR DESCRIPTION
I see link checking failures quite often, see e.g. https://github.com/kedacore/http-add-on/actions/runs/24560126202/job/71806415970 .
The reason is basically always "Network error: Connection failed" which a retry fixes indicating that the retries lychee does are happening in a too short time.

### Changes
- Rename linkinator.yaml to check-links.yaml (linkinator was the previous tool)
- Extract lychee config into lychee.toml for local runs
- Increase retry-wait-time from 1s to 10s (6 retries = 60s window)
- Increase max-cache-age from 1d to 7d to reduce redundant external requests
- Add .lycheecache to .gitignore
- Only exclude unreachable URLs


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
