### PR TITLE
feat(interceptor): add direct-to-pod routing for upstreams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,13 @@ This changelog keeps track of work items that have been completed and are ready 
 ### New
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Interceptor**: Add `KEDA_HTTP_DIRECT_POD_ROUTING` environment variable (`true` | `false`, default `false`). When enabled, the interceptor routes requests directly to a ready pod IP instead of through the Service ClusterIP, bypassing kube-proxy and other Service-layer features (Service-level NetworkPolicy, session affinity, topology-aware routing). ([#1473](https://github.com/kedacore/http-add-on/issues/1473))
 
 ### Improvements
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Interceptor**: The forwarding transport sets TLS `ServerName` per-dial via `DialTLSContext`, using the original service hostname captured in context, so SNI stays correct when the upstream URL is rewritten to a pod IP. ([#1473](https://github.com/kedacore/http-add-on/issues/1473))
+- **Interceptor**: TLS server name is captured in context by the routing middleware before any URL rewrites, so downstream transports always use the original service hostname for SNI. The routing middleware also resolves the upstream named port into context to drive direct-pod target selection. ([#1473](https://github.com/kedacore/http-add-on/issues/1473))
+- **Interceptor**: `ReadyEndpointsCache` now tracks full `(ip, port)` pairs per named port from EndpointSlices, enabling direct-pod routing (replaces the previous bool-only ready state). ([#1473](https://github.com/kedacore/http-add-on/issues/1473))
 
 ### Fixes
 

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -53,6 +53,10 @@ type Serving struct {
 	EnableColdStartHeader bool `env:"KEDA_HTTP_ENABLE_COLD_START_HEADER" envDefault:"true"`
 	// LogRequests enables/disables logging of incoming requests
 	LogRequests bool `env:"KEDA_HTTP_LOG_REQUESTS" envDefault:"false"`
+	// DirectPodOnColdStart routes requests directly to a ready pod IP (instead of
+	// the ClusterIP service) when a cold start is detected. Use this when the
+	// service mesh sidecar may not be ready at pod startup time.
+	DirectPodOnColdStart bool `env:"KEDA_HTTP_DIRECT_POD_ON_COLD_START" envDefault:"false"`
 }
 
 // MustParseServing parses standard configs and returns the

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -65,6 +65,10 @@ type Serving struct {
 	// server continues serving in-flight and new requests, giving Kubernetes
 	// time to propagate endpoint removal.
 	ShutdownDelay time.Duration `env:"KEDA_HTTP_SHUTDOWN_DELAY" envDefault:"5s"`
+	// DirectPodRouting routes requests to a ready pod IP instead of the Service
+	// ClusterIP, bypassing kube-proxy and other Service-layer features
+	// (NetworkPolicy, session affinity, topology-aware routing). Single-stack only.
+	DirectPodRouting bool `env:"KEDA_HTTP_DIRECT_POD_ROUTING" envDefault:"false"`
 }
 
 // MustParseServing parses standard configs and returns the

--- a/interceptor/middleware/endpoint_resolver.go
+++ b/interceptor/middleware/endpoint_resolver.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -18,6 +19,7 @@ const defaultFallbackReadinessTimeout = 30 * time.Second
 type EndpointResolverConfig struct {
 	ReadinessTimeout      time.Duration
 	EnableColdStartHeader bool
+	DirectPodOnColdStart  bool // route to pod IP directly during cold start
 }
 
 type EndpointResolver struct {
@@ -96,6 +98,21 @@ func (er *EndpointResolver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// isColdStart is only meaningful when the backend resolved without errors
 	if err == nil && er.cfg.EnableColdStartHeader {
 		w.Header().Set(kedahttp.HeaderColdStart, strconv.FormatBool(isColdStart))
+	}
+
+	// Direct-to-pod routing: only during cold start, rewrite the upstream URL
+	// to a pod IP so the request bypasses the ClusterIP service. This is useful
+	// when the `iptables-min-sync-period` is high.
+	if isColdStart && er.cfg.DirectPodOnColdStart {
+		if podIP, podPort, ok := er.readyCache.PickReadyEndpoint(serviceKey, ir.Spec.Target.PortName); ok {
+			if upstreamURL := util.UpstreamURLFromContext(ctx); upstreamURL != nil {
+				podURL := *upstreamURL
+				podURL.Host = net.JoinHostPort(podIP, strconv.Itoa(int(podPort)))
+				ctx = util.ContextWithUpstreamURL(ctx, &podURL)
+				r = r.WithContext(ctx)
+			}
+		}
+		// ok=false (ambiguous multi-port or unknown portName) → ClusterIP URL unchanged
 	}
 
 	er.next.ServeHTTP(w, r)

--- a/interceptor/middleware/endpoint_resolver.go
+++ b/interceptor/middleware/endpoint_resolver.go
@@ -18,6 +18,7 @@ const defaultFallbackReadinessTimeout = 30 * time.Second
 type EndpointResolverConfig struct {
 	ReadinessTimeout      time.Duration
 	EnableColdStartHeader bool
+	DirectPodRouting      bool // route every request to a pod IP instead of the ClusterIP service
 }
 
 type EndpointResolver struct {
@@ -64,7 +65,7 @@ func (er *EndpointResolver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	serviceKey := ir.Namespace + "/" + ir.Spec.Target.Service
-	isColdStart, err := er.readyCache.WaitForReady(waitCtx, serviceKey)
+	isColdStart, podHost, err := er.readyCache.WaitForReady(waitCtx, serviceKey, util.UpstreamPortNameFromContext(ctx))
 	if err != nil {
 		// No fallback, return an error
 		if !hasFallback {
@@ -90,12 +91,27 @@ func (er *EndpointResolver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Fall back to alternate upstream.
 		fallbackURL := util.FallbackURLFromContext(ctx)
 		ctx = util.ContextWithUpstreamURL(ctx, fallbackURL)
+		// Swapping to the fallback URL: refresh the SNI so TLS doesn't present
+		// the primary service's hostname (HTTP ignores ServerName).
+		if fallbackURL.Scheme == "https" {
+			ctx = util.ContextWithUpstreamServerName(ctx, fallbackURL.Hostname())
+		}
 		r = r.WithContext(ctx)
-	}
+	} else {
+		if er.cfg.EnableColdStartHeader {
+			w.Header().Set(kedahttp.HeaderColdStart, strconv.FormatBool(isColdStart))
+		}
 
-	// isColdStart is only meaningful when the backend resolved without errors
-	if err == nil && er.cfg.EnableColdStartHeader {
-		w.Header().Set(kedahttp.HeaderColdStart, strconv.FormatBool(isColdStart))
+		// Direct-pod routing: rewrite upstream to the pod IP (SNI stays the
+		// service hostname from context). Empty podHost leaves the URL as-is.
+		if er.cfg.DirectPodRouting && podHost != "" {
+			if upstreamURL := util.UpstreamURLFromContext(ctx); upstreamURL != nil {
+				podURL := *upstreamURL
+				podURL.Host = podHost
+				ctx = util.ContextWithUpstreamURL(ctx, &podURL)
+				r = r.WithContext(ctx)
+			}
+		}
 	}
 
 	er.next.ServeHTTP(w, r)

--- a/interceptor/middleware/endpoint_resolver_test.go
+++ b/interceptor/middleware/endpoint_resolver_test.go
@@ -424,3 +424,245 @@ func addReadyEndpoint(cache *k8s.ReadyEndpointsCache) {
 		{Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}}},
 	})
 }
+
+func addReadyEndpointWithPort(cache *k8s.ReadyEndpointsCache, port int32) {
+	cache.Update(testNamespace+"/"+testService, []*discov1.EndpointSlice{
+		{
+			Ports:     []discov1.EndpointPort{{Port: &port}},
+			Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+		},
+	})
+}
+
+func addReadyEndpointWithNamedPorts(cache *k8s.ReadyEndpointsCache, ports []discov1.EndpointPort) {
+	cache.Update(testNamespace+"/"+testService, []*discov1.EndpointSlice{
+		{
+			Ports:     ports,
+			Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+		},
+	})
+}
+
+// TestEndpointResolver_DirectPodOnColdStart_UsedOnColdStart verifies that when
+// DirectPodOnColdStart=true and the backend undergoes a cold start, the upstream
+// URL is rewritten to the pod IP:containerPort.
+func TestEndpointResolver_DirectPodOnColdStart_UsedOnColdStart(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+	// Start with no ready endpoints to force a cold start.
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout:     2 * time.Second,
+		DirectPodOnColdStart: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, defaultIR())
+
+	// Add endpoint with a known container port after the middleware starts waiting.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		addReadyEndpointWithPort(cache, 8080)
+	}()
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	if capturedUpstream.Host != "1.2.3.4:8080" {
+		t.Fatalf("upstream host = %q, want %q", capturedUpstream.Host, "1.2.3.4:8080")
+	}
+}
+
+// TestEndpointResolver_DirectPodOnColdStart_MultiPort verifies that when the pod
+// exposes multiple ports (e.g. metrics first, server second), direct-pod routing
+// picks the container port that matches the InterceptorRoute's PortName — not
+// whatever happens to be first in the EndpointSlice.
+func TestEndpointResolver_DirectPodOnColdStart_MultiPort(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+
+	metricsName := "metrics"
+	metricsPort := int32(9090)
+	httpName := "http"
+	httpPort := int32(8080)
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ir := defaultIR()
+	ir.Spec.Target.PortName = "http"
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout:     2 * time.Second,
+		DirectPodOnColdStart: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+
+	// metrics port is listed first; server port (http) is second.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		addReadyEndpointWithNamedPorts(cache, []discov1.EndpointPort{
+			{Name: &metricsName, Port: &metricsPort},
+			{Name: &httpName, Port: &httpPort},
+		})
+	}()
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	if capturedUpstream.Host != "1.2.3.4:8080" {
+		t.Fatalf("upstream host = %q, want %q — should route to http port, not metrics port",
+			capturedUpstream.Host, "1.2.3.4:8080")
+	}
+}
+
+// TestEndpointResolver_DirectPodOnColdStart_EmptyPortName verifies that when the
+// InterceptorRoute uses a numeric Port (PortName="") and the pod has only named
+// ports, direct-pod routing is skipped and the ClusterIP URL is left unchanged.
+func TestEndpointResolver_DirectPodOnColdStart_EmptyPortName(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+
+	httpName := "http"
+	httpPort := int32(8080)
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// IR uses numeric Port — PortName is empty.
+	ir := defaultIR()
+	ir.Spec.Target.PortName = ""
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout:     2 * time.Second,
+		DirectPodOnColdStart: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		addReadyEndpointWithNamedPorts(cache, []discov1.EndpointPort{
+			{Name: &httpName, Port: &httpPort},
+		})
+	}()
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	// PortName="" with only named ports → PickReadyEndpoint returns ok=false →
+	// ClusterIP URL must be left unchanged.
+	if capturedUpstream.Host != "upstream" {
+		t.Fatalf("upstream host = %q, want %q — should not rewrite when PortName is empty",
+			capturedUpstream.Host, "upstream")
+	}
+}
+
+// TestEndpointResolver_DirectPodOnColdStart_UnnamedPort verifies that when the
+// InterceptorRoute uses a numeric Port (PortName="") and the EndpointSlice port
+// is also unnamed (Name==nil), direct-pod routing succeeds because both sides use
+// the "" key.
+func TestEndpointResolver_DirectPodOnColdStart_UnnamedPort(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// IR uses numeric Port — PortName is empty.
+	ir := defaultIR()
+	ir.Spec.Target.PortName = ""
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout:     2 * time.Second,
+		DirectPodOnColdStart: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		// Port with Name==nil → stored under "" in the ports map.
+		addReadyEndpointWithPort(cache, 8080)
+	}()
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	// PortName="" with unnamed EndpointSlice port → lookup succeeds → URL rewritten.
+	if capturedUpstream.Host != "1.2.3.4:8080" {
+		t.Fatalf("upstream host = %q, want %q — unnamed port should match empty PortName",
+			capturedUpstream.Host, "1.2.3.4:8080")
+	}
+}
+
+// TestEndpointResolver_DirectPodOnColdStart_NotUsedOnWarmPath verifies that when
+// DirectPodOnColdStart=true but the backend is already warm (isColdStart=false),
+// the upstream URL is NOT rewritten to the pod IP.
+func TestEndpointResolver_DirectPodOnColdStart_NotUsedOnWarmPath(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+	// Pre-populate so WaitForReady returns immediately with isColdStart=false.
+	addReadyEndpointWithPort(cache, 8080)
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout:     2 * time.Second,
+		DirectPodOnColdStart: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, defaultIR())
+	// upstream URL is set to "upstream" in newRequest
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	// Must still be the original service URL, not the pod IP
+	if capturedUpstream.Host != "upstream" {
+		t.Fatalf("upstream host = %q, want %q (should not be rewritten on warm path)", capturedUpstream.Host, "upstream")
+	}
+}

--- a/interceptor/middleware/endpoint_resolver_test.go
+++ b/interceptor/middleware/endpoint_resolver_test.go
@@ -133,6 +133,105 @@ func TestEndpointResolver_Fallback(t *testing.T) {
 	}
 }
 
+// TestEndpointResolver_DirectPodRouting_DoesNotOverwriteFallback verifies that
+// when the backend never becomes ready and we fall back to the alternate upstream,
+// the direct-to-pod rewrite does not overwrite the fallback URL even when
+// DirectPodRouting is enabled.
+func TestEndpointResolver_DirectPodRouting_DoesNotOverwriteFallback(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+	// Do not mark ready — backend has no replicas, forcing the fallback path.
+
+	fallbackURL := &url.URL{Scheme: "http", Host: "fallback-svc"}
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ir := defaultIR()
+	ir.Spec.ColdStart = &httpv1beta1.ColdStartSpec{
+		Fallback: &httpv1beta1.ColdStartFallback{
+			Service: &httpv1beta1.ServiceRef{Name: "fallback-svc"},
+		},
+	}
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 25 * time.Millisecond,
+		DirectPodRouting: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+	ctx := util.ContextWithFallbackURL(req.Context(), fallbackURL)
+	req = req.WithContext(ctx)
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	if *capturedUpstream != *fallbackURL {
+		t.Fatalf("upstream = %v, want fallback %v — direct-to-pod must not overwrite fallback URL", capturedUpstream, fallbackURL)
+	}
+}
+
+// TestEndpointResolver_DirectPodRouting_DoesNotOverwriteFallback_HTTPS verifies
+// that when the fallback URL is HTTPS and the backend never becomes ready,
+// the SNI server name is updated to the fallback hostname and the direct-to-pod
+// rewrite does not interfere.
+func TestEndpointResolver_DirectPodRouting_DoesNotOverwriteFallback_HTTPS(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+	// Do not mark ready — backend has no replicas, forcing the fallback path.
+
+	fallbackURL := &url.URL{Scheme: "https", Host: "fallback-svc.default:443"}
+
+	var capturedUpstream *url.URL
+	var capturedServerName string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		capturedServerName = util.UpstreamServerNameFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ir := defaultIR()
+	ir.Spec.ColdStart = &httpv1beta1.ColdStartSpec{
+		Fallback: &httpv1beta1.ColdStartFallback{
+			Service: &httpv1beta1.ServiceRef{Name: "fallback-svc"},
+		},
+	}
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 25 * time.Millisecond,
+		DirectPodRouting: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+	// Pre-seed primary server name as Routing middleware would.
+	ctx := util.ContextWithUpstreamServerName(req.Context(), "primary-svc.default")
+	ctx = util.ContextWithFallbackURL(ctx, fallbackURL)
+	req = req.WithContext(ctx)
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	if *capturedUpstream != *fallbackURL {
+		t.Fatalf("upstream = %v, want fallback %v — direct-to-pod must not overwrite fallback URL", capturedUpstream, fallbackURL)
+	}
+	if capturedServerName != "fallback-svc.default" {
+		t.Fatalf("server name = %q, want %q — SNI must be updated to fallback hostname", capturedServerName, "fallback-svc.default")
+	}
+}
+
 func TestEndpointResolver_FallbackConfiguredButUpstreamReady(t *testing.T) {
 	cache := k8s.NewReadyEndpointsCache(logr.Discard())
 	addReadyEndpoint(cache)
@@ -429,6 +528,489 @@ func defaultIR() *httpv1beta1.InterceptorRoute {
 
 func addReadyEndpoint(cache *k8s.ReadyEndpointsCache) {
 	cache.Update(testNamespace+"/"+testService, []*discov1.EndpointSlice{
-		{Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}}},
+		{AddressType: discov1.AddressTypeIPv4, Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}}},
 	})
