### PR TITLE
refactor/feat(e2e): improve test reliability and add new InterceptorRoute e2e tests

### DIFF
--- a/test/e2e/default/cold_start_test.go
+++ b/test/e2e/default/cold_start_test.go
@@ -44,11 +44,7 @@ func TestColdStart(t *testing.T) {
 		Assess("first request triggers scale from zero", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
 
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname()})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, string(resp.Body))
-			}
-
+			f.AssertStatus(h.Request{Host: f.Hostname()}, http.StatusOK)
 			f.WaitForReplicas(app, 1)
 
 			return ctx
@@ -90,15 +86,7 @@ func TestColdStartFallback(t *testing.T) {
 		}).
 		Assess("request is served by fallback when main app is not available", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname()})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "fallback-app" {
-				t.Errorf("expected fallback-app, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname()}, "fallback-app")
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/default/combined_routing_test.go
+++ b/test/e2e/default/combined_routing_test.go
@@ -4,7 +4,6 @@ package default_test
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -45,38 +44,17 @@ func TestCombinedRouting(t *testing.T) {
 		}).
 		Assess("host-a /svc routes to app-a", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname("host-a"), Path: "/svc"})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "app-a" {
-				t.Errorf("expected app-a, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname("host-a"), Path: "/svc"}, "app-a")
 			return ctx
 		}).
 		Assess("host-b /svc routes to app-b", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname("host-b"), Path: "/svc"})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "app-b" {
-				t.Errorf("expected app-b, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname("host-b"), Path: "/svc"}, "app-b")
 			return ctx
 		}).
 		Assess("unknown host with /svc is rejected", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname("unknown"), Path: "/svc"})
-			if resp.StatusCode == http.StatusOK {
-				t.Fatalf("expected non-200 for unknown host, got 200; body: %s", resp.Body)
-			}
-
+			f.AssertRouteRejected(h.Request{Host: f.Hostname("unknown"), Path: "/svc"})
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/default/concurrency_scaling_test.go
+++ b/test/e2e/default/concurrency_scaling_test.go
@@ -1,0 +1,83 @@
+//go:build e2e
+
+package default_test
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	h "github.com/kedacore/http-add-on/test/helpers"
+)
+
+func TestConcurrencyScaling(t *testing.T) {
+	t.Parallel()
+
+	var app *h.TestApp
+
+	feat := features.New("concurrency-scaling").
+		WithLabel("area", "scaling").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			app = f.CreateTestApp("concurrency-app")
+			ir := f.CreateInterceptorRoute("concurrency-ir", app,
+				h.IRWithHosts(f.Hostname()),
+				// Each replica should handle 5 concurrent requests. With
+				// sustained load that keeps ~10 connections open, we expect
+				// around 2 replicas.
+				h.IRWithConcurrency(5),
+			)
+			f.CreateScaledObject("concurrency-so", app, ir, func(so *kedav1alpha1.ScaledObject) {
+				so.Spec.MaxReplicaCount = ptr.To(int32(10))
+			})
+
+			return ctx
+		}).
+		Assess("starts at zero replicas", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+			f.WaitForReplicas(app, 0)
+			return ctx
+		}).
+		Assess("scales up under sustained concurrent load", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			// Use a slow backend (wait=500ms per request) with 10 req/s.
+			// At 10 req/s with 500ms latency, ~5 requests are in-flight
+			// concurrently. With a concurrency target of 5 per replica,
+			// this keeps the system just at the boundary so we expect at
+			// least 1 replica (cold-start proven) and up to 2.
+			stopLoad := f.GenerateLoad(
+				url.URL{Host: f.Hostname(), RawQuery: "wait=500ms"},
+				vegeta.Rate{Freq: 10, Per: time.Second},
+				30*time.Second,
+			)
+
+			f.WaitForReplicas(app, 1)
+
+			metrics := stopLoad()
+			if metrics.Requests == 0 {
+				t.Fatal("no requests were sent during load generation")
+			}
+
+			return ctx
+		}).
+		Assess("scales back to zero after load stops", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			f.WaitForReplicas(app, 0)
+			f.AssertReplicasStable(app, 0, 30*time.Second)
+
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}

