### PR TITLE
chore: improve OpenSSF Scorecard security posture

### DIFF
--- a/.github/workflows/build_canary.yml
+++ b/.github/workflows/build_canary.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
+      id-token: write # needed for signing the images with GitHub OIDC Token
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -4,19 +4,22 @@ on:
   push:
     tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
-      id-token: write # needed for signing the images with GitHub OIDC Token
+      id-token: write # needed for signing images and release manifests with GitHub OIDC Token
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 'stable'
+          go-version: "stable"
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
       - name: Get the version
@@ -58,12 +61,22 @@ jobs:
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
 
+      - name: Sign release manifests
+        run: |
+          for f in "keda-add-ons-http-${VERSION}.yaml" "keda-add-ons-http-${VERSION}-crds.yaml"; do
+            cosign sign-blob --yes "$f" --bundle "${f}.bundle.json"
+          done
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+
       - name: Upload release assets
         run: |
           gh release upload "${GITHUB_REF_NAME}" \
             "keda-add-ons-http-${VERSION}.yaml" \
+            "keda-add-ons-http-${VERSION}.yaml.bundle.json" \
             "keda-add-ons-http-${VERSION}-crds.yaml" \
+            "keda-add-ons-http-${VERSION}-crds.yaml.bundle.json" \
             --clobber
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -2,6 +2,9 @@ name: Auto Assign
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   assign_reviewer:
     runs-on: ubuntu-slim

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,13 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   stale:
     runs-on: ubuntu-slim
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:

--- a/.github/workflows/static-analysis-codeql.yml
+++ b/.github/workflows/static-analysis-codeql.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -17,6 +16,9 @@ jobs:
   codeQl:
     name: Analyze CodeQL Go
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     if: (github.actor != 'dependabot[bot]')
     steps:
       - name: Checkout repository

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Prevention
+
+We have a few preventive measures in place to detect security vulnerabilities:
+
+- [Renovate](https://docs.renovatebot.com/) helps us keep our dependencies up-to-date to patch vulnerabilities as soon as possible by creating awareness and automated PRs.
+- [Snyk](https://snyk.io/) helps us ship secure container images:
+  - Images are scanned in every pull request (PR) to detect new vulnerabilities.
+  - Published images on GitHub Container Registry are monitored to detect new vulnerabilities so we can ship patches
+- [Semgrep](https://semgrep.dev/) helps us with identifying vulnerabilities in our code to raise awareness.
+- [FOSSA](https://fossa.com) scans our dependencies for license compliance and known vulnerabilities.
+- [GitHub's security features](https://github.com/features/security) are constantly monitoring our repo and dependencies:
+  - All pull requests (PRs) use CodeQL to scan our source code for vulnerabilities
+  - Dependabot will automatically identify vulnerabilities based on the GitHub Advisory Database and open PRs with patches
+  - Automated [secret scanning](https://docs.github.com/en/enterprise-cloud@latest/code-security/concepts/secret-security/about-secret-scanning) and alerts
+- Container images are signed with [cosign](https://github.com/sigstore/cosign) using keyless OIDC via GitHub Actions
+- All GitHub Actions are pinned to full commit SHAs to prevent supply chain attacks
+
+## Disclosures
+
+We strive to ship secure software, but we need the community to help us find security breaches.
+
+In case of a confirmed breach, reporters will get full credit and can be kept in the loop, if preferred.
+
+### Private Disclosure Processes
+
+We ask that all suspected vulnerabilities be privately and responsibly disclosed via one of:
+
+- [GitHub Private Vulnerability Reporting](https://github.com/kedacore/http-add-on/security/advisories/new) (preferred)
+- Email to [KEDA maintainers](mailto:cncf-keda-maintainers@lists.cncf.io)
+
+### Public Disclosure Processes
+
+If you know of a publicly disclosed security vulnerability please IMMEDIATELY email the [KEDA maintainers](mailto:cncf-keda-maintainers@lists.cncf.io) to inform about the vulnerability so they may start the patch, release, and communication process.
+
+## Communication
+
+[GitHub Security Advisory](https://github.com/kedacore/http-add-on/security/advisories) will be used to communicate during the process of identifying, fixing, and shipping the mitigation of the vulnerability.
+
+The advisory will only be made public when the patched version is released to inform the community of the breach and its potential security impact.
+
+## Security Scope
+
+Vulnerabilities in the HTTP Add-on components (interceptor, operator, scaler) are in scope. This includes authentication/authorization bypasses, request smuggling, denial of service, and privilege escalation within the components.
+
+Misconfiguration of upstream Kubernetes RBAC, network policies, or KEDA core is out of scope.


### PR DESCRIPTION
### TODO

- [x] Have private vulnerability reporting enabled in this repo, see https://github.com/kedacore/http-add-on/settings/security_analysis 
	- works https://github.com/kedacore/http-add-on/security/advisories/new

### Summary

Addresses multiple OpenSSF Scorecard checks to improve the project's supply chain security score.

Current status of this project can be found here: https://scorecard.dev/viewer/?uri=github.com/kedacore/http-add-on

This PR should improve:
- Token-Permissions
- Signed-Releases
- Security-Policy

### Changes
- Add top-level `permissions: contents: read` to build_release and pr-notify workflows
- Remove unnecessary `actions: write` from stale workflow
- Move write permissions from top-level to job-level in stale and codeql workflows
- Add SECURITY.md with vulnerability disclosure process based on the KEDA SECURITY.md
- Sign release manifests with cosign using modern --bundle format
- Switch to `github.token` canonical form
- Remove outdated "not production ready" comment from canary workflow

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

See #1619 