+}
+
+func addReadyEndpointWithPort(cache *k8s.ReadyEndpointsCache, port int32) {
+	cache.Update(testNamespace+"/"+testService, []*discov1.EndpointSlice{
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       []discov1.EndpointPort{{Port: &port}},
+			Endpoints:   []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+		},
+	})
+}
+
+func addReadyEndpointWithNamedPorts(cache *k8s.ReadyEndpointsCache, ports []discov1.EndpointPort) {
+	cache.Update(testNamespace+"/"+testService, []*discov1.EndpointSlice{
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       ports,
+			Endpoints:   []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+		},
+	})
+}
+
+// TestEndpointResolver_DirectPodRouting_UsedOnColdStart verifies that when
+// DirectPodRouting=true and the backend undergoes a cold start, the upstream
+// URL is rewritten to the pod IP:containerPort. For HTTP upstreams, no server name
+// is set so SNI is not involved.
+func TestEndpointResolver_DirectPodRouting_UsedOnColdStart(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+	// Start with no ready endpoints to force a cold start.
+
+	var capturedUpstream *url.URL
+	var capturedServerName string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		capturedServerName = util.UpstreamServerNameFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 200 * time.Millisecond,
+		DirectPodRouting: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, defaultIR())
+
+	// Add endpoint with a known container port after the middleware starts waiting.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		addReadyEndpointWithPort(cache, 8080)
+	}()
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	if capturedUpstream.Host != "1.2.3.4:8080" {
+		t.Fatalf("upstream host = %q, want %q", capturedUpstream.Host, "1.2.3.4:8080")
+	}
+	// HTTP upstream: Routing middleware sets serverName="" so no SNI is expected.
+	if capturedServerName != "" {
+		t.Fatalf("server name = %q, want %q — HTTP upstream must not set a server name", capturedServerName, "")
+	}
+}
+
+// TestEndpointResolver_DirectPodRouting_UsedOnColdStart_HTTPS verifies that when
+// DirectPodRouting=true and the backend undergoes a cold start with an HTTPS upstream,
+// the upstream URL is rewritten to the pod IP:containerPort and the SNI server name
+// is preserved as the original service hostname.
+func TestEndpointResolver_DirectPodRouting_UsedOnColdStart_HTTPS(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+	// Start with no ready endpoints to force a cold start.
+
+	var capturedUpstream *url.URL
+	var capturedServerName string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		capturedServerName = util.UpstreamServerNameFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 200 * time.Millisecond,
+		DirectPodRouting: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, defaultIR())
+	// Simulate what Routing middleware does for TLS upstreams: set scheme to https
+	// and pre-seed the server name before any URL rewrite.
+	ctx := util.ContextWithUpstreamURL(req.Context(), &url.URL{Scheme: "https", Host: "myservice.default:443"})
+	ctx = util.ContextWithUpstreamServerName(ctx, "myservice.default")
+	req = req.WithContext(ctx)
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		addReadyEndpointWithPort(cache, 8443)
+	}()
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	if capturedUpstream.Host != "1.2.3.4:8443" {
+		t.Fatalf("upstream host = %q, want %q — https upstream should be rewritten to pod IP", capturedUpstream.Host, "1.2.3.4:8443")
+	}
+	if capturedUpstream.Scheme != "https" {
+		t.Fatalf("upstream scheme = %q, want %q — scheme must be preserved", capturedUpstream.Scheme, "https")
+	}
+	if capturedServerName != "myservice.default" {
+		t.Fatalf("server name = %q, want %q — SNI must not be overwritten by pod-IP rewrite", capturedServerName, "myservice.default")
+	}
+}
+
+// TestEndpointResolver_DirectPodRouting_MultiPort verifies that when the pod
+// exposes multiple ports (e.g. metrics first, server second), direct-pod routing
+// picks the container port that matches the InterceptorRoute's PortName — not
+// whatever happens to be first in the EndpointSlice.
+func TestEndpointResolver_DirectPodRouting_MultiPort(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+
+	metricsName := "metrics"
+	metricsPort := int32(9090)
+	httpName := "http"
+	httpPort := int32(8080)
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ir := defaultIR()
+	ir.Spec.Target.PortName = "http"
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 200 * time.Millisecond,
+		DirectPodRouting: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+	// Simulate Routing middleware: portName resolved into context.
+	req = req.WithContext(util.ContextWithUpstreamPortName(req.Context(), ir.Spec.Target.PortName))
+
+	// metrics port is listed first; server port (http) is second.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		addReadyEndpointWithNamedPorts(cache, []discov1.EndpointPort{
+			{Name: &metricsName, Port: &metricsPort},
+			{Name: &httpName, Port: &httpPort},
+		})
+	}()
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	if capturedUpstream.Host != "1.2.3.4:8080" {
+		t.Fatalf("upstream host = %q, want %q — should route to http port, not metrics port",
+			capturedUpstream.Host, "1.2.3.4:8080")
+	}
+}
+
+// TestEndpointResolver_DirectPodRouting_MultiPort_HTTPS verifies that when the
+// upstream is HTTPS and the pod exposes multiple named ports, direct-pod routing
+// picks the correct port by PortName and preserves both the https scheme and the
+// SNI server name captured before the rewrite.
+func TestEndpointResolver_DirectPodRouting_MultiPort_HTTPS(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+
+	metricsName := "metrics"
+	metricsPort := int32(9090)
+	httpName := "http"
+	httpPort := int32(8443)
+
+	var capturedUpstream *url.URL
+	var capturedServerName string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		capturedServerName = util.UpstreamServerNameFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ir := defaultIR()
+	ir.Spec.Target.PortName = "http"
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 200 * time.Millisecond,
+		DirectPodRouting: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+	// Simulate Routing middleware: https upstream + pre-seeded server name + resolved portName.
+	ctx := util.ContextWithUpstreamURL(req.Context(), &url.URL{Scheme: "https", Host: "myservice.default:443"})
+	ctx = util.ContextWithUpstreamServerName(ctx, "myservice.default")
+	ctx = util.ContextWithUpstreamPortName(ctx, ir.Spec.Target.PortName)
+	req = req.WithContext(ctx)
+
+	// metrics port is listed first; http (TLS) port is second.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		addReadyEndpointWithNamedPorts(cache, []discov1.EndpointPort{
+			{Name: &metricsName, Port: &metricsPort},
+			{Name: &httpName, Port: &httpPort},
+		})
+	}()
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	if capturedUpstream.Host != "1.2.3.4:8443" {
+		t.Fatalf("upstream host = %q, want %q — should route to http port, not metrics port", capturedUpstream.Host, "1.2.3.4:8443")
+	}
+	if capturedUpstream.Scheme != "https" {
+		t.Fatalf("upstream scheme = %q, want %q — scheme must be preserved", capturedUpstream.Scheme, "https")
+	}
+	if capturedServerName != "myservice.default" {
+		t.Fatalf("server name = %q, want %q — SNI must not be overwritten by pod-IP rewrite", capturedServerName, "myservice.default")
+	}
+}
+
+// TestEndpointResolver_DirectPodRouting_EmptyPortName verifies that when the
+// InterceptorRoute uses a numeric Port (PortName="") and the pod has only named
+// ports, direct-pod routing is skipped and the ClusterIP URL is left unchanged.
+func TestEndpointResolver_DirectPodRouting_EmptyPortName(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+
+	httpName := "http"
+	httpPort := int32(8080)
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// IR uses numeric Port — PortName is empty.
+	ir := defaultIR()
+	ir.Spec.Target.PortName = ""
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 200 * time.Millisecond,
+		DirectPodRouting: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		addReadyEndpointWithNamedPorts(cache, []discov1.EndpointPort{
+			{Name: &httpName, Port: &httpPort},
+		})
+	}()
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	// PortName="" with only named ports → WaitForReady returns podHost="" →
+	// ClusterIP URL must be left unchanged.
+	if capturedUpstream.Host != "upstream" {
+		t.Fatalf("upstream host = %q, want %q — should not rewrite when PortName is empty",
+			capturedUpstream.Host, "upstream")
+	}
+}
+
+// TestEndpointResolver_DirectPodRouting_EmptyPortName_HTTPS verifies that when
+// the InterceptorRoute uses a numeric Port (PortName="") and the pod has only named
+// ports, direct-pod routing is skipped, the ClusterIP HTTPS URL is left unchanged,
+// and the original SNI server name is preserved.
+func TestEndpointResolver_DirectPodRouting_EmptyPortName_HTTPS(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+
+	httpName := "http"
+	httpPort := int32(8443)
+
+	var capturedUpstream *url.URL
+	var capturedServerName string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		capturedServerName = util.UpstreamServerNameFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// IR uses numeric Port — PortName is empty.
+	ir := defaultIR()
+	ir.Spec.Target.PortName = ""
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 200 * time.Millisecond,
+		DirectPodRouting: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+	// Simulate Routing middleware: https ClusterIP URL + pre-seeded server name.
+	ctx := util.ContextWithUpstreamURL(req.Context(), &url.URL{Scheme: "https", Host: "myservice.default:443"})
+	ctx = util.ContextWithUpstreamServerName(ctx, "myservice.default")
+	req = req.WithContext(ctx)
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		addReadyEndpointWithNamedPorts(cache, []discov1.EndpointPort{
+			{Name: &httpName, Port: &httpPort},
+		})
+	}()
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	// PortName="" with only named ports → podHost="" → ClusterIP URL must be left unchanged.
+	if capturedUpstream.Host != "myservice.default:443" {
+		t.Fatalf("upstream host = %q, want %q — should not rewrite when PortName is empty", capturedUpstream.Host, "myservice.default:443")
+	}
+	if capturedUpstream.Scheme != "https" {
+		t.Fatalf("upstream scheme = %q, want %q — scheme must be preserved", capturedUpstream.Scheme, "https")
+	}
+	// Server name must be unchanged since the URL was not rewritten.
+	if capturedServerName != "myservice.default" {
+		t.Fatalf("server name = %q, want %q — SNI must be preserved when ClusterIP fallback is used", capturedServerName, "myservice.default")
+	}
+}
+
+// TestEndpointResolver_DirectPodRouting_UnnamedPort verifies that when the
+// InterceptorRoute uses a numeric Port (PortName="") and the EndpointSlice port
+// is also unnamed (Name==nil), direct-pod routing succeeds because both sides use
+// the "" key.
+func TestEndpointResolver_DirectPodRouting_UnnamedPort(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// IR uses numeric Port — PortName is empty.
+	ir := defaultIR()
+	ir.Spec.Target.PortName = ""
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 200 * time.Millisecond,
+		DirectPodRouting: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, ir)
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		// Port with Name==nil → stored under "" in the ports map.
+		addReadyEndpointWithPort(cache, 8080)
+	}()
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	// PortName="" with unnamed EndpointSlice port → lookup succeeds → URL rewritten.
+	if capturedUpstream.Host != "1.2.3.4:8080" {
+		t.Fatalf("upstream host = %q, want %q — unnamed port should match empty PortName",
+			capturedUpstream.Host, "1.2.3.4:8080")
+	}
+}
+
+// TestEndpointResolver_DirectPodRouting_HTTPSUpstream verifies that when the
+// upstream is HTTPS (TLS-enabled proxy), the pod-IP rewrite still happens.
+// SNI is handled by the transport pool using the service hostname captured
+// before this rewrite, so the HTTPS scheme alone must not block the rewrite.
+func TestEndpointResolver_DirectPodRouting_HTTPSUpstream(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+
+	var capturedUpstream *url.URL
+	var capturedServerName string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		capturedServerName = util.UpstreamServerNameFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 200 * time.Millisecond,
+		DirectPodRouting: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, defaultIR())
+	// Simulate TLS-enabled upstream: scheme is https.
+	// Also pre-seed the server name as the Routing middleware would before any URL rewrite.
+	ctx := util.ContextWithUpstreamURL(req.Context(), &url.URL{Scheme: "https", Host: "myservice.default:443"})
+	ctx = util.ContextWithUpstreamServerName(ctx, "myservice.default")
+	req = req.WithContext(ctx)
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		addReadyEndpointWithPort(cache, 8443)
+	}()
+
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	if capturedUpstream.Host != "1.2.3.4:8443" {
+		t.Fatalf("upstream host = %q, want %q — https upstream should still be rewritten to pod IP", capturedUpstream.Host, "1.2.3.4:8443")
+	}
+	if capturedUpstream.Scheme != "https" {
+		t.Fatalf("upstream scheme = %q, want %q — scheme must be preserved", capturedUpstream.Scheme, "https")
+	}
+	if capturedServerName != "myservice.default" {
+		t.Fatalf("server name = %q, want %q — SNI must not be overwritten by pod-IP rewrite", capturedServerName, "myservice.default")
+	}
+}
+
+// TestEndpointResolver_DirectPodRouting_UsedOnWarmPath verifies that when
+// DirectPodRouting=true and the backend is already warm, the upstream URL is
+// still rewritten to the pod IP.
+func TestEndpointResolver_DirectPodRouting_UsedOnWarmPath(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+	// Pre-populate so WaitForReady returns immediately with isColdStart=false.
+	addReadyEndpointWithPort(cache, 8080)
+
+	var capturedUpstream *url.URL
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUpstream = util.UpstreamURLFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 200 * time.Millisecond,
+		DirectPodRouting: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, defaultIR())
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedUpstream == nil {
+		t.Fatal("upstream URL should not be nil")
+	}
+	// Must be the pod IP, not the original service URL
+	if capturedUpstream.Host == "upstream" {
+		t.Fatalf("upstream host = %q, want pod IP (should be rewritten on warm path too)", capturedUpstream.Host)
+	}
 }