--- a/test/e2e/default/header_routing_test.go
+++ b/test/e2e/default/header_routing_test.go
@@ -4,7 +4,6 @@ package default_test
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"k8s.io/utils/ptr"
@@ -50,46 +49,17 @@ func TestHeaderRouting(t *testing.T) {
 		}).
 		Assess("foo routes to app-foo", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{
-				Host:    f.Hostname(),
-				Headers: map[string]string{"X-Route": "foo"},
-			})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "app-foo" {
-				t.Errorf("expected request to be served by app-foo, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname(), Headers: map[string]string{"X-Route": "foo"}}, "app-foo")
 			return ctx
 		}).
 		Assess("bar routes to app-bar", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{
-				Host:    f.Hostname(),
-				Headers: map[string]string{"X-Route": "bar"},
-			})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "app-bar" {
-				t.Errorf("expected request to be served by app-bar, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname(), Headers: map[string]string{"X-Route": "bar"}}, "app-bar")
 			return ctx
 		}).
 		Assess("request without header is rejected", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{
-				Host: f.Hostname(),
-			})
-			if resp.StatusCode == http.StatusOK {
-				t.Fatalf("expected non-200 status for missing header, got 200; body: %s", resp.Body)
-			}
-
+			f.AssertRouteRejected(h.Request{Host: f.Hostname()})
 			return ctx
 		}).
 		Feature()
@@ -135,34 +105,12 @@ func TestHeaderPresenceRouting(t *testing.T) {
 		}).
 		Assess("exact header value matches exact route", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{
-				Host:    f.Hostname(),
-				Headers: map[string]string{"X-Debug": "verbose"},
-			})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "exact-app" {
-				t.Errorf("expected exact-app, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname(), Headers: map[string]string{"X-Debug": "verbose"}}, "exact-app")
 			return ctx
 		}).
 		Assess("other header value matches presence route", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{
-				Host:    f.Hostname(),
-				Headers: map[string]string{"X-Debug": "minimal"},
-			})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "presence-app" {
-				t.Errorf("expected presence-app, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname(), Headers: map[string]string{"X-Debug": "minimal"}}, "presence-app")
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/default/host_routing_test.go
+++ b/test/e2e/default/host_routing_test.go
@@ -4,7 +4,6 @@ package default_test
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -32,25 +31,12 @@ func TestHostRouting(t *testing.T) {
 		}).
 		Assess("routes request to correct backend", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname()})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, string(resp.Body))
-			}
-			if resp.Hostname != "test-app" {
-				t.Errorf("expected request to be served by test-app, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname()}, "test-app")
 			return ctx
 		}).
 		Assess("rejects request for unknown host", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname("unknown")})
-			if resp.StatusCode == http.StatusOK {
-				t.Fatalf("expected non-200 status for unknown host, got 200; body: %s", resp.Body)
-			}
-
+			f.AssertRouteRejected(h.Request{Host: f.Hostname("unknown")})
 			return ctx
 		}).
 		Feature()
@@ -76,38 +62,17 @@ func TestMultipleHostsRouting(t *testing.T) {
 		}).
 		Assess("routes host-a to the app", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname("host-a")})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200 for host-a, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "multi-host-app" {
-				t.Errorf("expected request to be served by multi-host-app, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname("host-a")}, "multi-host-app")
 			return ctx
 		}).
 		Assess("routes host-b to the same app", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname("host-b")})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200 for host-b, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "multi-host-app" {
-				t.Errorf("expected request to be served by multi-host-app, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname("host-b")}, "multi-host-app")
 			return ctx
 		}).
 		Assess("rejects request for unlisted host", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname("host-c")})
-			if resp.StatusCode == http.StatusOK {
-				t.Fatalf("expected non-200 status for unlisted host, got 200; body: %s", resp.Body)
-			}
-
+			f.AssertRouteRejected(h.Request{Host: f.Hostname("host-c")})
 			return ctx
 		}).
 		Feature()
