### PR TITLE
ci: add stable e2e summary job for branch protection

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -125,3 +125,16 @@ jobs:
           KO_DOCKER_REPO: kind.local
           KO_DEFAULTPLATFORMS: ${{ matrix.platform }} # only need target arch
           VERSION: ${{ github.sha }}
+
+  e2e_summary:
+    name: "e2e Summary"
+    if: always()
+    needs: [e2e_tests, e2e_tests_legacy]
+    runs-on: ubuntu-latest
+    steps:
+      - if: |
+          needs.e2e_tests.result == 'failure' ||
+          needs.e2e_tests.result == 'cancelled' ||
+          needs.e2e_tests_legacy.result == 'failure' ||
+          needs.e2e_tests_legacy.result == 'cancelled'
+        run: exit 1


### PR DESCRIPTION
Matrix job names include the kindest/node version, so they change on every patch bump and break required status checks.

We should then be able to replace these here with the new summary job:
<img width="743" height="778" alt="image" src="https://github.com/user-attachments/assets/2d53aa4b-f1d8-4e8f-a3a0-ae63a8e7afa4" />

I'm open for other ideas though.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