--- a/interceptor/middleware/routing.go
+++ b/interceptor/middleware/routing.go
@@ -66,6 +66,15 @@ func (rm *Routing) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx = util.ContextWithLogger(ctx, logger.WithName("RoutingMiddleware"))
 	ctx = util.ContextWithInterceptorRoute(ctx, ir)
 	ctx = util.ContextWithUpstreamURL(ctx, url)
+	// Capture the SNI hostname before EndpointResolver may rewrite the URL to a
+	// pod IP. Empty for non-TLS upstreams.
+	serverName := ""
+	if rm.tlsEnabled {
+		serverName = url.Hostname()
+	}
+	ctx = util.ContextWithUpstreamServerName(ctx, serverName)
+	portName := rm.resolveUpstreamPortName(ctx, ir.Spec.Target.AsServiceRef(), ir.Namespace)
+	ctx = util.ContextWithUpstreamPortName(ctx, portName)
 
 	if ir.Spec.ColdStart != nil && ir.Spec.ColdStart.Fallback != nil && ir.Spec.ColdStart.Fallback.Service != nil {
 		fallbackURL, err := rm.resolveUpstreamURL(ctx, *ir.Spec.ColdStart.Fallback.Service, ir.Namespace)
@@ -91,6 +100,31 @@ func (rm *Routing) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	r = r.WithContext(ctx)
 	rm.next.ServeHTTP(w, r)
+}
+
+// resolveUpstreamPortName returns the named port for direct-pod routing, or ""
+// when the port is unnamed or the Service lookup fails ("" matches unnamed
+// EndpointSlice ports).
+func (rm *Routing) resolveUpstreamPortName(ctx context.Context, svc httpv1beta.ServiceRef, namespace string) string {
+	if svc.PortName != "" {
+		return svc.PortName
+	}
+
+	var k8sSvc corev1.Service
+	if err := rm.reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: svc.Name}, &k8sSvc); err != nil {
+		util.LoggerFromContext(ctx).V(1).Info(
+			"failed to look up Service for upstream port name; direct-pod routing may not engage for this request",
+			"namespace", namespace, "service", svc.Name, "err", err.Error(),
+		)
+		return ""
+	}
+
+	for _, port := range k8sSvc.Spec.Ports {
+		if port.Port == svc.Port {
+			return port.Name
+		}
+	}
+	return ""
 }
 
 func (rm *Routing) resolvePort(ctx context.Context, svc httpv1beta.ServiceRef, namespace string) (int32, error) {

--- a/interceptor/middleware/routing_test.go
+++ b/interceptor/middleware/routing_test.go
@@ -17,6 +17,7 @@ import (
 	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
 	"github.com/kedacore/http-add-on/pkg/cache"
 	routingtest "github.com/kedacore/http-add-on/pkg/routing/test"
+	"github.com/kedacore/http-add-on/pkg/util"
 )
 
 const requestTimeout = 60 * time.Second
@@ -127,6 +128,42 @@ var _ = Describe("RoutingMiddleware", func() {
 			})
 		})
 
+		When("route is found with TLS enabled", func() {
+			It("stores the upstream hostname as server name in context", func() {
+				irTLS := &httpv1beta1.InterceptorRoute{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+					Spec: httpv1beta1.InterceptorRouteSpec{
+						Target: httpv1beta1.TargetRef{Service: "my-svc", Port: 8443},
+					},
+				}
+				tlsMiddleware := NewRouting(upstreamHandler, routingTable, client, true, requestTimeout)
+
+				var capturedServerName string
+				upstreamHandler.Handle(path, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					capturedServerName = util.UpstreamServerNameFromContext(r.Context())
+					w.WriteHeader(http.StatusOK)
+				}))
+
+				routingTable.Memory[host] = irTLS
+				tlsMiddleware.ServeHTTP(w, r)
+				Expect(capturedServerName).To(Equal("my-svc.default"))
+			})
+		})
+
+		When("route is found with TLS disabled", func() {
+			It("stores an empty server name in context", func() {
+				var capturedServerName string
+				upstreamHandler.Handle(path, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					capturedServerName = util.UpstreamServerNameFromContext(r.Context())
+					w.WriteHeader(http.StatusOK)
+				}))
+
+				routingTable.Memory[host] = &ir
+				routingMiddleware.ServeHTTP(w, r)
+				Expect(capturedServerName).To(Equal(""))
+			})
+		})
+
 		When("route is found with portName", func() {
 			It("routes to the upstream handler", func() {
 				clientWithSvc := fake.NewClientBuilder().WithScheme(cache.NewScheme()).WithObjects(svc).Build()
@@ -154,6 +191,38 @@ var _ = Describe("RoutingMiddleware", func() {
 				Expect(uh).To(BeTrue())
 				Expect(w.Code).To(Equal(sc))
 				Expect(w.Body.String()).To(Equal(st))
+			})
+		})
+
+		When("route is found with numeric port and the Service has a named port", func() {
+			It("resolves the portName and stores it in context", func() {
+				clientWithSvc := fake.NewClientBuilder().WithScheme(cache.NewScheme()).WithObjects(svc).Build()
+				routingMiddleware = NewRouting(upstreamHandler, routingTable, clientWithSvc, false, requestTimeout)
+
+				irWithNumericPort := &httpv1beta1.InterceptorRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "keda",
+						Namespace: "default",
+					},
+					Spec: httpv1beta1.InterceptorRouteSpec{
+						Target: httpv1beta1.TargetRef{
+							Service: "keda-svc",
+							Port:    80,
+						},
+					},
+				}
+
+				var capturedPortName string
+				upstreamHandler.Handle(path, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					capturedPortName = util.UpstreamPortNameFromContext(r.Context())
+					w.WriteHeader(http.StatusOK)
+				}))
+
+				routingTable.Memory["keda2.sh"] = irWithNumericPort
+				r.Host = "keda2.sh"
+				routingMiddleware.ServeHTTP(w, r)
+				Expect(w.Code).To(Equal(http.StatusOK))
+				Expect(capturedPortName).To(Equal("http"))
 			})
 		})
 

