### PR TITLE
fix: disable digest pinning for kindest/node in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -74,6 +74,13 @@
       matchUpdateTypes: ["minor", "major"],
       enabled: false,
     },
+    // Disable digest pinning for kindest/node as we don't need it and as it causes renovate update failures when not captured.
+    {
+      matchManagers: ["custom.regex"],
+      matchFileNames: [".github/workflows/e2e-tests.yaml"],
+      matchDepNames: ["/kindest\\/node/"],
+      pinDigests: false,
+    },
     {
       matchFileNames: [".devcontainer/**"],
       pinDigests: false,
@@ -91,7 +98,7 @@
       customType: "regex",
       managerFilePatterns: [".github/workflows/**"],
       matchStrings: [
-        '# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?:\\s+packageName=(?<packageName>\\S+))?\\n\\s+- (?<currentValue>\\S+)',
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?:\\s+packageName=(?<packageName>\\S+))?\\n\\s+- (?<currentValue>\\S+)",
       ],
     },
     {


### PR DESCRIPTION
Renovate cannot pin digests for kindest/node entries matched by the custom regex (no currentDigest capture group), likely causing the e2e-dependencies branch update to fail.

This seems to be the likely fix for the current renovate branch creation failure, see the dependency dashboard.

### Changes 
- Add pinDigests: false rule for kindest/node entries


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