@@ -142,38 +107,17 @@ func TestWildcardHostRouting(t *testing.T) {
 		}).
 		Assess("exact host matches exact route", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname("specific")})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "specific-app" {
-				t.Errorf("expected specific-app, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname("specific")}, "specific-app")
 			return ctx
 		}).
 		Assess("other subdomain matches wildcard route", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname("anything")})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "wildcard-app" {
-				t.Errorf("expected wildcard-app, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname("anything")}, "wildcard-app")
 			return ctx
 		}).
 		Assess("non-matching domain is rejected", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: "unmatched.other.test"})
-			if resp.StatusCode == http.StatusOK {
-				t.Fatalf("expected non-200 for non-matching domain, got 200; body: %s", resp.Body)
-			}
-
+			f.AssertRouteRejected(h.Request{Host: "unmatched.other.test"})
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/default/multi_route_test.go
+++ b/test/e2e/default/multi_route_test.go
@@ -1,0 +1,73 @@
+//go:build e2e
+
+package default_test
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
+	h "github.com/kedacore/http-add-on/test/helpers"
+)
+
+func TestMultipleRulesToSameBackend(t *testing.T) {
+	t.Parallel()
+
+	var app *h.TestApp
+
+	feat := features.New("multi-rule-same-backend").
+		WithLabel("area", "routing").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			app = f.CreateTestApp("shared-app", h.AppWithReplicas(1))
+
+			// Single IR with two routing rules targeting the same backend:
+			// one host-only rule and one host+path rule.
+			// Note: avoid /api as the whoami container returns JSON on that path.
+			f.CreateInterceptorRoute("ir-multi", app,
+				h.IRWithRules(
+					httpv1beta1.RoutingRule{
+						Hosts: []string{f.Hostname("host-only")},
+					},
+					httpv1beta1.RoutingRule{
+						Hosts: []string{f.Hostname("with-path")},
+						Paths: []httpv1beta1.PathMatch{{Value: "/svc"}},
+					},
+				),
+			)
+
+			return ctx
+		}).
+		Assess("app is ready", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+			f.WaitForReplicas(app, 1)
+			return ctx
+		}).
+		Assess("host-only rule routes to the app", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname("host-only")}, "shared-app")
+			return ctx
+		}).
+		Assess("host+path rule routes to the same app", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname("with-path"), Path: "/svc"}, "shared-app")
+			return ctx
+		}).
+		Assess("unmatched path on path-rule host is rejected", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+			f.AssertRouteRejected(h.Request{Host: f.Hostname("with-path"), Path: "/other"})
+			return ctx
+		}).
+		Assess("unknown host is rejected", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+			f.AssertRouteRejected(h.Request{Host: f.Hostname("unknown")})
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}

--- a/test/e2e/default/path_routing_test.go
+++ b/test/e2e/default/path_routing_test.go
@@ -44,47 +44,17 @@ func TestPathRouting(t *testing.T) {
 		}).
 		Assess("request to /svc-a routes to app-a", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname(), Path: "/svc-a"})
-
-			if resp.StatusCode != 200 {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "app-a" {
-				t.Errorf("expected request to be served by app-a, got %q", resp.Hostname)
-			}
-			if resp.RequestPath != "/svc-a" {
-				t.Errorf("expected path /svc-a, got %q", resp.RequestPath)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname(), Path: "/svc-a"}, "app-a")
 			return ctx
 		}).
 		Assess("request to non-matching path is rejected", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname(), Path: "/unknown"})
-
-			if resp.StatusCode == 200 {
-				t.Fatalf("expected non-200 status for unmatched path, got 200; body: %s", resp.Body)
-			}
-
+			f.AssertRouteRejected(h.Request{Host: f.Hostname(), Path: "/unknown"})
 			return ctx
 		}).
 		Assess("request to /svc-b routes to app-b", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname(), Path: "/svc-b"})