--- a/interceptor/proxy.go
+++ b/interceptor/proxy.go
@@ -79,6 +79,7 @@ func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
 	h = middleware.NewEndpointResolver(h, cfg.ReadyCache, middleware.EndpointResolverConfig{
 		ReadinessTimeout:      cfg.Timeouts.Readiness,
 		EnableColdStartHeader: cfg.Serving.EnableColdStartHeader,
+		DirectPodOnColdStart:  cfg.Serving.DirectPodOnColdStart,
 	})
 
 	h = middleware.NewCounting(h, cfg.Queue, cfg.Instruments)

--- a/interceptor/proxy.go
+++ b/interceptor/proxy.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 
@@ -18,6 +19,7 @@ import (
 	kedanet "github.com/kedacore/http-add-on/pkg/net"
 	"github.com/kedacore/http-add-on/pkg/queue"
 	"github.com/kedacore/http-add-on/pkg/routing"
+	"github.com/kedacore/http-add-on/pkg/util"
 )
 
 // ProxyHandlerConfig contains all dependencies for building the proxy handler chain.
@@ -60,6 +62,10 @@ func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
 			MaxVersion:         cfg.TLSConfig.MaxVersion,
 			CipherSuites:       cfg.TLSConfig.CipherSuites,
 			CurvePreferences:   cfg.TLSConfig.CurvePreferences,
+			// Advertise h2 in ALPN explicitly: a custom TLSClientConfig +
+			// DialTLSContext disables net/http's auto-h2, so without this HTTPS
+			// upstreams (incl. gRPC) downgrade to HTTP/1.1 (golang/go#20645).
+			NextProtos: []string{"h2", "http/1.1"},
 		}
 	}
 
@@ -70,6 +76,12 @@ func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
 	baseTransport.MaxIdleConnsPerHost = cfg.Timeouts.MaxIdleConnsPerHost
 	baseTransport.TLSClientConfig = forwardingTLSCfg
 
+	// Direct-pod routing rewrites the upstream URL to a pod IP, so SNI must come
+	// from context (the original service hostname) rather than the dial address.
+	if forwardingTLSCfg != nil {
+		baseTransport.DialTLSContext = newTLSDialer(forwardingTLSCfg, dialFunc)
+	}
+
 	// Build handler chain (innermost to outermost)
 	var h http.Handler
 
@@ -78,6 +90,7 @@ func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
 	h = middleware.NewEndpointResolver(h, cfg.ReadyCache, middleware.EndpointResolverConfig{
 		ReadinessTimeout:      cfg.Timeouts.Readiness,
 		EnableColdStartHeader: cfg.Serving.EnableColdStartHeader,
+		DirectPodRouting:      cfg.Serving.DirectPodRouting,
 	})
 
 	h = middleware.NewPlaceholder(h, cfg.ReadyCache, cfg.Reader)
@@ -103,4 +116,25 @@ func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
 	}
 
 	return h
+}
+
+// newTLSDialer dials TCP then wraps the conn in TLS, taking ServerName from
+// context (not the dial address, which direct-pod routing rewrites to a pod IP).
+// The SNI should never be empty here as Routing sets it before any https dial;
+// the empty check is just a safety net so we fail closed instead of dialing
+// without an explicit upstream identity.
+func newTLSDialer(tlsCfg *tls.Config, dial func(ctx context.Context, network, addr string) (net.Conn, error)) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		serverName := util.UpstreamServerNameFromContext(ctx)
+		if serverName == "" {
+			return nil, fmt.Errorf("upstream server name missing from context for TLS dial to %s (refusing to dial without explicit SNI)", addr)
+		}
+		conn, err := dial(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		dialed := tlsCfg.Clone()
+		dialed.ServerName = serverName
+		return tls.Client(conn, dialed), nil
+	}
 }

--- a/interceptor/proxy_integration_test.go
+++ b/interceptor/proxy_integration_test.go
@@ -59,7 +59,8 @@ func TestIntegrationHappyPath(t *testing.T) {
 				Namespace: target.Namespace,
 				Labels:    map[string]string{discov1.LabelServiceName: serviceName},
 			},
-			Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+			AddressType: discov1.AddressTypeIPv4,
+			Endpoints:   []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
 		},
 	})
 
@@ -190,7 +191,8 @@ func TestIntegrationWaitReplicas(t *testing.T) {
 					Namespace: target.Namespace,
 					Labels:    map[string]string{discov1.LabelServiceName: serviceName},
 				},
-				Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+				AddressType: discov1.AddressTypeIPv4,
+				Endpoints:   []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
 			},
 		})
 		return nil

--- a/interceptor/proxy_test.go
+++ b/interceptor/proxy_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -26,6 +28,7 @@ import (
 	"github.com/kedacore/http-add-on/pkg/k8s"
 	"github.com/kedacore/http-add-on/pkg/queue"
 	routingtest "github.com/kedacore/http-add-on/pkg/routing/test"
+	"github.com/kedacore/http-add-on/pkg/util"
 )
 
 const (
@@ -40,7 +43,8 @@ var testEndpointSlice = &discov1.EndpointSlice{
 		Namespace: "test-namespace",
 		Labels:    map[string]string{discov1.LabelServiceName: "test-service"},
 	},
-	Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+	AddressType: discov1.AddressTypeIPv4,
+	Endpoints:   []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
 }
 
 func TestProxyHandler_SuccessfulRequest(t *testing.T) {
@@ -401,4 +405,86 @@ func (h *proxyTestHarness) doRequest(t *testing.T, method, path, host string) *h
 	h.Handler.ServeHTTP(rec, req)
 
 	return rec.Result()
+}
+
+// TestNewTLSDialer_UsesServerNameFromContext verifies the happy path: when
+// Routing has stamped UpstreamServerName, the dialer uses it and proceeds
+// with the underlying TCP dial regardless of cert-verification policy.
+func TestNewTLSDialer_UsesServerNameFromContext(t *testing.T) {
+	for _, insecure := range []bool{false, true} {
+		var dialCalled bool
+		stubDial := func(_ context.Context, _, _ string) (net.Conn, error) {
+			dialCalled = true
+			c, _ := net.Pipe()
+			return c, nil
+		}
+		dialer := newTLSDialer(&tls.Config{InsecureSkipVerify: insecure}, stubDial)
+
+		ctx := util.ContextWithUpstreamServerName(context.Background(), "myservice.default")
+		conn, err := dialer(ctx, "tcp", "10.1.2.3:8443")
+		if err != nil {
+			t.Fatalf("InsecureSkipVerify=%v: unexpected error: %v", insecure, err)
+		}
+		if !dialCalled {
+			t.Errorf("InsecureSkipVerify=%v: dial was not called", insecure)
+		}
+		if conn == nil {
+			t.Errorf("InsecureSkipVerify=%v: returned conn was nil", insecure)
+		} else {
+			_ = conn.Close()
+		}
+	}
+}
+
+// TestNewTLSDialer_HardFailsWhenNoSNI verifies the guardrail: a missing SNI
+// must error out without dialing, so we never open a TLS connection without an
+// explicit upstream identity. The error message must name both the dial address
+// and the reason, so operators don't mistake it for an upstream connectivity
+// failure. This holds regardless of InsecureSkipVerify.
+func TestNewTLSDialer_HardFailsWhenNoSNI(t *testing.T) {
+	for _, skipVerify := range []bool{true, false} {
+		var dialCalled bool
+		stubDial := func(_ context.Context, _, _ string) (net.Conn, error) {
+			dialCalled = true
+			return nil, nil
+		}
+		dialer := newTLSDialer(&tls.Config{InsecureSkipVerify: skipVerify}, stubDial)
+
+		conn, err := dialer(context.Background(), "tcp", "10.1.2.3:8443")
+		if err == nil {
+			t.Fatalf("expected error when SNI is missing (InsecureSkipVerify=%v), got nil", skipVerify)
+		}
+		if dialCalled {
+			t.Errorf("dial must not be called when we hard-fail on missing SNI (InsecureSkipVerify=%v)", skipVerify)
+		}
+		if conn != nil {
+			t.Errorf("returned conn must be nil on error (InsecureSkipVerify=%v)", skipVerify)
+		}
+		if !strings.Contains(err.Error(), "10.1.2.3:8443") {
+			t.Errorf("error %q should name the dial address", err)
+		}
+		if !strings.Contains(err.Error(), "refusing to dial without explicit SNI") {
+			t.Errorf("error %q should explain why we refuse to dial", err)
+		}
+	}
+}
+
+// TestNewTLSDialer_PropagatesDialError verifies that errors from the
+// underlying TCP dialer surface unchanged — there's no swallow / wrap that
+// would mask a connection refusal or timeout.
+func TestNewTLSDialer_PropagatesDialError(t *testing.T) {
+	wantErr := errors.New("connection refused")
+	stubDial := func(_ context.Context, _, _ string) (net.Conn, error) {
+		return nil, wantErr
+	}
+	dialer := newTLSDialer(&tls.Config{InsecureSkipVerify: false}, stubDial)
+
+	ctx := util.ContextWithUpstreamServerName(context.Background(), "myservice.default")
+	conn, err := dialer(ctx, "tcp", "10.1.2.3:8443")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if conn != nil {
+		t.Error("returned conn must be nil on dial error")
+	}
 }

--- a/pkg/k8s/ready_endpoints_cache.go
+++ b/pkg/k8s/ready_endpoints_cache.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"slices"
+	"math/rand"
 	"sync"
 	"sync/atomic"
 
