### PR TITLE
feat: log deprecation warning for HTTPScaledObject

### DIFF
--- a/operator/controllers/http/httpscaledobject_controller.go
+++ b/operator/controllers/http/httpscaledobject_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"sync"
 	"time"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -49,6 +50,8 @@ type HTTPScaledObjectReconciler struct {
 
 	ExternalScalerConfig config.ExternalScaler
 	BaseConfig           config.Base
+
+	deprecationWarned sync.Map
 }
 
 // +kubebuilder:rbac:groups=http.keda.sh,resources=httpscaledobjects,verbs=get;list;watch;create;update;patch;delete
@@ -82,6 +85,11 @@ func (r *HTTPScaledObjectReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if httpso.GetDeletionTimestamp() != nil {
 		return ctrl.Result{}, finalizeScaledObject(ctx, logger, r.Client, httpso)
+	}
+
+	// TODO(v1): remove before v1 release
+	if _, alreadyWarned := r.deprecationWarned.LoadOrStore(req.String(), true); !alreadyWarned {
+		logger.Info("WARNING: HTTPScaledObject is deprecated and will be removed in a future release, migrate to InterceptorRoute + ScaledObject: https://keda.sh/http-add-on/0.14/operations/migrate-httpscaledobject-to-interceptorroute/")
 	}
 
 	// ensure finalizer is set on this resource


### PR DESCRIPTION
Users still on HTTPScaledObject need visibility that it will be removed. A one-time warning per resource (per pod lifetime) nudges migration without spamming logs on every reconcile.

Waits for the docs to be merged, URL should be stable. The current logging tools allow only INFO or ERROR - thus the strange warning log.

Example (see the line before the last):
```
2026-04-22T08:15:16Z    INFO    setup    starting manager
2026-04-22T08:15:16Z    INFO    controller-runtime.metrics    Starting metrics server
2026-04-22T08:15:16Z    INFO    starting server    {"name": "health probe", "addr": "[::]:8081"}
2026-04-22T08:15:16Z    INFO    controller-runtime.metrics    Serving metrics server    {"bindAddress": ":8080", "secure": false}
I0422 08:15:16.562091       1 leaderelection.go:257] attempting to acquire leader lease keda/http-add-on.keda.sh...
I0422 08:15:20.392732       1 leaderelection.go:271] successfully acquired lease keda/http-add-on.keda.sh
2026-04-22T08:15:20Z    INFO    Starting EventSource    {"controller": "httpscaledobject", "controllerGroup": "http.keda.sh", "controllerKind": "HTTPScaledObject", "source": "kind source: *v1alpha1.ScaledObject"}
2026-04-22T08:15:20Z    INFO    Starting EventSource    {"controller": "interceptorroute", "controllerGroup": "http.keda.sh", "controllerKind": "InterceptorRoute", "source": "kind source: *v1beta1.InterceptorRoute"}
2026-04-22T08:15:20Z    INFO    Starting EventSource    {"controller": "httpscaledobject", "controllerGroup": "http.keda.sh", "controllerKind": "HTTPScaledObject", "source": "kind source: *v1alpha1.HTTPScaledObject"}
2026-04-22T08:15:20Z    INFO    Starting Controller    {"controller": "interceptorroute", "controllerGroup": "http.keda.sh", "controllerKind": "InterceptorRoute"}
2026-04-22T08:15:20Z    INFO    Starting workers    {"controller": "interceptorroute", "controllerGroup": "http.keda.sh", "controllerKind": "InterceptorRoute", "worker count": 1}
2026-04-22T08:15:20Z    INFO    Starting Controller    {"controller": "httpscaledobject", "controllerGroup": "http.keda.sh", "controllerKind": "HTTPScaledObject"}
2026-04-22T08:15:20Z    INFO    Starting workers    {"controller": "httpscaledobject", "controllerGroup": "http.keda.sh", "controllerKind": "HTTPScaledObject", "worker count": 1}
2026-04-22T08:15:20Z    INFO    Reconciliation start    {"controller": "httpscaledobject", "controllerGroup": "http.keda.sh", "controllerKind": "HTTPScaledObject", "HTTPScaledObject": {"name":"whoami-httpso","namespace":"default"}, "namespace": "default", "name": "whoami-httpso", "reconcileID": "871efc5c-a18a-494c-89e7-a0550c80de35", "httpscaledobject": {"name":"whoami-httpso","namespace":"default"}}
2026-04-22T08:15:20Z    INFO    WARNING: HTTPScaledObject is deprecated and will be removed in a future release, migrate to InterceptorRoute + ScaledObject: https://keda.sh/http-add-on/0.14/operations/migrate-httpscaledobject-to-interceptorroute/    {"controller": "httpscaledobject", "controllerGroup": "http.keda.sh", "controllerKind": "HTTPScaledObject", "HTTPScaledObject": {"name":"whoami-httpso","namespace":"default"}, "namespace": "default", "name": "whoami-httpso", "reconcileID": "871efc5c-a18a-494c-89e7-a0550c80de35", "httpscaledobject": {"name":"whoami-httpso","namespace":"default"}}
2026-04-22T08:15:20Z    INFO    Reconciling HTTPScaledObject    {"controller": "httpscaledobject", "controllerGroup": "http.keda.sh", "controllerKind": "HTTPScaledObject", "HTTPScaledObject": {"name":"whoami-httpso","namespace":"default"}, "namespace": "default", "name": "whoami-httpso", "reconcileID": "871efc5c-a18a-494c-89e7-a0550c80de35", "httpscaledobject": {"name":"whoami-httpso","namespace":"default"}, "Namespace": "default", "DeploymentName": "whoami-httpso"}
...
```


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

See #1501 