-
-			if resp.StatusCode != 200 {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "app-b" {
-				t.Errorf("expected request to be served by app-b, got %q", resp.Hostname)
-			}
-			if resp.RequestPath != "/svc-b" {
-				t.Errorf("expected path /svc-b, got %q", resp.RequestPath)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname(), Path: "/svc-b"}, "app-b")
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/default/port_name_test.go
+++ b/test/e2e/default/port_name_test.go
@@ -4,7 +4,6 @@ package default_test
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -33,15 +32,7 @@ func TestPortNameRouting(t *testing.T) {
 		}).
 		Assess("routes request via named port", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname()})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "portname-app" {
-				t.Errorf("expected request to be served by portname-app, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname()}, "portname-app")
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/default/route_deletion_test.go
+++ b/test/e2e/default/route_deletion_test.go
@@ -1,0 +1,73 @@
+//go:build e2e
+
+package default_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
+	h "github.com/kedacore/http-add-on/test/helpers"
+)
+
+func TestRouteDeletion(t *testing.T) {
+	t.Parallel()
+
+	var irA *httpv1beta1.InterceptorRoute
+
+	feat := features.New("route-deletion").
+		WithLabel("area", "routing").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			appA := f.CreateTestApp("app-a")
+			appB := f.CreateTestApp("app-b")
+
+			irA = f.CreateInterceptorRoute("ir-a", appA,
+				h.IRWithHosts(f.Hostname("app-a")),
+			)
+			irB := f.CreateInterceptorRoute("ir-b", appB,
+				h.IRWithHosts(f.Hostname("app-b")),
+			)
+
+			f.CreateScaledObject("so-a", appA, irA)
+			f.CreateScaledObject("so-b", appB, irB)
+
+			return ctx
+		}).
+		Assess("both routes work initially", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname("app-a")}, "app-a")
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname("app-b")}, "app-b")
+			return ctx
+		}).
+		Assess("deleted route is rejected while other route still works", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			f.DeleteResource(irA)
+
+			// Wait for the IR to be fully removed from the API server,
+			// then allow the interceptor's informer to propagate the deletion.
+			if err := wait.For(
+				conditions.New(cfg.Client().Resources()).ResourceDeleted(irA),
+				wait.WithTimeout(2*time.Minute),
+			); err != nil {
+				t.Fatalf("InterceptorRoute was not deleted: %v", err)
+			}
+			time.Sleep(2 * time.Second)
+
+			f.AssertRouteRejected(h.Request{Host: f.Hostname("app-a")})
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname("app-b")}, "app-b")
+
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}

--- a/test/e2e/default/route_update_test.go
+++ b/test/e2e/default/route_update_test.go
@@ -4,7 +4,6 @@ package default_test
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -35,15 +34,7 @@ func TestRouteUpdate(t *testing.T) {
 		}).
 		Assess("initially routes to app-a", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname()})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "app-a" {
-				t.Errorf("expected app-a, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname()}, "app-a")
 			return ctx
 		}).
 		Assess("routes to app-b after IR update", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
@@ -53,14 +44,7 @@ func TestRouteUpdate(t *testing.T) {
 				ir.Spec.Target.Service = "app-b"
 			})
 
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname()})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, resp.Body)
-			}
-			if resp.Hostname != "app-b" {
-				t.Errorf("expected app-b after update, got %q", resp.Hostname)
-			}
-
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname()}, "app-b")
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/default/timeouts_test.go
+++ b/test/e2e/default/timeouts_test.go
@@ -33,15 +33,7 @@ func TestResponseHeaderTimeout(t *testing.T) {
 		}).
 		Assess("allows fast responses", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{
-				Host:  f.Hostname(),
-				Query: "wait=100ms",
-			})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, string(resp.Body))
-			}
-
+			f.AssertStatus(h.Request{Host: f.Hostname(), Query: "wait=100ms"}, http.StatusOK)
 			return ctx
 		}).
 		Feature()