@@ -14,14 +14,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ReadyEndpointsCache maintains a derived map of service -> ready (bool)
+// serviceState is an immutable snapshot of a service's ready pod IPs.
+// Replaced atomically on every EndpointSlice event; readers hold a pointer
+// to the old snapshot safely without locks.
+type serviceState struct {
+	ready    bool             // len(readyIPs) > 0
+	readyIPs []string         // K8s-ready pod IPs (deduplicated)
+	ports    map[string]int32 // portName → containerPort from EndpointSlice
+}
+
+func (s *serviceState) hasReady() bool { return s != nil && s.ready }
+
+// ReadyEndpointsCache maintains a derived map of service -> serviceState
 // for O(1) hot-path lookups, plus a broadcast mechanism so the cold-start
 // wait function can block until a service becomes ready.
 type ReadyEndpointsCache struct {
 	lggr logr.Logger
 
-	// "namespace/service" -> *atomic.Bool
-	ready sync.Map
+	// "namespace/service" -> *atomic.Pointer[serviceState]
+	states sync.Map
 
 	// Broadcast mechanism: the channel is closed on any change,
 	// then replaced with a fresh one. Waiters select on the channel.
@@ -40,8 +51,8 @@ func NewReadyEndpointsCache(lggr logr.Logger) *ReadyEndpointsCache {
 // HasReadyEndpoints returns true if the service has at least one ready endpoint.
 // This is the fast hot-path check (one atomic load).
 func (c *ReadyEndpointsCache) HasReadyEndpoints(serviceKey string) bool {
-	if v, ok := c.ready.Load(serviceKey); ok {
-		return v.(*atomic.Bool).Load()
+	if v, ok := c.states.Load(serviceKey); ok {
+		return v.(*atomic.Pointer[serviceState]).Load().hasReady()
 	}
 	return false
 }
@@ -98,21 +109,48 @@ func (c *ReadyEndpointsCache) WaitForReady(ctx context.Context, serviceKey strin
 	}
 }
 
-// Update checks whether the given service has at least one ready,
-// non-terminating endpoint and stores the result. Short-circuits on
-// the first ready endpoint found. If no slices remain for the service,
-// the key is removed to avoid unbounded map growth.
+// PickReadyEndpoint returns a randomly selected ready pod IP and its container
+// port for the given portName. portName must match the EndpointSlice port name
+// (which equals the Service port name). Returns ok=false when no ready pod IPs
+// are known for the service or the portName is not found in the port map.
+func (c *ReadyEndpointsCache) PickReadyEndpoint(serviceKey, portName string) (ip string, port int32, ok bool) {
+	v, exists := c.states.Load(serviceKey)
+	if !exists {
+		return "", 0, false
+	}
+	state := v.(*atomic.Pointer[serviceState]).Load()
+	if !state.hasReady() {
+		return "", 0, false
+	}
+	port, ok = state.ports[portName]
+	if !ok {
+		return "", 0, false
+	}
+	return state.readyIPs[rand.Intn(len(state.readyIPs))], port, true
+}
+
+// Update checks the given EndpointSlices, builds a new serviceState snapshot,
+// and atomically replaces the old one.
 func (c *ReadyEndpointsCache) Update(serviceKey string, endpointSlices []*discov1.EndpointSlice) {
 	if len(endpointSlices) == 0 {
-		c.ready.Delete(serviceKey)
+		c.states.Delete(serviceKey)
 		c.broadcast()
 		return
 	}
 
-	hasReady := slices.ContainsFunc(endpointSlices, hasAnyReadyEndpoint)
+	newState := collectServiceState(endpointSlices)
 
-	v, _ := c.ready.LoadOrStore(serviceKey, &atomic.Bool{})
-	if old := v.(*atomic.Bool).Swap(hasReady); old != hasReady {
+	ptr := &atomic.Pointer[serviceState]{}
+	ptr.Store(newState)
+	actual, loaded := c.states.LoadOrStore(serviceKey, ptr)
+
+	if loaded {
+		oldState := actual.(*atomic.Pointer[serviceState]).Load()
+		actual.(*atomic.Pointer[serviceState]).Store(newState)
+		if oldState.hasReady() != newState.hasReady() {
+			c.broadcast()
+		}
+	} else if newState.hasReady() {
 		c.broadcast()
 	}
 }
@@ -127,19 +165,43 @@ func (c *ReadyEndpointsCache) broadcast() {
 	close(old)
 }
 
-// hasAnyReadyEndpoint returns true if the slice contains at least one
-// ready endpoint with at least one address.
-// Kubernetes guarantees that Ready is false for terminating pods, so a
-// separate Terminating check is unnecessary. For services with
-// publishNotReadyAddresses, Ready is always true — we respect that.
-func hasAnyReadyEndpoint(slice *discov1.EndpointSlice) bool {
-	for i := range slice.Endpoints {
-		ep := &slice.Endpoints[i]
-		if (ep.Conditions.Ready == nil || *ep.Conditions.Ready) && len(ep.Addresses) > 0 {
-			return true
+// collectServiceState extracts ready pod IPs and the container port map from a
+// set of EndpointSlices into an immutable serviceState snapshot.
+// ports maps portName → containerPort; the port name matches Service.spec.ports[i].name.
+// Unnamed ports (Name == nil) are stored under the empty string key.
+func collectServiceState(slices []*discov1.EndpointSlice) *serviceState {
+	seen := make(map[string]struct{})
+	ports := make(map[string]int32)
+	for _, sl := range slices {
+		for _, p := range sl.Ports {
+			if p.Port == nil {
+				continue
+			}
+			name := ""
+			if p.Name != nil {
+				name = *p.Name
+			}
+			if _, exists := ports[name]; !exists {
+				ports[name] = *p.Port
+			}
+		}
+		for i := range sl.Endpoints {
+			ep := &sl.Endpoints[i]
+			// Kubernetes guarantees that Ready is false for terminating pods, so a
+			// separate Terminating check is unnecessary. For services with
+			// publishNotReadyAddresses, Ready is always true — we respect that.
+			if (ep.Conditions.Ready == nil || *ep.Conditions.Ready) && len(ep.Addresses) > 0 {
+				for _, addr := range ep.Addresses {
+					seen[addr] = struct{}{}
+				}
+			}
 		}
 	}
-	return false
+	ips := make([]string, 0, len(seen))
+	for ip := range seen {
+		ips = append(ips, ip)
+	}
+	return &serviceState{ready: len(ips) > 0, readyIPs: ips, ports: ports}
 }
 
 // updateReadyCache updates the ready cache for the service that owns

--- a/pkg/k8s/ready_endpoints_cache.go
+++ b/pkg/k8s/ready_endpoints_cache.go
@@ -3,9 +3,10 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"slices"
+	"math/rand/v2"
+	"net"
+	"strconv"
 	"sync"
-	"sync/atomic"
 
 	"github.com/go-logr/logr"
 	discov1 "k8s.io/api/discovery/v1"
@@ -14,14 +15,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ReadyEndpointsCache maintains a derived map of service -> ready (bool)
+// endpoint is one ready pod: its address paired with the container port from
+// the same EndpointSlice.
+type endpoint struct {
+	ip   string
+	port int32
+}
+
+// serviceState is an immutable snapshot of a service's ready pods, swapped
+// atomically on every EndpointSlice event so readers need no locks.
+type serviceState struct {
+	ready bool // true if the service has at least one ready endpoint
+	// candidates maps portName ("" for unnamed) to its ready pods.
+	candidates map[string][]endpoint
+}
+
+func (s *serviceState) hasReady() bool { return s != nil && s.ready }
+
+// ReadyEndpointsCache maintains a derived map of service -> serviceState
 // for O(1) hot-path lookups, plus a broadcast mechanism so the cold-start
 // wait function can block until a service becomes ready.
 type ReadyEndpointsCache struct {
 	lggr logr.Logger
 
-	// "namespace/service" -> *atomic.Bool
-	ready sync.Map
+	// "namespace/service" -> *serviceState
+	states sync.Map
 
 	// Broadcast mechanism: the channel is closed on any change,
 	// then replaced with a fresh one. Waiters select on the channel.
@@ -40,21 +58,27 @@ func NewReadyEndpointsCache(lggr logr.Logger) *ReadyEndpointsCache {
 // HasReadyEndpoints returns true if the service has at least one ready endpoint.
 // This is the fast hot-path check (one atomic load).
 func (c *ReadyEndpointsCache) HasReadyEndpoints(serviceKey string) bool {
-	if v, ok := c.ready.Load(serviceKey); ok {
-		return v.(*atomic.Bool).Load()
+	if v, ok := c.states.Load(serviceKey); ok {
+		return v.(*serviceState).hasReady()
 	}
 	return false
 }
 
 // WaitForReady waits until the service has at least one ready endpoint or
 // the context is cancelled/timed out.
+//
 // Returns:
-//   - (false, nil)  — warm backend, already ready (fast path)
-//   - (true, nil)   — cold start, but backend became ready
-//   - (false, error) — context cancelled or timed out
-func (c *ReadyEndpointsCache) WaitForReady(ctx context.Context, serviceKey string) (isColdStart bool, err error) {
-	if c.HasReadyEndpoints(serviceKey) {
-		return false, nil
+//   - (false, podHost, nil)  — warm backend, already ready (fast path)
+//   - (true, podHost, nil)   — cold start, backend became ready
+//   - (false, "", error)     — context cancelled or timed out
+//
+// podHost is "ip:port" for portName, or "" when portName has no candidates
+// (signals direct-pod routing isn't possible).
+func (c *ReadyEndpointsCache) WaitForReady(ctx context.Context, serviceKey, portName string) (isColdStart bool, podHost string, err error) {
+	if v, ok := c.states.Load(serviceKey); ok {
+		if state := v.(*serviceState); state.hasReady() {
+			return false, pickHost(state, portName), nil
+		}
 	}
 
 	// Get the current notification channel before re-checking
@@ -65,8 +89,10 @@ func (c *ReadyEndpointsCache) WaitForReady(ctx context.Context, serviceKey strin
 	// Re-check after getting the channel (close the race window).
 	// Return isColdStart=false: we never actually blocked, so this
 	// is still the warm/fast path.
-	if c.HasReadyEndpoints(serviceKey) {
-		return false, nil
+	if v, ok := c.states.Load(serviceKey); ok {
+		if state := v.(*serviceState); state.hasReady() {
+			return false, pickHost(state, portName), nil
+		}
 	}
 
 	c.lggr.V(1).Info("cold-start: waiting for ready endpoints", "key", serviceKey)
@@ -74,15 +100,17 @@ func (c *ReadyEndpointsCache) WaitForReady(ctx context.Context, serviceKey strin
 	for {
 		select {
 		case <-ctx.Done():
-			return false, fmt.Errorf(
+			return false, "", fmt.Errorf(
 				"context done while waiting for ready endpoints for %s: %w",
 				serviceKey, ctx.Err(),
 			)
 
 		case <-ch:
-			if c.HasReadyEndpoints(serviceKey) {
-				c.lggr.Info("cold-start: endpoints became ready", "key", serviceKey)
-				return true, nil
+			if v, ok := c.states.Load(serviceKey); ok {
+				if state := v.(*serviceState); state.hasReady() {
+					c.lggr.Info("cold-start: endpoints became ready", "key", serviceKey)
+					return true, pickHost(state, portName), nil
+				}
 			}
 			// Not our service — get the new channel and re-check
 			// before waiting again to avoid missing a broadcast
@@ -90,29 +118,48 @@ func (c *ReadyEndpointsCache) WaitForReady(ctx context.Context, serviceKey strin
 			c.mu.Lock()
 			ch = c.notifyCh
 			c.mu.Unlock()
-			if c.HasReadyEndpoints(serviceKey) {
-				c.lggr.Info("cold-start: endpoints became ready", "key", serviceKey)
-				return true, nil
+			if v, ok := c.states.Load(serviceKey); ok {
+				if state := v.(*serviceState); state.hasReady() {
+					c.lggr.Info("cold-start: endpoints became ready", "key", serviceKey)
+					return true, pickHost(state, portName), nil
+				}
 			}
 		}
 	}
 }
 
-// Update checks whether the given service has at least one ready,
-// non-terminating endpoint and stores the result. Short-circuits on
-// the first ready endpoint found. If no slices remain for the service,
-// the key is removed to avoid unbounded map growth.
+// pickHost selects a random ready pod for portName from state and returns its
+// "ip:port" host string. Returns "" if portName has no candidates.
+func pickHost(state *serviceState, portName string) string {
+	eps := state.candidates[portName]
+	if len(eps) == 0 {
+		return ""
+	}
+	ep := eps[rand.IntN(len(eps))] //nolint:gosec // G404: math/rand is sufficient for load-balancing endpoint selection
+	return net.JoinHostPort(ep.ip, strconv.Itoa(int(ep.port)))
+}
+
+// Update checks the given EndpointSlices, builds a new serviceState snapshot,
+// and atomically replaces the old one. serviceKey is "namespace/service".
 func (c *ReadyEndpointsCache) Update(serviceKey string, endpointSlices []*discov1.EndpointSlice) {
 	if len(endpointSlices) == 0 {
-		c.ready.Delete(serviceKey)
-		c.broadcast()
+		if v, ok := c.states.LoadAndDelete(serviceKey); ok {
+			if v.(*serviceState).hasReady() {
+				c.broadcast()
+			}
+		}
 		return
 	}
 
-	hasReady := slices.ContainsFunc(endpointSlices, hasAnyReadyEndpoint)
+	newState := collectServiceState(endpointSlices)
+	old, loaded := c.states.Swap(serviceKey, newState)
 
-	v, _ := c.ready.LoadOrStore(serviceKey, &atomic.Bool{})
-	if old := v.(*atomic.Bool).Swap(hasReady); old != hasReady {
+	var oldState *serviceState
+	if loaded {
+		oldState = old.(*serviceState)
+	}
+
+	if oldState.hasReady() != newState.hasReady() {
 		c.broadcast()
 	}
 }
@@ -127,19 +174,70 @@ func (c *ReadyEndpointsCache) broadcast() {
 	close(old)
 }
 
-// hasAnyReadyEndpoint returns true if the slice contains at least one
-// ready endpoint with at least one address.
-// Kubernetes guarantees that Ready is false for terminating pods, so a
-// separate Terminating check is unnecessary. For services with
-// publishNotReadyAddresses, Ready is always true — we respect that.
-func hasAnyReadyEndpoint(slice *discov1.EndpointSlice) bool {
-	for i := range slice.Endpoints {
-		ep := &slice.Endpoints[i]
-		if (ep.Conditions.Ready == nil || *ep.Conditions.Ready) && len(ep.Addresses) > 0 {
-			return true
+// collectServiceState builds an immutable serviceState snapshot. Each candidate
+// pairs a ready pod's address with a port from the same slice, keyed by portName
+// ("" for unnamed). Address families are not distinguished.
+func collectServiceState(slices []*discov1.EndpointSlice) *serviceState {
+	// Dedup (ip, port) per portName so overlapping slices don't weight a pod twice.
+	seen := make(map[string]map[endpoint]struct{})
+	candidates := make(map[string][]endpoint)
+	anyReady := false
+
+	for _, sl := range slices {
+		// Collect this slice's ports.
+		type slicePort struct {
+			name string
+			port int32
+		}
+		var slicePorts []slicePort
+		for _, p := range sl.Ports {
+			if p.Port == nil {
+				continue
+			}
+			name := ""
+			if p.Name != nil {
+				name = *p.Name
+			}
+			slicePorts = append(slicePorts, slicePort{name, *p.Port})
+		}
+
+		// Collect this slice's ready pod IPs (the canonical address per pod).
+		var readyIPs []string
+		for i := range sl.Endpoints {
+			ep := &sl.Endpoints[i]
+			// Kubernetes guarantees that Ready is false for terminating pods, so a
+			// separate Terminating check is unnecessary. For services with
+			// publishNotReadyAddresses, Ready is always true — we respect that.
+			if (ep.Conditions.Ready == nil || *ep.Conditions.Ready) && len(ep.Addresses) > 0 {
+				readyIPs = append(readyIPs, ep.Addresses[0])
+				anyReady = true
+			}
+		}
+
+		if len(readyIPs) == 0 || len(slicePorts) == 0 {
+			continue
+		}
+
+		// Cross-product: pair every ready pod with every port from this slice.
+		for _, sp := range slicePorts {
+			if seen[sp.name] == nil {
+				seen[sp.name] = make(map[endpoint]struct{})
+			}
+			for _, ip := range readyIPs {
+				k := endpoint{ip: ip, port: sp.port}
+				if _, dup := seen[sp.name][k]; dup {
+					continue
+				}
+				seen[sp.name][k] = struct{}{}
+				candidates[sp.name] = append(candidates[sp.name], k)
+			}
 		}
 	}
-	return false
+
+	return &serviceState{
+		ready:      anyReady,
+		candidates: candidates,
+	}
 }
 
 // updateReadyCache updates the ready cache for the service that owns

--- a/pkg/k8s/ready_endpoints_cache_test.go
+++ b/pkg/k8s/ready_endpoints_cache_test.go
@@ -110,7 +110,213 @@ func TestWaitForReady_ContextCancelled(t *testing.T) {
 	r.ErrorIs(err, context.Canceled)
 }
 
-// --- Update / key retention tests ---
+// --- PickReadyEndpoint tests ---
+
+func TestPickReadyEndpoint_ReturnsReadyIPAndPort(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	const key = "testns/testsvc"
+
+	port := int32(8080)
+	c.Update(key, []*discov1.EndpointSlice{
+		{
+			Ports:     []discov1.EndpointPort{{Port: &port}},
+			Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+		},
+	})
+
+	// unnamed port (Name==nil) is stored under the "" key
+	ip, gotPort, ok := c.PickReadyEndpoint(key, "")
+	r.True(ok)
+	r.Equal("1.2.3.4", ip)
+	r.Equal(int32(8080), gotPort)
+}
+
+func TestPickReadyEndpoint_EmptyCache(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+
+	_, _, ok := c.PickReadyEndpoint("testns/testsvc", "")
+	r.False(ok, "should return false for unknown service")
+}
+
+func TestPickReadyEndpoint_ReturnsIPFromSet(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	const key = "testns/testsvc"
+
+	port := int32(8080)
+	c.Update(key, []*discov1.EndpointSlice{
+		{
+			Ports: []discov1.EndpointPort{{Port: &port}},
+			Endpoints: []discov1.Endpoint{
+				{Addresses: []string{"1.2.3.4"}},
+				{Addresses: []string{"5.6.7.8"}},
+				{Addresses: []string{"9.10.11.12"}},
+			},
+		},
+	})
+
+	seen := make(map[string]bool)
+	for i := 0; i < 50; i++ {
+		ip, _, ok := c.PickReadyEndpoint(key, "")
+		r.True(ok)
+		seen[ip] = true
+	}
+	for ip := range seen {
+		r.Contains([]string{"1.2.3.4", "5.6.7.8", "9.10.11.12"}, ip)
+	}
+}
+
+func TestPickReadyEndpoint_PortResolution(t *testing.T) {
+	httpPort := int32(8080)
+	metricsPort := int32(9090)
+	httpName := "http"
+	metricsName := "metrics"
+
+	slice := &discov1.EndpointSlice{
+		Ports: []discov1.EndpointPort{
+			{Name: &httpName, Port: &httpPort},
+			{Name: &metricsName, Port: &metricsPort},
+		},
+		Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+	}
+
+	tests := map[string]struct {
+		portName string
+		wantPort int32
+		wantOK   bool
+	}{
+		"named port present": {
+			portName: "http",
+			wantPort: 8080,
+			wantOK:   true,
+		},
+		"named port absent": {
+			portName: "admin",
+			wantOK:   false,
+		},
+		"empty portName with only named ports": {
+			portName: "",
+			wantOK:   false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			c := NewReadyEndpointsCache(logr.Discard())
+			c.Update("testns/testsvc", []*discov1.EndpointSlice{slice})
+
+			_, gotPort, ok := c.PickReadyEndpoint("testns/testsvc", tc.portName)
+			r.Equal(tc.wantOK, ok)
+			if tc.wantOK {
+				r.Equal(tc.wantPort, gotPort)
+			}
+		})
+	}
+}
+
+func TestPickReadyEndpoint_UnnamedPortWithEmptyPortName(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+
+	port := int32(8080)
+	c.Update("testns/testsvc", []*discov1.EndpointSlice{
+		{
+			Ports:     []discov1.EndpointPort{{Port: &port}}, // Name is nil → stored as ""
+			Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+		},
+	})
+
+	_, gotPort, ok := c.PickReadyEndpoint("testns/testsvc", "")
+	r.True(ok)
+	r.Equal(int32(8080), gotPort)
+}
+
+// --- collectServiceState tests ---
+
+func TestCollectServiceState_ReadyEndpoints(t *testing.T) {
+	r := require.New(t)
+	slice := &discov1.EndpointSlice{
+		Endpoints: []discov1.Endpoint{
+			{Addresses: []string{"1.2.3.4"}},
+			{Addresses: []string{"5.6.7.8"}},
+		},
+	}
+	s := collectServiceState([]*discov1.EndpointSlice{slice})
+	r.True(s.ready)
+	r.ElementsMatch([]string{"1.2.3.4", "5.6.7.8"}, s.readyIPs)
+}
+
+func TestCollectServiceState_NotReadyEndpoints(t *testing.T) {
+	r := require.New(t)
+	notReady := false
+	slice := &discov1.EndpointSlice{
+		Endpoints: []discov1.Endpoint{
+			{
+				Addresses:  []string{"1.2.3.4"},
+				Conditions: discov1.EndpointConditions{Ready: &notReady},
+			},
+		},
+	}
+	s := collectServiceState([]*discov1.EndpointSlice{slice})
+	r.False(s.ready)
+}
+
+func TestCollectServiceState_NilReadyTreatedAsReady(t *testing.T) {
+	r := require.New(t)
+	slice := &discov1.EndpointSlice{
+		Endpoints: []discov1.Endpoint{
+			{Addresses: []string{"1.2.3.4"}},
+		},
+	}
+	s := collectServiceState([]*discov1.EndpointSlice{slice})
+	r.True(s.ready, "nil Ready should be treated as ready per K8s API spec")
+}
+
+func TestCollectServiceState_ExtractsPort(t *testing.T) {
+	r := require.New(t)
+	slice := &discov1.EndpointSlice{
+		Ports: []discov1.EndpointPort{
+			{Port: ptr.To(int32(8080))},
+		},
+		Endpoints: []discov1.Endpoint{
+			{Addresses: []string{"1.2.3.4"}},
+		},
+	}
+	s := collectServiceState([]*discov1.EndpointSlice{slice})
+	r.Equal(int32(8080), s.ports[""])
+}
+
+func TestCollectServiceState_DeduplicatesIPs(t *testing.T) {
+	r := require.New(t)
+	// Two slices with overlapping IPs.
+	s := collectServiceState([]*discov1.EndpointSlice{
+		{Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}}},
+		{Endpoints: []discov1.Endpoint{{Addresses: []string{"1.2.3.4", "5.6.7.8"}}}},
+	})
+	r.True(s.ready)
+	r.Len(s.readyIPs, 2)
+}
+
+// --- Update tests ---
+
+func TestUpdate_ClearsStateOnEmptySlices(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	const key = "testns/testsvc"
+
+	c.Update(key, []*discov1.EndpointSlice{
+		newReadySlice("testns", "testsvc", "1.2.3.4"),
+	})
+
+	c.Update(key, nil) // clear
+
+	r.False(c.HasReadyEndpoints(key))
+	_, _, ok := c.PickReadyEndpoint(key, "")
+	r.False(ok)
+}
 
 func TestUpdateDeletesKeyWhenNoSlices(t *testing.T) {
 	r := require.New(t)
@@ -122,13 +328,13 @@ func TestUpdateDeletesKeyWhenNoSlices(t *testing.T) {
 	})
 
 	r.True(cache.HasReadyEndpoints(key))
-	_, ok := cache.ready.Load(key)
+	_, ok := cache.states.Load(key)
 	r.True(ok, "key should exist after update with slices")
 
 	cache.Update(key, nil)
 
 	r.False(cache.HasReadyEndpoints(key))
-	_, ok = cache.ready.Load(key)
+	_, ok = cache.states.Load(key)
 	r.False(ok, "key should be removed when service has no slices")
 }
 
@@ -137,96 +343,21 @@ func TestUpdateRetainsKeyForNonReadySlices(t *testing.T) {
 	cache := NewReadyEndpointsCache(logr.Discard())
 	const key = "testns/testsvc"
 
+	notReady := false
 	cache.Update(key, []*discov1.EndpointSlice{
-		newReadySlice("testns", "testsvc"),
+		{
+			Endpoints: []discov1.Endpoint{
+				{
+					Addresses:  []string{"1.2.3.4"},
+					Conditions: discov1.EndpointConditions{Ready: &notReady},
+				},
+			},
+		},
 	})
 
 	r.False(cache.HasReadyEndpoints(key))
-	_, ok := cache.ready.Load(key)
+	_, ok := cache.states.Load(key)
 	r.True(ok, "key should remain when slices exist but none are ready")
-}
-
-// --- hasAnyReadyEndpoint tests ---
-
-func TestHasAnyReadyEndpoint_ReadyWithAddress(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{
-		Endpoints: []discov1.Endpoint{
-			{Addresses: []string{"1.2.3.4"}},
-		},
-	}
-	r.True(hasAnyReadyEndpoint(slice))
-}
-
-func TestHasAnyReadyEndpoint_ExplicitReady(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{
-		Endpoints: []discov1.Endpoint{
-			{
-				Addresses:  []string{"1.2.3.4"},
-				Conditions: discov1.EndpointConditions{Ready: ptr.To(true)},
-			},
-		},
-	}
-	r.True(hasAnyReadyEndpoint(slice))
-}
-
-func TestHasAnyReadyEndpoint_NotReady(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{
-		Endpoints: []discov1.Endpoint{
-			{
-				Addresses:  []string{"1.2.3.4"},
-				Conditions: discov1.EndpointConditions{Ready: ptr.To(false)},
-			},
-		},
-	}
-	r.False(hasAnyReadyEndpoint(slice))
-}
-
-func TestHasAnyReadyEndpoint_NoAddresses(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{
-		Endpoints: []discov1.Endpoint{
-			{Addresses: []string{}},
-		},
-	}
-	r.False(hasAnyReadyEndpoint(slice))
-}
-
-func TestHasAnyReadyEndpoint_EmptySlice(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{}
-	r.False(hasAnyReadyEndpoint(slice))
-}
-
-func TestHasAnyReadyEndpoint_MixedEndpoints(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{
-		Endpoints: []discov1.Endpoint{
-			{
-				Addresses:  []string{"1.2.3.4"},
-				Conditions: discov1.EndpointConditions{Ready: ptr.To(false)},
-			},
-			{
-				Addresses: []string{"5.6.7.8"},
-			},
-		},
-	}
-	r.True(hasAnyReadyEndpoint(slice), "should find the second endpoint with nil Ready (defaults to ready)")
-}
-
-func TestHasAnyReadyEndpoint_NilReadyIsReady(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{
-		Endpoints: []discov1.Endpoint{
-			{
-				Addresses:  []string{"1.2.3.4"},
-				Conditions: discov1.EndpointConditions{},
-			},
-		},
-	}
-	r.True(hasAnyReadyEndpoint(slice), "nil Ready should be treated as ready per K8s API spec")
 }
 
 // --- endpointSliceFromDeleteObj tests ---

--- a/pkg/k8s/ready_endpoints_cache_test.go
+++ b/pkg/k8s/ready_endpoints_cache_test.go
@@ -27,7 +27,7 @@ func TestWaitForReady_AlreadyReady(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	isColdStart, err := cache.WaitForReady(ctx, key)
+	isColdStart, _, err := cache.WaitForReady(ctx, key, "")
 	r.NoError(err)
 	r.False(isColdStart, "should not be a cold start when already ready")
 }
@@ -40,7 +40,7 @@ func TestWaitForReady_TimesOut(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	isColdStart, err := cache.WaitForReady(ctx, key)
+	isColdStart, _, err := cache.WaitForReady(ctx, key, "")
 	r.Error(err)
 	r.False(isColdStart)
 	r.ErrorIs(err, context.DeadlineExceeded)
@@ -62,7 +62,7 @@ func TestWaitForReady_ColdStart(t *testing.T) {
 		})
 	}()
 
-	isColdStart, err := cache.WaitForReady(ctx, key)
+	isColdStart, _, err := cache.WaitForReady(ctx, key, "")
 	r.NoError(err)
 	r.True(isColdStart, "should be a cold start when we had to wait")
 }
@@ -87,7 +87,7 @@ func TestWaitForReady_IgnoresUnrelatedBroadcast(t *testing.T) {
 		})
 	}()
 
-	isColdStart, err := cache.WaitForReady(ctx, key)
+	isColdStart, _, err := cache.WaitForReady(ctx, key, "")
 	r.NoError(err)
 	r.True(isColdStart)
 }
@@ -104,13 +104,364 @@ func TestWaitForReady_ContextCancelled(t *testing.T) {
 		cancel()
 	}()
 
-	isColdStart, err := cache.WaitForReady(ctx, key)
+	isColdStart, _, err := cache.WaitForReady(ctx, key, "")
 	r.Error(err)
 	r.False(isColdStart)
 	r.ErrorIs(err, context.Canceled)
 }
 
-// --- Update / key retention tests ---
+func TestWaitForReady_ReturnsPodHost(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	const key = "testns/testsvc"
+
+	c.Update(key, []*discov1.EndpointSlice{
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       []discov1.EndpointPort{{Port: ptr.To(int32(8080))}},
+			Endpoints: []discov1.Endpoint{
+				{
+					Addresses:  []string{"1.2.3.4"},
+					Conditions: discov1.EndpointConditions{Ready: ptr.To(true)},
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, podHost, err := c.WaitForReady(ctx, key, "")
+	r.NoError(err)
+	r.Equal("1.2.3.4:8080", podHost)
+}
+
+func TestWaitForReady_NamedPortSelectsCorrectHost(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	const key = "testns/testsvc"
+
+	c.Update(key, []*discov1.EndpointSlice{
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       []discov1.EndpointPort{{Name: ptr.To("http"), Port: ptr.To(int32(8080))}},
+			Endpoints: []discov1.Endpoint{
+				{
+					Addresses:  []string{"1.2.3.4"},
+					Conditions: discov1.EndpointConditions{Ready: ptr.To(true)},
+				},
+			},
+		},
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       []discov1.EndpointPort{{Name: ptr.To("grpc"), Port: ptr.To(int32(9090))}},
+			Endpoints: []discov1.Endpoint{
+				{
+					Addresses:  []string{"1.2.3.4"},
+					Conditions: discov1.EndpointConditions{Ready: ptr.To(true)},
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, httpHost, err := c.WaitForReady(ctx, key, "http")
+	r.NoError(err)
+	r.Equal("1.2.3.4:8080", httpHost)
+
+	_, grpcHost, err := c.WaitForReady(ctx, key, "grpc")
+	r.NoError(err)
+	r.Equal("1.2.3.4:9090", grpcHost)
+}
+
+func TestWaitForReady_BlocksOnNonReadyUpdates(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	const key = "testns/testsvc"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	type result struct {
+		isColdStart bool
+		podHost     string
+		err         error
+	}
+	done := make(chan result, 1)
+	go func() {
+		isColdStart, podHost, err := c.WaitForReady(ctx, key, "")
+		done <- result{isColdStart, podHost, err}
+	}()
+
+	for range 3 {
+		time.Sleep(5 * time.Millisecond)
+		c.Update(key, []*discov1.EndpointSlice{
+			{
+				AddressType: discov1.AddressTypeIPv4,
+				Ports:       []discov1.EndpointPort{{Port: ptr.To(int32(8080))}},
+				Endpoints: []discov1.Endpoint{
+					{
+						Addresses:  []string{"1.2.3.4"},
+						Conditions: discov1.EndpointConditions{Ready: ptr.To(false)},
+					},
+				},
+			},
+		})
+		select {
+		case <-done:
+			t.Fatal("WaitForReady returned early on a non-ready update")
+		default:
+		}
+	}
+
+	c.Update(key, []*discov1.EndpointSlice{
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       []discov1.EndpointPort{{Port: ptr.To(int32(8080))}},
+			Endpoints: []discov1.Endpoint{
+				{
+					Addresses:  []string{"1.2.3.4"},
+					Conditions: discov1.EndpointConditions{Ready: ptr.To(true)},
+				},
+			},
+		},
+	})
+
+	select {
+	case res := <-done:
+		r.NoError(res.err)
+		r.True(res.isColdStart)
+		r.Equal("1.2.3.4:8080", res.podHost)
+	case <-ctx.Done():
+		t.Fatal("WaitForReady did not unblock after ready update")
+	}
+}
+
+func TestWaitForReady_UnknownPortNameReturnsEmptyHost(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	const key = "testns/testsvc"
+
+	c.Update(key, []*discov1.EndpointSlice{
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       []discov1.EndpointPort{{Name: ptr.To("http"), Port: ptr.To(int32(8080))}},
+			Endpoints: []discov1.Endpoint{
+				{
+					Addresses:  []string{"1.2.3.4"},
+					Conditions: discov1.EndpointConditions{Ready: ptr.To(true)},
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, podHost, err := c.WaitForReady(ctx, key, "grpc")
+	r.NoError(err)
+	r.Empty(podHost, "unknown portName should return empty podHost")
+}
+
+// --- collectServiceState tests ---
+
+func TestCollectServiceState_ReadyEndpoints(t *testing.T) {
+	r := require.New(t)
+	port := int32(8080)
+	slice := &discov1.EndpointSlice{
+		AddressType: discov1.AddressTypeIPv4,
+		Ports:       []discov1.EndpointPort{{Port: &port}},
+		Endpoints: []discov1.Endpoint{
+			{Addresses: []string{"1.2.3.4"}},
+			{Addresses: []string{"5.6.7.8"}},
+		},
+	}
+	s := collectServiceState([]*discov1.EndpointSlice{slice})
+	r.True(s.ready)
+	got := make([]string, 0)
+	for _, ep := range s.candidates[""] {
+		got = append(got, ep.ip)
+		r.Equal(int32(8080), ep.port)
+	}
+	r.ElementsMatch([]string{"1.2.3.4", "5.6.7.8"}, got)
+}
+
+func TestCollectServiceState_NotReadyEndpoints(t *testing.T) {
+	r := require.New(t)
+	notReady := false
+	slice := &discov1.EndpointSlice{
+		AddressType: discov1.AddressTypeIPv4,
+		Endpoints: []discov1.Endpoint{
+			{
+				Addresses:  []string{"1.2.3.4"},
+				Conditions: discov1.EndpointConditions{Ready: &notReady},
+			},
+		},
+	}
+	s := collectServiceState([]*discov1.EndpointSlice{slice})
+	r.False(s.ready)
+}
+
+func TestCollectServiceState_NilReadyTreatedAsReady(t *testing.T) {
+	r := require.New(t)
+	slice := &discov1.EndpointSlice{
+		AddressType: discov1.AddressTypeIPv4,
+		Endpoints: []discov1.Endpoint{
+			{Addresses: []string{"1.2.3.4"}},
+		},
+	}
+	s := collectServiceState([]*discov1.EndpointSlice{slice})
+	r.True(s.ready, "nil Ready should be treated as ready per K8s API spec")
+}
+
+func TestCollectServiceState_ExtractsPort(t *testing.T) {
+	r := require.New(t)
+	slice := &discov1.EndpointSlice{
+		AddressType: discov1.AddressTypeIPv4,
+		Ports: []discov1.EndpointPort{
+			{Port: ptr.To(int32(8080))},
+		},
+		Endpoints: []discov1.Endpoint{
+			{Addresses: []string{"1.2.3.4"}},
+		},
+	}
+	s := collectServiceState([]*discov1.EndpointSlice{slice})
+	r.Len(s.candidates[""], 1)
+	r.Equal(int32(8080), s.candidates[""][0].port)
+}
+
+// TestCollectServiceState_DeduplicatesPods verifies that the same pod (same
+// address list + port) appearing in transiently-overlapping slices is counted
+// once, so it is not weighted multiple times in random selection.
+func TestCollectServiceState_DeduplicatesPods(t *testing.T) {
+	r := require.New(t)
+	port := int32(8080)
+	s := collectServiceState([]*discov1.EndpointSlice{
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       []discov1.EndpointPort{{Port: &port}},
+			Endpoints:   []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+		},
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       []discov1.EndpointPort{{Port: &port}},
+			Endpoints:   []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+		},
+	})
+	r.True(s.ready)
+	r.Len(s.candidates[""], 1, "the same pod across overlapping slices must be deduped")
+}
+
+func TestCollectServiceState_HeterogeneousPortsSamePortName(t *testing.T) {
+	r := require.New(t)
+	httpName := "http"
+	port8080 := int32(8080)
+	port9090 := int32(9090)
+
+	s := collectServiceState([]*discov1.EndpointSlice{
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       []discov1.EndpointPort{{Name: &httpName, Port: &port8080}},
+			Endpoints:   []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+		},
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       []discov1.EndpointPort{{Name: &httpName, Port: &port9090}},
+			Endpoints:   []discov1.Endpoint{{Addresses: []string{"10.0.0.1"}}},
+		},
+	})
+
+	r.True(s.ready)
+	r.Len(s.candidates["http"], 2, "both (ip,port) pairs must be kept")
+
+	ipToPort := make(map[string]int32)
+	for _, ep := range s.candidates["http"] {
+		ipToPort[ep.ip] = ep.port
+	}
+	r.Equal(int32(8080), ipToPort["1.2.3.4"])
+	r.Equal(int32(9090), ipToPort["10.0.0.1"])
+
+	c := NewReadyEndpointsCache(logr.Discard())
+	c.Update("testns/testsvc", []*discov1.EndpointSlice{
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       []discov1.EndpointPort{{Name: &httpName, Port: &port8080}},
+			Endpoints:   []discov1.Endpoint{{Addresses: []string{"1.2.3.4"}}},
+		},
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Ports:       []discov1.EndpointPort{{Name: &httpName, Port: &port9090}},
+			Endpoints:   []discov1.Endpoint{{Addresses: []string{"10.0.0.1"}}},
+		},
+	})
+	for range 100 {
+		_, podHost, err := c.WaitForReady(context.Background(), "testns/testsvc", "http")
+		r.NoError(err)
+		r.Contains([]string{"1.2.3.4:8080", "10.0.0.1:9090"}, podHost,
+			"host must be a consistent ip:port pair from the same slice")
+	}
+}
+
+func TestCollectServiceState_SkipsNilPort(t *testing.T) {
+	r := require.New(t)
+	slice := &discov1.EndpointSlice{
+		AddressType: discov1.AddressTypeIPv4,
+		Ports: []discov1.EndpointPort{
+			{Port: nil},
+			{Port: ptr.To(int32(8080))},
+		},
+		Endpoints: []discov1.Endpoint{
+			{
+				Addresses:  []string{"1.2.3.4"},
+				Conditions: discov1.EndpointConditions{Ready: ptr.To(true)},
+			},
+		},
+	}
+	s := collectServiceState([]*discov1.EndpointSlice{slice})
+	r.True(s.ready)
+	r.Len(s.candidates[""], 1)
+	r.Equal(int32(8080), s.candidates[""][0].port, "nil port entry must not produce a candidate")
+}
+
+func TestCollectServiceState_SkipsEndpointWithNoAddresses(t *testing.T) {
+	r := require.New(t)
+	slice := &discov1.EndpointSlice{
+		AddressType: discov1.AddressTypeIPv4,
+		Ports:       []discov1.EndpointPort{{Port: ptr.To(int32(8080))}},
+		Endpoints: []discov1.Endpoint{
+			{
+				Addresses:  []string{},
+				Conditions: discov1.EndpointConditions{Ready: ptr.To(true)},
+			},
+			{
+				Addresses:  []string{"1.2.3.4"},
+				Conditions: discov1.EndpointConditions{Ready: ptr.To(true)},
+			},
+		},
+	}
+	s := collectServiceState([]*discov1.EndpointSlice{slice})
+	r.True(s.ready)
+	r.Len(s.candidates[""], 1, "empty-address endpoint must not produce a candidate")
+	r.Equal("1.2.3.4", s.candidates[""][0].ip)
+}
+
+// --- Update tests ---
+
+func TestUpdate_ClearsStateOnEmptySlices(t *testing.T) {
+	r := require.New(t)
+	c := NewReadyEndpointsCache(logr.Discard())
+	const key = "testns/testsvc"
+
+	c.Update(key, []*discov1.EndpointSlice{
+		newReadySlice("testns", "testsvc", "1.2.3.4"),
+	})
+
+	c.Update(key, nil) // clear
+
+	r.False(c.HasReadyEndpoints(key))
+}
 
 func TestUpdateDeletesKeyWhenNoSlices(t *testing.T) {
 	r := require.New(t)
@@ -122,13 +473,13 @@ func TestUpdateDeletesKeyWhenNoSlices(t *testing.T) {
 	})
 
 	r.True(cache.HasReadyEndpoints(key))
-	_, ok := cache.ready.Load(key)
+	_, ok := cache.states.Load(key)
 	r.True(ok, "key should exist after update with slices")
 
 	cache.Update(key, nil)
 
 	r.False(cache.HasReadyEndpoints(key))
-	_, ok = cache.ready.Load(key)
+	_, ok = cache.states.Load(key)
 	r.False(ok, "key should be removed when service has no slices")
 }
 
@@ -137,96 +488,22 @@ func TestUpdateRetainsKeyForNonReadySlices(t *testing.T) {
 	cache := NewReadyEndpointsCache(logr.Discard())
 	const key = "testns/testsvc"
 
+	notReady := false
 	cache.Update(key, []*discov1.EndpointSlice{
-		newReadySlice("testns", "testsvc"),
+		{
+			AddressType: discov1.AddressTypeIPv4,
+			Endpoints: []discov1.Endpoint{
+				{
+					Addresses:  []string{"1.2.3.4"},
+					Conditions: discov1.EndpointConditions{Ready: &notReady},
+				},
+			},
+		},
 	})
 
 	r.False(cache.HasReadyEndpoints(key))
-	_, ok := cache.ready.Load(key)
+	_, ok := cache.states.Load(key)
 	r.True(ok, "key should remain when slices exist but none are ready")
-}
-
-// --- hasAnyReadyEndpoint tests ---
-
-func TestHasAnyReadyEndpoint_ReadyWithAddress(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{
-		Endpoints: []discov1.Endpoint{
-			{Addresses: []string{"1.2.3.4"}},
-		},
-	}
-	r.True(hasAnyReadyEndpoint(slice))
-}
-
-func TestHasAnyReadyEndpoint_ExplicitReady(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{
-		Endpoints: []discov1.Endpoint{
-			{
-				Addresses:  []string{"1.2.3.4"},
-				Conditions: discov1.EndpointConditions{Ready: ptr.To(true)},
-			},
-		},
-	}
-	r.True(hasAnyReadyEndpoint(slice))
-}
-
-func TestHasAnyReadyEndpoint_NotReady(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{
-		Endpoints: []discov1.Endpoint{
-			{
-				Addresses:  []string{"1.2.3.4"},
-				Conditions: discov1.EndpointConditions{Ready: ptr.To(false)},
-			},
-		},
-	}
-	r.False(hasAnyReadyEndpoint(slice))
-}
-
-func TestHasAnyReadyEndpoint_NoAddresses(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{
-		Endpoints: []discov1.Endpoint{
-			{Addresses: []string{}},
-		},
-	}
-	r.False(hasAnyReadyEndpoint(slice))
-}
-
-func TestHasAnyReadyEndpoint_EmptySlice(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{}
-	r.False(hasAnyReadyEndpoint(slice))
-}
-
-func TestHasAnyReadyEndpoint_MixedEndpoints(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{
-		Endpoints: []discov1.Endpoint{
-			{
-				Addresses:  []string{"1.2.3.4"},
-				Conditions: discov1.EndpointConditions{Ready: ptr.To(false)},
-			},
-			{
-				Addresses: []string{"5.6.7.8"},
-			},
-		},
-	}
-	r.True(hasAnyReadyEndpoint(slice), "should find the second endpoint with nil Ready (defaults to ready)")
-}
-
-func TestHasAnyReadyEndpoint_NilReadyIsReady(t *testing.T) {
-	r := require.New(t)
-	slice := &discov1.EndpointSlice{
-		Endpoints: []discov1.Endpoint{
-			{
-				Addresses:  []string{"1.2.3.4"},
-				Conditions: discov1.EndpointConditions{},
-			},
-		},
-	}
-	r.True(hasAnyReadyEndpoint(slice), "nil Ready should be treated as ready per K8s API spec")
 }
 
 // --- endpointSliceFromDeleteObj tests ---
@@ -266,6 +543,13 @@ func TestEndpointSliceFromDeleteObj_InvalidTombstonePayload(t *testing.T) {
 	r.Error(err)
 }
 
+func TestEndpointSliceFromDeleteObj_UnknownType(t *testing.T) {
+	r := require.New(t)
+
+	_, err := endpointSliceFromDeleteObj("unexpected-string-type")
+	r.Error(err)
+}
+
 // --- helpers ---
 
 func newReadySlice(namespace, service string, addresses ...string) *discov1.EndpointSlice {
@@ -284,6 +568,7 @@ func newReadySlice(namespace, service string, addresses ...string) *discov1.Endp
 				discov1.LabelServiceName: service,
 			},
 		},
-		Endpoints: endpoints,
+		AddressType: discov1.AddressTypeIPv4,
+		Endpoints:   endpoints,
 	}
 }

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -16,6 +16,8 @@ const (
 	ckUpstreamURL
 	ckFallbackURL
 	ckIR
+	ckUpstreamServerName
+	ckUpstreamPortName
 )
 
 func ContextWithLogger(ctx context.Context, logger logr.Logger) context.Context {
@@ -51,5 +53,27 @@ func ContextWithFallbackURL(ctx context.Context, url *url.URL) context.Context {
 
 func FallbackURLFromContext(ctx context.Context) *url.URL {
 	cv, _ := ctx.Value(ckFallbackURL).(*url.URL)
+	return cv
+}
+
+// ContextWithUpstreamServerName stores the upstream TLS server name (SNI),
+// set before any middleware rewrites the upstream URL.
+func ContextWithUpstreamServerName(ctx context.Context, serverName string) context.Context {
+	return context.WithValue(ctx, ckUpstreamServerName, serverName)
+}
+
+func UpstreamServerNameFromContext(ctx context.Context) string {
+	cv, _ := ctx.Value(ckUpstreamServerName).(string)
+	return cv
+}
+
+// ContextWithUpstreamPortName stores the upstream's resolved named port so
+// EndpointResolver can pick the correct pod port.
+func ContextWithUpstreamPortName(ctx context.Context, portName string) context.Context {
+	return context.WithValue(ctx, ckUpstreamPortName, portName)
+}
+
+func UpstreamPortNameFromContext(ctx context.Context) string {
+	cv, _ := ctx.Value(ckUpstreamPortName).(string)
 	return cv
 }


### PR DESCRIPTION
### Key changes:
  New `KEDA_HTTP_DIRECT_POD_ROUTING` environment variable
  - Adds DirectPodRoutingMode type with two values: `disabled` (default) and `cold-start-only`.
  - On cold start, the interceptor waits for a pod to become ready then rewrites the upstream URL directly to that pod's ip:port, bypassing the service ClusterIP and avoiding latency from kube-proxy rules that are slow to propagate after scale-from-zero.
  
  `ReadyEndpointsCache` now tracks (ip, port) pairs
  - `WaitForReady` now returns a podHost (ip:port string) in addition to the isColdStart bool. Stores ready endpoint state as a map of **`serviceKey → {ip, ports-by-name}`** backed by EndpointSlice updates, replacing the previous bool-only ready flag.
  - Port lookup is keyed on the named port from the InterceptorRoute's PortName field, so multi-port pods route to thecorrect container port.
  - Returns podHost="" when PortName has no match, leaving the upstream URL unchanged.

  Cold-start URL rewrite in EndpointResolver
  - When DirectPodOnColdStart=true, isColdStart=true, and podHost!="", the upstream URL's Host is replaced with the pod ip:port.
  - The rewrite is skipped when the request falls back to an alternate upstream — the fallback URL is not overwritten.
  - For HTTPS fallback upstreams, the TLS server name context is updated to the fallback hostname.

  TLS SNI preservation
  - Routing middleware now stores the intended TLS server name in context before any downstream middleware can rewrite the upstream URL.
  - `TransportPool.Get` now takes a **serverName** argument and keys transports on `(responseHeaderTimeout, serverName)`, applying `tls.Config.ServerName` per transport.
  - Upstream handler passes `util.UpstreamServerNameFromContext` to `transportPool.Get.`
  
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [The `docs/` directory](../docs)
  - [The docs repo](https://github.com/kedacore/keda-docs)

Fixes #1473
