### PR TITLE
fix: restrict metrics endpoint to /metrics path

### DIFF
--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -297,7 +297,9 @@ func runMetricsServer(
 ) error {
 	lggr.Info("starting the prometheus metrics server", "port", metricsCfg.OtelPrometheusExporterPort, "path", "/metrics")
 	addr := fmt.Sprintf("0.0.0.0:%d", metricsCfg.OtelPrometheusExporterPort)
-	return kedahttp.ServeContext(ctx, addr, promhttp.Handler(), nil)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	return kedahttp.ServeContext(ctx, addr, mux, nil)
 }
 
 func runProxyServer(


### PR DESCRIPTION
The handler was mounted at the root, serving metrics on every path. Restrict to /metrics only, matching the Prometheus convention and the default scrape path.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