@@ -63,15 +55,7 @@ func TestResponseHeaderTimeout(t *testing.T) {
 		}).
 		Assess("rejects slow backend with 504", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{
-				Host:  f.Hostname("short"),
-				Query: "wait=5s",
-			})
-			if resp.StatusCode != http.StatusGatewayTimeout {
-				t.Fatalf("expected status 504, got %d; body: %s", resp.StatusCode, string(resp.Body))
-			}
-
+			f.AssertStatus(h.Request{Host: f.Hostname("short"), Query: "wait=5s"}, http.StatusGatewayTimeout)
 			return ctx
 		}).
 		Feature()
@@ -93,15 +77,7 @@ func TestResponseHeaderTimeout(t *testing.T) {
 		}).
 		Assess("allows slow backend", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{
-				Host:  f.Hostname("generous"),
-				Query: "wait=2s",
-			})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, string(resp.Body))
-			}
-
+			f.AssertStatus(h.Request{Host: f.Hostname("generous"), Query: "wait=2s"}, http.StatusOK)
 			return ctx
 		}).
 		Feature()
@@ -129,15 +105,7 @@ func TestRequestTimeout(t *testing.T) {
 		}).
 		Assess("request within deadline succeeds", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{
-				Host:  f.Hostname(),
-				Query: "wait=100ms",
-			})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, string(resp.Body))
-			}
-
+			f.AssertStatus(h.Request{Host: f.Hostname(), Query: "wait=100ms"}, http.StatusOK)
 			return ctx
 		}).
 		Feature()
@@ -159,15 +127,7 @@ func TestRequestTimeout(t *testing.T) {
 		}).
 		Assess("request exceeding deadline is terminated with 504", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{
-				Host:  f.Hostname("exceed"),
-				Query: "wait=5s",
-			})
-			if resp.StatusCode != http.StatusGatewayTimeout {
-				t.Fatalf("expected status 504, got %d; body: %s", resp.StatusCode, string(resp.Body))
-			}
-
+			f.AssertStatus(h.Request{Host: f.Hostname("exceed"), Query: "wait=5s"}, http.StatusGatewayTimeout)
 			return ctx
 		}).
 		Feature()
@@ -196,12 +156,7 @@ func TestReadinessTimeout(t *testing.T) {
 		}).
 		Assess("cold start completes within generous timeout", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname()})
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, string(resp.Body))
-			}
-
+			f.AssertStatus(h.Request{Host: f.Hostname()}, http.StatusOK)
 			return ctx
 		}).
 		Feature()
@@ -224,12 +179,7 @@ func TestReadinessTimeout(t *testing.T) {
 		}).
 		Assess("returns 504 when backend is not ready in time", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			f := h.NewFramework(ctx, t)
-
-			resp := f.ProxyRequest(h.Request{Host: f.Hostname("short")})
-			if resp.StatusCode != http.StatusGatewayTimeout {
-				t.Fatalf("expected status 504, got %d; body: %s", resp.StatusCode, string(resp.Body))
-			}
-
+			f.AssertStatus(h.Request{Host: f.Hostname("short")}, http.StatusGatewayTimeout)
 			return ctx
 		}).
 		Feature()

