### PR TITLE
chore: pin ko base image to digest and track with Renovate

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
 {
-	"name": "Go",
+	"name": "KEDA HTTP Add-on",
 	"image": "mcr.microsoft.com/devcontainers/go:latest"
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -94,6 +94,14 @@
         '# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?:\\s+packageName=(?<packageName>\\S+))?\\n\\s+- (?<currentValue>\\S+)',
       ],
     },
+    {
+      customType: "regex",
+      managerFilePatterns: [".ko.yaml"],
+      matchStrings: [
+        "defaultBaseImage:\\s+(?<depName>[^:@\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)",
+      ],
+      datasourceTemplate: "docker",
+    },
   ],
   postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
   // Experimental: pre-commit manager is in beta and disabled by default

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-      id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
+      id-token: write # needed for signing the images with GitHub OIDC Token
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -2,7 +2,7 @@
 # See https://ko.build/configuration/ for details
 
 # Preferred over chainguard/static (missing s390x) and distroless/static (12 vs 1 layer)
-defaultBaseImage: ghcr.io/wolfi-dev/static:alpine
+defaultBaseImage: ghcr.io/wolfi-dev/static:alpine@sha256:4020c25b4dcf538db0e01623a8917ed25b1a88b2762ff3f259373c398f0fa1db
 
 defaultEnv:
   - CGO_ENABLED=0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,11 @@ For larger changes or new features, please [open an issue](https://github.com/ke
 2. Set up your development environment — see [docs/developing.md](./docs/developing.md) for prerequisites and tooling
 3. Create a branch for your changes (`git switch -c my-change`)
 4. Make your changes and verify them:
-
    ```bash
    make lint       # runs linter
    make lint-fix   # runs linter and auto-fixes issues
    make test       # runs unit tests
    ```
-
 5. Commit using [conventional commits](#commit-conventions) with a DCO sign-off (`git commit -s`)
 6. Update the [changelog](#updating-the-changelog) for user-facing changes
 7. Open a pull request — see [pull request guidelines](#pull-request-guidelines)


### PR DESCRIPTION
Pins the wolfi-dev/static base image in .ko.yaml to a specific digest for reproducible builds and supply chain security. Adds a Renovate custom manager to keep the digest updated automatically.

Also removes an outdated "not production ready" comment from cosign keyless signing, which has been production-ready since Cosign 2.0.
We removed the experimental cosign stuff in the Makefile already some time ago, must have missed this.

### Changes
- Pin ghcr.io/wolfi-dev/static:alpine to sha256 digest in .ko.yaml
- Add Renovate custom regex manager for .ko.yaml digest tracking
- Remove stale "not production ready" from cosign OIDC comment
- Minor cleanup of devcontainer name and whitespace issue in CONTRIBUTING.md

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

