### PR TITLE
feat: require explicit targetValue in scaling metric specs

### DIFF
--- a/config/crd/bases/http.keda.sh_interceptorroutes.yaml
+++ b/config/crd/bases/http.keda.sh_interceptorroutes.yaml
@@ -159,11 +159,12 @@ spec:
                     description: Scale based on concurrent request count.
                     properties:
                       targetValue:
-                        default: 100
                         description: Target concurrent request count per replica.
                         format: int32
                         minimum: 1
                         type: integer
+                    required:
+                    - targetValue
                     type: object
                   requestRate:
                     description: Scale based on request rate.
@@ -173,7 +174,6 @@ spec:
                         description: Bucket size for rate calculation within the window.
                         type: string
                       targetValue:
-                        default: 100
                         description: Target request rate per replica.
                         format: int32
                         minimum: 1
@@ -183,6 +183,8 @@ spec:
                         description: Sliding time window over which the request rate
                           is calculated.
                         type: string
+                    required:
+                    - targetValue
                     type: object
                 type: object
                 x-kubernetes-validations:

--- a/operator/apis/http/v1beta1/interceptorroute_types.go
+++ b/operator/apis/http/v1beta1/interceptorroute_types.go
@@ -63,10 +63,8 @@ type RoutingRule struct {
 // ConcurrencyTargetSpec defines concurrency-based scaling.
 type ConcurrencyTargetSpec struct {
 	// Target concurrent request count per replica.
-	// +kubebuilder:default=100
 	// +kubebuilder:validation:Minimum=1
-	// +optional
-	TargetValue int32 `json:"targetValue,omitzero"`
+	TargetValue int32 `json:"targetValue"`
 }
 
 // RequestRateTargetSpec defines rate-based scaling.
@@ -76,10 +74,8 @@ type RequestRateTargetSpec struct {
 	// +optional
 	Granularity metav1.Duration `json:"granularity,omitzero"`
 	// Target request rate per replica.
-	// +kubebuilder:default=100
 	// +kubebuilder:validation:Minimum=1
-	// +optional
-	TargetValue int32 `json:"targetValue,omitzero"`
+	TargetValue int32 `json:"targetValue"`
 	// Sliding time window over which the request rate is calculated.
 	// +kubebuilder:default="1m"
 	// +optional


### PR DESCRIPTION
Absolute autoscaling thresholds are highly workload-dependent and should not have silent defaults.

No changelog entry as this is part of the unreleased work for #1501 .


### Changes
- Remove +kubebuilder:default=100 and +optional from TargetValue in ConcurrencyTargetSpec and RequestRateTargetSpec
- Update CRD schema to mark targetValue as required

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Docs are updated right now