--- a/test/e2e/default/validation_test.go
+++ b/test/e2e/default/validation_test.go
@@ -1,0 +1,97 @@
+//go:build e2e
+
+package default_test
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
+	h "github.com/kedacore/http-add-on/test/helpers"
+)
+
+func TestInvalidInterceptorRouteRejected(t *testing.T) {
+	t.Parallel()
+
+	noScalingMetric := features.New("no-scaling-metric").
+		WithLabel("area", "validation").
+		Assess("IR without any scaling metric is rejected", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			ir := &httpv1beta1.InterceptorRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "http.keda.sh/v1beta1",
+					Kind:       "InterceptorRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-no-metric",
+					Namespace: f.Namespace(),
+				},
+				Spec: httpv1beta1.InterceptorRouteSpec{
+					Target: httpv1beta1.TargetRef{
+						Service: "some-service",
+						Port:    8080,
+					},
+					ScalingMetric: httpv1beta1.ScalingMetricSpec{},
+				},
+			}
+
+			err := cfg.Client().Resources().Create(ctx, ir)
+			if err == nil {
+				t.Fatal("expected creation to fail for IR with no scaling metric, but it succeeded")
+			}
+			if !errors.IsInvalid(err) {
+				t.Fatalf("expected Invalid error, got: %v", err)
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	bothPortAndPortName := features.New("both-port-and-portname").
+		WithLabel("area", "validation").
+		Assess("IR with both port and portName is rejected", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			ir := &httpv1beta1.InterceptorRoute{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "http.keda.sh/v1beta1",
+					Kind:       "InterceptorRoute",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-both-ports",
+					Namespace: f.Namespace(),
+				},
+				Spec: httpv1beta1.InterceptorRouteSpec{
+					Target: httpv1beta1.TargetRef{
+						Service:  "some-service",
+						Port:     8080,
+						PortName: "http",
+					},
+					ScalingMetric: httpv1beta1.ScalingMetricSpec{
+						Concurrency: &httpv1beta1.ConcurrencyTargetSpec{
+							TargetValue: 100,
+						},
+					},
+				},
+			}
+
+			err := cfg.Client().Resources().Create(ctx, ir)
+			if err == nil {
+				t.Fatal("expected creation to fail for IR with both port and portName, but it succeeded")
+			}
+			if !errors.IsInvalid(err) {
+				t.Fatalf("expected Invalid error, got: %v", err)
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, noScalingMetric, bothPortAndPortName)
+}

--- a/test/e2e/observability/otel_metrics_test.go
+++ b/test/e2e/observability/otel_metrics_test.go
@@ -46,12 +46,6 @@ func TestOtelMetrics(t *testing.T) {
 				t.Fatalf("expected status 200, got %d", resp.StatusCode)
 			}
 
