### PR TITLE
refactor: align metric names with OTel semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Breaking Changes
 
 - **Interceptor**: Change default timeout behavior: request timeout (`KEDA_HTTP_REQUEST_TIMEOUT`) defaults to `0` (disabled), response header timeout (`KEDA_RESPONSE_HEADER_TIMEOUT` → `KEDA_HTTP_RESPONSE_HEADER_TIMEOUT`) defaults to `300s` (was `500ms`), and readiness timeout (`KEDA_CONDITION_WAIT_TIMEOUT` → `KEDA_HTTP_READINESS_TIMEOUT`) defaults to `0` (disabled, was `20s`). Timeout errors return 504 instead of 502. ([#1474](https://github.com/kedacore/http-add-on/issues/1474))
-- **Interceptor**: Redesign interceptor metrics: `interceptor_request_count` → `interceptor_requests_total` (labels: `method`, `code`, `route_name`, `route_namespace`), `interceptor_pending_request_count` → `interceptor_pending_requests` (labels: `route_name`, `route_namespace`), added `interceptor_request_duration_seconds` histogram; `path` and `host` labels removed in favor of route identity via InterceptorRoute name/namespace to fix unbounded cardinality OOM issues; non-standard HTTP methods normalized to `_OTHER`; dashboards and alerting rules must be updated ([#1559](https://github.com/kedacore/http-add-on/issues/1559))
+- **Interceptor**: Redesign interceptor metrics with bounded labels: `path`/`host` labels replaced by `route_name`/`route_namespace`; non-standard HTTP methods normalized to `_OTHER`; dashboards must be updated ([#1559](https://github.com/kedacore/http-add-on/issues/1559))
 - **Interceptor**: Remove `KEDA_HTTP_TLS_HANDSHAKE_TIMEOUT`, `KEDA_HTTP_EXPECT_CONTINUE_TIMEOUT`, `KEDA_HTTP_KEEP_ALIVE`, `KEDA_HTTP_IDLE_CONN_TIMEOUT`, and `KEDA_HTTP_DIAL_RETRY_TIMEOUT` environment variables; these now use Go's `DefaultTransport` defaults. ([#1474](https://github.com/kedacore/http-add-on/issues/1474))
+- **Interceptor**: Rename interceptor metrics to follow OTel semantic conventions: `interceptor_requests_total` → `interceptor_request_count_total`, `interceptor_pending_requests` → `interceptor_request_concurrency`, `interceptor_request_duration_seconds` unchanged ([#1589](https://github.com/kedacore/http-add-on/issues/1589))
 
 ### New
 

--- a/docs/operate.md
+++ b/docs/operate.md
@@ -1,8 +1,8 @@
 # Configuring metrics for the KEDA HTTP Add-on interceptor proxy
 
 ### Exportable metrics:
-* **`interceptor_pending_requests`** (gauge) - the number of requests currently in-flight for a given route, labeled by `route_name` and `route_namespace`.
-* **`interceptor_requests_total`** (counter) - the total number of requests for a given route, labeled by `method`, `code`, `route_name`, and `route_namespace`.
+* **`interceptor_request_concurrency`** (gauge) - concurrent requests at the interceptor proxy for a given route, labeled by `route_name` and `route_namespace`.
+* **`interceptor_request_count_total`** (counter) - the total number of requests for a given route, labeled by `method`, `code`, `route_name`, and `route_namespace`.
 * **`interceptor_request_duration_seconds`** (histogram) - request duration in seconds for a given route, labeled by `method`, `code`, `route_name`, and `route_namespace`.
 
 There are currently 2 supported methods for exposing metrics from the interceptor proxy service - via a Prometheus compatible metrics endpoint or by pushing metrics to a OTEL HTTP collector.

--- a/interceptor/metrics/instruments.go
+++ b/interceptor/metrics/instruments.go
@@ -15,9 +15,9 @@ const (
 	meterName   = "keda-interceptor-proxy"
 	serviceName = "interceptor-proxy"
 
-	MetricPendingRequests        = "interceptor_pending_requests"
-	MetricRequestDurationSeconds = "interceptor_request_duration_seconds"
-	MetricRequests               = "interceptor_requests"
+	MetricRequestConcurrency = "interceptor.request.concurrency"
+	MetricRequestCount       = "interceptor.request.count"
+	MetricRequestDuration    = "interceptor.request.duration"
 
 	AttrCode           = "code"
 	AttrMethod         = "method"
@@ -64,7 +64,7 @@ func NewInstruments(provider *sdkmetric.MeterProvider) (*Instruments, error) {
 	meter := provider.Meter(meterName)
 
 	requestCounter, err := meter.Int64Counter(
-		MetricRequests,
+		MetricRequestCount,
 		api.WithDescription("Total requests processed by the interceptor proxy"),
 	)
 	if err != nil {
@@ -72,7 +72,7 @@ func NewInstruments(provider *sdkmetric.MeterProvider) (*Instruments, error) {
 	}
 
 	requestDuration, err := meter.Float64Histogram(
-		MetricRequestDurationSeconds,
+		MetricRequestDuration,
 		api.WithDescription("Time from request received to response written"),
 		api.WithUnit("s"),
 		// Bucket boundaries from OTel HTTP semconv: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/
@@ -85,8 +85,8 @@ func NewInstruments(provider *sdkmetric.MeterProvider) (*Instruments, error) {
 	}
 
 	pendingRequests, err := meter.Int64UpDownCounter(
-		MetricPendingRequests,
-		api.WithDescription("Requests currently in-flight at the interceptor proxy"),
+		MetricRequestConcurrency,
+		api.WithDescription("Concurrent requests at the interceptor proxy"),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating pending requests counter: %w", err)

--- a/interceptor/metrics/prometheus_test.go
+++ b/interceptor/metrics/prometheus_test.go
@@ -14,9 +14,14 @@ import (
 	"github.com/kedacore/http-add-on/interceptor/config"
 )
 
-func TestPrometheus_RequestMetrics(t *testing.T) {
+func testRegistry(t *testing.T) (*prometheus.Registry, *Instruments) {
+	t.Helper()
+
 	registry := prometheus.NewRegistry()
-	exporter, err := promexporter.New(promexporter.WithRegisterer(registry), promexporter.WithoutScopeInfo())
+	exporter, err := promexporter.New(
+		promexporter.WithRegisterer(registry),
+		promexporter.WithoutScopeInfo(),
+	)
 	if err != nil {
 		t.Fatalf("creating prometheus exporter: %v", err)
 	}
@@ -34,41 +39,29 @@ func TestPrometheus_RequestMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewInstruments() error: %v", err)
 	}
+
+	return registry, instruments
+}
+
+func TestPrometheus_RequestMetrics(t *testing.T) {
+	registry, instruments := testRegistry(t)
 
 	instruments.RecordRequest("GET", 200, "my-route", "my-ns", 100*time.Millisecond)
 	instruments.RecordRequest("POST", 500, "my-route", "my-ns", 200*time.Millisecond)
 
 	expected := `
-		# HELP interceptor_requests_total Total requests processed by the interceptor proxy
-		# TYPE interceptor_requests_total counter
-		interceptor_requests_total{code="200",method="GET",route_name="my-route",route_namespace="my-ns"} 1
-		interceptor_requests_total{code="500",method="POST",route_name="my-route",route_namespace="my-ns"} 1
+		# HELP interceptor_request_count_total Total requests processed by the interceptor proxy
+		# TYPE interceptor_request_count_total counter
+		interceptor_request_count_total{code="200",method="GET",route_name="my-route",route_namespace="my-ns"} 1
+		interceptor_request_count_total{code="500",method="POST",route_name="my-route",route_namespace="my-ns"} 1
 	`
-	if err := testutil.CollectAndCompare(registry, strings.NewReader(expected), MetricRequests); err != nil {
+	if err := testutil.CollectAndCompare(registry, strings.NewReader(expected), "interceptor_request_count_total"); err != nil {
 		t.Fatalf("unexpected metrics output:\n%v", err)
 	}
 }
 
 func TestPrometheus_DurationMetrics(t *testing.T) {
-	registry := prometheus.NewRegistry()
-	exporter, err := promexporter.New(promexporter.WithRegisterer(registry), promexporter.WithoutScopeInfo())
-	if err != nil {
-		t.Fatalf("creating prometheus exporter: %v", err)
-	}
-
-	provider, err := NewMeterProvider(
-		config.Metrics{OtelPrometheusExporterEnabled: false},
-		sdkmetric.WithReader(exporter),
-	)
-	if err != nil {
-		t.Fatalf("NewMeterProvider() error: %v", err)
-	}
-	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
-
-	instruments, err := NewInstruments(provider)
-	if err != nil {
-		t.Fatalf("NewInstruments() error: %v", err)
-	}
+	registry, instruments := testRegistry(t)
 
 	instruments.RecordRequest("GET", 200, "app-alpha", "production", 30*time.Millisecond)
 	instruments.RecordRequest("GET", 200, "app-alpha", "production", 3*time.Second)
@@ -112,40 +105,22 @@ func TestPrometheus_DurationMetrics(t *testing.T) {
 		interceptor_request_duration_seconds_sum{code="503",method="POST",route_name="app-beta",route_namespace="staging"} 12
 		interceptor_request_duration_seconds_count{code="503",method="POST",route_name="app-beta",route_namespace="staging"} 1
 	`
-	if err := testutil.CollectAndCompare(registry, strings.NewReader(expected), MetricRequestDurationSeconds); err != nil {
+	if err := testutil.CollectAndCompare(registry, strings.NewReader(expected), "interceptor_request_duration_seconds"); err != nil {
 		t.Fatalf("unexpected metrics output:\n%v", err)
 	}
 }
 
-func TestPrometheus_PendingRequestMetrics(t *testing.T) {
-	registry := prometheus.NewRegistry()
-	exporter, err := promexporter.New(promexporter.WithRegisterer(registry), promexporter.WithoutScopeInfo())
-	if err != nil {
-		t.Fatalf("creating prometheus exporter: %v", err)
-	}
-
-	provider, err := NewMeterProvider(
-		config.Metrics{OtelPrometheusExporterEnabled: false},
-		sdkmetric.WithReader(exporter),
-	)
-	if err != nil {
-		t.Fatalf("NewMeterProvider() error: %v", err)
-	}
-	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
-
-	instruments, err := NewInstruments(provider)
-	if err != nil {
-		t.Fatalf("NewInstruments() error: %v", err)
-	}
+func TestPrometheus_ConcurrencyMetrics(t *testing.T) {
+	registry, instruments := testRegistry(t)
 
 	instruments.RecordPendingRequest("my-route", "my-ns", 5)
 
 	expected := `
-		# HELP interceptor_pending_requests Requests currently in-flight at the interceptor proxy
-		# TYPE interceptor_pending_requests gauge
-		interceptor_pending_requests{route_name="my-route",route_namespace="my-ns"} 5
+		# HELP interceptor_request_concurrency Concurrent requests at the interceptor proxy
+		# TYPE interceptor_request_concurrency gauge
+		interceptor_request_concurrency{route_name="my-route",route_namespace="my-ns"} 5
 	`
-	if err := testutil.CollectAndCompare(registry, strings.NewReader(expected), MetricPendingRequests); err != nil {
+	if err := testutil.CollectAndCompare(registry, strings.NewReader(expected), "interceptor_request_concurrency"); err != nil {
 		t.Fatalf("unexpected metrics output:\n%v", err)
 	}
 }

--- a/interceptor/middleware/helpers_test.go
+++ b/interceptor/middleware/helpers_test.go
@@ -1,8 +1,14 @@
 package middleware
 
-import "go.opentelemetry.io/otel/sdk/metric/metricdata"
+import (
+	"testing"
 
-func findMetric(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics {
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func requireMetric(t *testing.T, rm metricdata.ResourceMetrics, name string) *metricdata.Metrics {
+	t.Helper()
+
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
 			if m.Name == name {
@@ -10,5 +16,8 @@ func findMetric(rm metricdata.ResourceMetrics, name string) *metricdata.Metrics 
 			}
 		}
 	}
+
+	t.Fatalf("metric not found: %s", name)
+
 	return nil
 }

--- a/interceptor/middleware/metrics_test.go
+++ b/interceptor/middleware/metrics_test.go
@@ -36,10 +36,7 @@ func TestMetrics_RecordsRequestWithRouteInfo(t *testing.T) {
 		t.Fatalf("Collect() error: %v", err)
 	}
 
-	m := findMetric(rm, metrics.MetricRequests)
-	if m == nil {
-		t.Fatal("metric interceptor_requests_total not found")
-	}
+	m := requireMetric(t, rm, metrics.MetricRequestCount)
 
 	sum := m.Data.(metricdata.Sum[int64])
 	if got := len(sum.DataPoints); got != 1 {
@@ -52,11 +49,7 @@ func TestMetrics_RecordsRequestWithRouteInfo(t *testing.T) {
 	assertStringAttr(t, dp.Attributes, metrics.AttrRouteName, "test-route")
 	assertStringAttr(t, dp.Attributes, metrics.AttrRouteNamespace, "test-ns")
 
-	// Duration histogram should also be recorded
-	m = findMetric(rm, metrics.MetricRequestDurationSeconds)
-	if m == nil {
-		t.Fatal("metric interceptor_request_duration_seconds not found")
-	}
+	requireMetric(t, rm, metrics.MetricRequestDuration)
 }
 
 func TestMetrics_UnmatchedRoute(t *testing.T) {
@@ -78,10 +71,7 @@ func TestMetrics_UnmatchedRoute(t *testing.T) {
 		t.Fatalf("Collect() error: %v", err)
 	}
 
-	m := findMetric(rm, metrics.MetricRequests)
-	if m == nil {
-		t.Fatal("metric interceptor_requests_total not found")
-	}
+	m := requireMetric(t, rm, metrics.MetricRequestCount)
 
 	dp := m.Data.(metricdata.Sum[int64]).DataPoints[0]
 	assertStringAttr(t, dp.Attributes, metrics.AttrRouteName, "")

--- a/test/helpers/constants.go
+++ b/test/helpers/constants.go
@@ -5,7 +5,7 @@ package helpers
 // InterceptorMetrics is the set of Prometheus metric names that the interceptor
 // is expected to expose. Shared between the prometheus and otel metric tests.
 var InterceptorMetrics = []string{
-	"interceptor_pending_requests",
+	"interceptor_request_concurrency",
+	"interceptor_request_count_total",
 	"interceptor_request_duration_seconds",
-	"interceptor_requests_total",
 }


### PR DESCRIPTION
OTel semantic conventions specify dots as namespace separators and prohibit embedding units in metric names. Rename instruments to follow these conventions.

I decided rename `pending` to `concurrency` which is more in line with what we use in other parts of the code. `pending` is not very clear and might also mean requests not sent to a backend app yet at all (=waiting). Alternatives were also `inflight`, let me know what you think.

OTel instrument names:
- interceptor.request.count (was interceptor_requests)
- interceptor.request.duration (was interceptor_request_duration_seconds)
- interceptor.request.concurrency (was interceptor_pending_requests)

Prometheus-exported names:
- interceptor_request_count_total (was interceptor_requests_total)
- interceptor_request_duration_seconds (unchanged)
- interceptor_request_concurrency (was interceptor_pending_requests)

References:
- https://opentelemetry.io/docs/specs/semconv/general/naming/

### Changes:
- Rename OTel instrument names and Go constants
- Rename findMetric to requireMetric with built-in assertion
- Fix Prometheus test filters to use Prometheus family names
- Update docs and e2e tests



### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)

Fixes #1589 
