### PR TITLE
chore: group e2e-framework with Kubernetes deps in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,6 +40,7 @@
         "k8s.io/**",
         "sigs.k8s.io/controller-runtime",
         "sigs.k8s.io/controller-tools",
+        "sigs.k8s.io/e2e-framework",
         "sigs.k8s.io/gateway-api",
         "github.com/cert-manager/cert-manager",
       ],
@@ -52,6 +53,7 @@
         "k8s.io/**",
         "sigs.k8s.io/controller-runtime",
         "sigs.k8s.io/controller-tools",
+        "sigs.k8s.io/e2e-framework", // tracks k8s.io/* minor versions
         "sigs.k8s.io/gateway-api", // independently versioned but depends on k8s.io/*
         "github.com/cert-manager/cert-manager", // depends on specific k8s.io/* minor versions
       ],


### PR DESCRIPTION
sigs.k8s.io/e2e-framework tracks k8s minor versions, so bumping it transitively forces k8s.io/* and controller-runtime upgrades. Grouping it with the Kubernetes Dependencies rule prevents k8s minor bumps from sneaking into the non-major catch-all PRs.

Related PR is https://github.com/kedacore/http-add-on/pull/1611


### Changes
- Add sigs.k8s.io/e2e-framework to separateMinorPatch rule
- Add sigs.k8s.io/e2e-framework to Kubernetes Dependencies group

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)