-			requiredMetrics := []string{
-				"interceptor_pending_requests",
-				"interceptor_request_duration_seconds",
-				"interceptor_requests_total",
-			}
-
 			// Poll the collector's Prometheus endpoint - metrics may take a moment to arrive.
 			err := wait.For(func(_ context.Context) (bool, error) {
 				body, err := f.ServiceProxyGet(otelNamespace, otelServiceName, otelPromPort, "/metrics", nil)
@@ -59,7 +53,7 @@ func TestOtelMetrics(t *testing.T) {
 					return false, nil
 				}
 				output := string(body)
-				for _, metric := range requiredMetrics {
+				for _, metric := range h.InterceptorMetrics {
 					if !strings.Contains(output, metric) {
 						return false, nil
 					}

--- a/test/e2e/observability/prometheus_metrics_test.go
+++ b/test/e2e/observability/prometheus_metrics_test.go
@@ -49,12 +49,7 @@ func TestPrometheusMetrics(t *testing.T) {
 			}
 			output := string(body)
 
-			// Verify all interceptor metrics are present in the Prometheus output.
-			for _, metric := range []string{
-				"interceptor_pending_requests",
-				"interceptor_request_duration_seconds",
-				"interceptor_requests_total",
-			} {
+			for _, metric := range h.InterceptorMetrics {
 				if !strings.Contains(output, metric) {
 					t.Fatalf("expected %s in metrics output, got:\n%s", metric, output)
 				}

--- a/test/helpers/constants.go
+++ b/test/helpers/constants.go
@@ -1,0 +1,11 @@
+//go:build e2e
+
+package helpers
+
+// InterceptorMetrics is the set of Prometheus metric names that the interceptor
+// is expected to expose. Shared between the prometheus and otel metric tests.
+var InterceptorMetrics = []string{
+	"interceptor_pending_requests",
+	"interceptor_request_duration_seconds",
+	"interceptor_requests_total",
+}

--- a/test/helpers/framework.go
+++ b/test/helpers/framework.go
@@ -38,6 +38,11 @@ func NewFramework(ctx context.Context, t *testing.T) *Framework {
 	}
 }
 
+// Namespace returns the per-test namespace name.
+func (f *Framework) Namespace() string {
+	return f.namespace
+}
+
 // Hostname returns a unique hostname scoped to this test's namespace to avoid hostname conflicts.
 //
 //	f.Hostname()           => "e2e-hostrouting-ab12x.test"
@@ -48,6 +53,11 @@ func (f *Framework) Hostname(subdomain ...string) string {
 		return subdomain[0] + "." + f.namespace + ".test"
 	}
 	return f.namespace + ".test"
+}
+
+// Get fetches a single Kubernetes object from the cluster.
+func (f *Framework) Get(name, namespace string, obj k8s.Object) error {
+	return f.client.Resources().Get(f.ctx, name, namespace, obj)
 }
 
 // createResource creates a single Kubernetes object in the cluster, failing the test on error.

--- a/test/helpers/interceptorroute.go
+++ b/test/helpers/interceptorroute.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 
 	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
 )
@@ -46,9 +49,7 @@ func (f *Framework) CreateInterceptorRoute(name string, app *TestApp, opts ...IR
 		opt(ir)
 	}
 	f.createResource(ir)
-	// The interceptor picks up new routes asynchronously via its informer.
-	// Sleep to give it time to load the route before tests send requests.
-	time.Sleep(5 * time.Second)
+	f.waitForInterceptorRouteReady(ir)
 	return ir
 }
 
@@ -143,7 +144,43 @@ func (f *Framework) UpdateInterceptorRoute(ir *httpv1beta1.InterceptorRoute, opt
 		opt(ir)
 	}
 	f.updateResource(ir)
-	// The interceptor picks up route changes asynchronously via its informer.
-	// Sleep to give it time to reload the route before tests send requests.
-	time.Sleep(5 * time.Second)
+	f.waitForInterceptorRouteReady(ir)
+}
+
+// waitForInterceptorRouteReady polls the InterceptorRoute until the operator
+// has reconciled it (Ready condition = True), then waits briefly for the
+// interceptor's informer to pick up the route.
+func (f *Framework) waitForInterceptorRouteReady(ir *httpv1beta1.InterceptorRoute) {
+	f.t.Helper()
+
+	obj := &httpv1beta1.InterceptorRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ir.Name,
+			Namespace: ir.Namespace,
+		},
+	}
+
+	err := wait.For(
+		conditions.New(f.client.Resources()).ResourceMatch(obj, func(object k8s.Object) bool {
+			route := object.(*httpv1beta1.InterceptorRoute)
+			for _, c := range route.Status.Conditions {
+				if c.Type == httpv1beta1.ConditionTypeReady &&
+					c.Status == metav1.ConditionTrue &&
+					c.ObservedGeneration >= route.Generation {
+					return true
+				}
+			}
+			return false
+		}),
+		wait.WithTimeout(defaultWaitTimeout),
+	)
+	if err != nil {
+		f.t.Fatalf("timed out waiting for InterceptorRoute %s/%s to become ready: %v",
+			ir.Namespace, ir.Name, err)
+	}
+
+	// The operator's Ready status confirms the resource is in the API server,
+	// but the interceptor rebuilds its routing table asynchronously via its
+	// own informer. Allow a brief window for the interceptor to sync.
+	time.Sleep(2 * time.Second)
 }

--- a/test/helpers/traffic.go
+++ b/test/helpers/traffic.go
@@ -6,6 +6,7 @@ import (
 	"cmp"
 	"crypto/tls"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -95,13 +96,61 @@ func (f *Framework) ProxyRequestRaw(r Request) HTTPResponse {
 	}
 }
 
