### PR TITLE
feat: add orphan-scaledobject annotation for HTTPSO->IR migration

### DIFF
--- a/operator/controllers/http/app.go
+++ b/operator/controllers/http/app.go
@@ -6,14 +6,20 @@ import (
 
 	"github.com/go-logr/logr"
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kedacore/http-add-on/operator/apis/http/v1alpha1"
 	"github.com/kedacore/http-add-on/operator/controllers/http/config"
 )
 
-var SkipScaledObjectCreationAnnotation = "httpscaledobject.keda.sh/skip-scaledobject-creation"
+const (
+	annotationEnabled                  = "true"
+	SkipScaledObjectCreationAnnotation = "httpscaledobject.keda.sh/skip-scaledobject-creation"
+	OrphanScaledObjectAnnotation       = "httpscaledobject.keda.sh/orphan-scaledobject"
+)
 
 func (r *HTTPScaledObjectReconciler) createOrUpdateApplicationResources(
 	ctx context.Context,
@@ -32,11 +38,18 @@ func (r *HTTPScaledObjectReconciler) createOrUpdateApplicationResources(
 		httpso.Namespace,
 	)
 
+	if httpso.Annotations[OrphanScaledObjectAnnotation] == annotationEnabled {
+		logger.Info(
+			"Orphaning ScaledObject with annotation 'httpscaledobject.keda.sh/orphan-scaledobject'=true",
+			"HTTPScaledObject", httpso.Name)
+		return r.orphanScaledObject(ctx, cl, logger, httpso)
+	}
+
 	// We want to integrate http scaler with other
 	// scalers. when "httpscaledobject.keda.sh/skip-scaledobject-creation" is set to true,
 	// reconciler will skip the KEDA core ScaledObjects creation or delete scaledObject if it already exists.
 	// you can then create your own SO, and add http scaler as one of your triggers.
-	if httpso.Annotations[SkipScaledObjectCreationAnnotation] == "true" {
+	if httpso.Annotations[SkipScaledObjectCreationAnnotation] == annotationEnabled {
 		logger.Info(
 			"Skip scaled objects creation with flag 'httpscaledobject.keda.sh/skip-scaledobject-creation'=true",
 			"HTTPScaledObject", httpso.Name)
@@ -90,6 +103,45 @@ func (r *HTTPScaledObjectReconciler) deleteScaledObject(
 			"ScaledObject", &fetchedSO.Name)
 	}
 
+	return nil
+}
+
+func (r *HTTPScaledObjectReconciler) orphanScaledObject(
+	ctx context.Context,
+	cl client.Client,
+	logger logr.Logger,
+	httpso *v1alpha1.HTTPScaledObject,
+) error {
+	var fetchedSO kedav1alpha1.ScaledObject
+
+	objectKey := types.NamespacedName{
+		Namespace: httpso.Namespace,
+		Name:      httpso.Name,
+	}
+
+	if err := cl.Get(ctx, objectKey, &fetchedSO); err != nil {
+		if k8serrors.IsNotFound(err) {
+			logger.Info("ScaledObject not found, nothing to orphan",
+				"HTTPScaledObject", httpso.Name)
+			return nil
+		}
+		return err
+	}
+
+	if !isOwnerReferenceMatch(&fetchedSO, httpso) {
+		return nil
+	}
+
+	if err := controllerutil.RemoveOwnerReference(httpso, &fetchedSO, r.Scheme); err != nil {
+		return err
+	}
+
+	if err := cl.Update(ctx, &fetchedSO); err != nil {
+		return err
+	}
+
+	logger.Info("Orphaned ScaledObject by removing owner reference",
+		"ScaledObject", fetchedSO.Name)
 	return nil
 }
 

--- a/operator/controllers/http/httpscaledobject_controller.go
+++ b/operator/controllers/http/httpscaledobject_controller.go
@@ -162,6 +162,10 @@ func (r *HTTPScaledObjectReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&httpv1alpha1.HTTPScaledObject{}, builder.WithPredicates(
 			predicate.Or(
+				util.AnnotationKeyChangedPredicate{Keys: []string{
+					OrphanScaledObjectAnnotation,
+					SkipScaledObjectCreationAnnotation,
+				}},
 				predicate.GenerationChangedPredicate{},
 				util.HTTPScaledObjectReadyConditionPredicate{},
 			),

--- a/operator/controllers/http/httpscaledobject_controller_test.go
+++ b/operator/controllers/http/httpscaledobject_controller_test.go
@@ -8,6 +8,70 @@ import (
 	"github.com/kedacore/http-add-on/operator/controllers/http/config"
 )
 
+func TestOrphanAnnotationRemovesOwnerReference(t *testing.T) {
+	r := require.New(t)
+	testInfra := newCommonTestInfra("testns", "testapp")
+	reconciler := &HTTPScaledObjectReconciler{
+		Client:               testInfra.cl,
+		Scheme:               testInfra.cl.Scheme(),
+		ExternalScalerConfig: config.ExternalScaler{},
+		BaseConfig:           config.Base{},
+	}
+
+	// First reconcile without annotation — ScaledObject created with owner reference
+	err := reconciler.createOrUpdateApplicationResources(
+		testInfra.ctx, testInfra.logger, testInfra.cl,
+		config.Base{}, config.ExternalScaler{}, &testInfra.httpso,
+	)
+	r.NoError(err)
+
+	so, err := getSO(testInfra.ctx, testInfra.cl, testInfra.httpso)
+	r.NoError(err)
+	r.Len(so.OwnerReferences, 1)
+
+	// Add orphan annotation and reconcile again
+	testInfra.httpso.Annotations[OrphanScaledObjectAnnotation] = "true"
+	err = reconciler.createOrUpdateApplicationResources(
+		testInfra.ctx, testInfra.logger, testInfra.cl,
+		config.Base{}, config.ExternalScaler{}, &testInfra.httpso,
+	)
+	r.NoError(err)
+
+	// ScaledObject must still exist but with no owner references
+	so, err = getSO(testInfra.ctx, testInfra.cl, testInfra.httpso)
+	r.NoError(err)
+	r.Empty(so.OwnerReferences)
+
+	// Third reconcile with orphan annotation still set — must be idempotent
+	err = reconciler.createOrUpdateApplicationResources(
+		testInfra.ctx, testInfra.logger, testInfra.cl,
+		config.Base{}, config.ExternalScaler{}, &testInfra.httpso,
+	)
+	r.NoError(err)
+}
+
+func TestOrphanAnnotationWhenNoScaledObjectExists(t *testing.T) {
+	r := require.New(t)
+	testInfra := newCommonTestInfra("testns", "testapp")
+	testInfra.httpso.Annotations[OrphanScaledObjectAnnotation] = "true"
+	reconciler := &HTTPScaledObjectReconciler{
+		Client:               testInfra.cl,
+		Scheme:               testInfra.cl.Scheme(),
+		ExternalScalerConfig: config.ExternalScaler{},
+		BaseConfig:           config.Base{},
+	}
+
+	err := reconciler.createOrUpdateApplicationResources(
+		testInfra.ctx, testInfra.logger, testInfra.cl,
+		config.Base{}, config.ExternalScaler{}, &testInfra.httpso,
+	)
+	r.NoError(err)
+
+	// ScaledObject must not have been created
+	_, err = getSO(testInfra.ctx, testInfra.cl, testInfra.httpso)
+	r.Error(err)
+}
+
 func TestHttpScaledObjectControllerWhenSkipAnnotationNotSet(t *testing.T) {
 	r := require.New(t)
 

--- a/operator/controllers/util/predicate.go
+++ b/operator/controllers/util/predicate.go
@@ -10,6 +10,27 @@ import (
 	"github.com/kedacore/http-add-on/operator/apis/http/v1alpha1"
 )
 
+type AnnotationKeyChangedPredicate struct {
+	predicate.Funcs
+	Keys []string
+}
+
+func (p AnnotationKeyChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
+
+	oldAnnotations := e.ObjectOld.GetAnnotations()
+	newAnnotations := e.ObjectNew.GetAnnotations()
+
+	for _, key := range p.Keys {
+		if oldAnnotations[key] != newAnnotations[key] {
+			return true
+		}
+	}
+	return false
+}
+
 type HTTPScaledObjectReadyConditionPredicate struct {
 	predicate.Funcs
 }


### PR DESCRIPTION
When migrating from HTTPScaledObject to InterceptorRoute, the auto-created ScaledObject is cascade-deleted with the HTTPScaledObject. GitOps tools cannot use --cascade=orphan because deletion is declarative.

The new httpscaledobject.keda.sh/orphan-scaledobject annotation tells the controller to remove the owner reference from the ScaledObject, allowing it to survive HTTPScaledObject deletion without a scaling gap.

More of a nice to have but quite simple to implement.

### Changes
- Add OrphanScaledObjectAnnotation and orphanScaledObject method
- Add AnnotationChangedPredicate to HTTPScaledObject watch predicates
- Add tests for orphan annotation with and without existing ScaledObject

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)