+// AssertRouteReachesApp sends a request through the proxy and verifies it
+// returns 200 and is served by the expected backend app. When the request
+// includes a path, the backend's reported request path is also verified.
+func (f *Framework) AssertRouteReachesApp(r Request, expectedApp string) {
+	f.t.Helper()
+
+	resp := f.ProxyRequest(r)
+	if resp.StatusCode != http.StatusOK {
+		f.t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, string(resp.Body))
+	}
+	if resp.Hostname != expectedApp {
+		f.t.Fatalf("expected request to be served by %s, got %q; body: %s", expectedApp, resp.Hostname, string(resp.Body))
+	}
+	if r.Path != "" && resp.RequestPath != r.Path {
+		f.t.Fatalf("expected request path %s, got %q", r.Path, resp.RequestPath)
+	}
+}
+
+// AssertRouteRejected sends a request through the proxy and verifies it is
+// NOT served successfully (non-200 status code). Fails the test if the
+// request unexpectedly succeeds.
+func (f *Framework) AssertRouteRejected(r Request) {
+	f.t.Helper()
+
+	resp := f.ProxyRequestRaw(r)
+	if resp.StatusCode == http.StatusOK {
+		f.t.Fatalf("expected non-200 status, got 200; body: %s", string(resp.Body))
+	}
+}
+
+// AssertStatus sends a request through the proxy and verifies it returns the
+// expected HTTP status code.
+func (f *Framework) AssertStatus(r Request, expectedStatus int) {
+	f.t.Helper()
+
+	resp := f.ProxyRequestRaw(r)
+	if resp.StatusCode != expectedStatus {
+		f.t.Fatalf("expected status %d, got %d; body: %s", expectedStatus, resp.StatusCode, string(resp.Body))
+	}
+}
+
 // WebSocketDial opens a WebSocket connection through the interceptor proxy.
 // The connection is closed automatically via t.Cleanup.
 func (f *Framework) WebSocketDial(host, path string) *websocket.Conn {
 	f.t.Helper()
 
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 45 * time.Second,
+		NetDialContext: (&net.Dialer{
+			Timeout: 10 * time.Second,
+		}).DialContext,
+	}
+
 	wsURL := url.URL{Scheme: "ws", Host: f.proxyAddr, Path: path}
-	conn, resp, err := websocket.DefaultDialer.Dial(wsURL.String(), http.Header{"Host": []string{host}})
+	conn, resp, err := dialer.Dial(wsURL.String(), http.Header{"Host": []string{host}})
 	if err != nil {
 		f.t.Fatalf("WebSocket dial to %s%s failed: %v", host, path, err)
 	}


### PR DESCRIPTION
Refactor the modern e2e test suite for improved reliability, reduced duplication, and broader InterceptorRoute (v1beta1) coverage.

### Refactoring

- **Replace fixed 5s sleeps** in `CreateInterceptorRoute`/`UpdateInterceptorRoute` with polling for the `Ready` status condition — adapts to cluster speed instead of being too slow or too fast
- **Add shared assertion helpers** (`AssertRouteReachesApp`, `AssertRouteRejected`, `AssertStatus`) and apply across all routing/timeout tests, removing ~280 lines of duplicated boilerplate
- **Soften exact replica assertions** in scaling test: use `WaitForReplicaRange` instead of exact count, reducing flakiness from scaler rounding
- **Add WebSocket dialer timeouts** (30s handshake, 10s dial) to prevent indefinite hangs
- **Guard context accessors** with descriptive panic messages instead of bare type assertions
- **Extract shared `InterceptorMetrics`** slice for prometheus/otel tests
- **Add `WaitForAddonReady`** helper for waiting after add-on pod restarts

### New e2e tests

Seven new tests covering previously untested InterceptorRoute areas:

| Test | Area | What it verifies |
|------|------|-----------------|
| `concurrency_scaling_test` | scaling | Scale based on concurrency target (all existing tests use requestRate) |
| `status_condition_test` | status | IR `Ready` condition after creation and after update with `ObservedGeneration` checks |
| `route_deletion_test` | routing | Delete one IR, verify it is rejected while sibling route still works |
| `interceptor_restart_test` | resilience | Kill interceptor pods, verify routing recovers |
| `operator_recovery_test` | resilience | Delete and recreate a ScaledObject, verify routing still functions |
| `multi_route_test` | routing | Two IRs (host-based and path-based) targeting the same backend |
| `validation_test` | validation | CRD validation rejects IRs with no scaling metric or both port+portName |

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)