### PR TITLE
fix: rename KEDAHTTP_OPERATOR_EXTERNAL_SCALER_* env vars to KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Deprecations
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Operator**: Rename `KEDAHTTP_OPERATOR_EXTERNAL_SCALER_SERVICE` and `KEDAHTTP_OPERATOR_EXTERNAL_SCALER_PORT` environment variables to `KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_SERVICE` and `KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_PORT`. Old names are still accepted but log a deprecation warning and will be removed in a future release. ([#1623](https://github.com/kedacore/http-add-on/issues/1623))
 
 ### Other
 

--- a/config/operator/deployment.yaml
+++ b/config/operator/deployment.yaml
@@ -31,9 +31,9 @@ spec:
             - --zap-encoder=console
             - --zap-time-encoding=rfc3339
           env:
-            - name: KEDAHTTP_OPERATOR_EXTERNAL_SCALER_SERVICE
+            - name: KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_SERVICE
               value: "keda-add-ons-http-external-scaler"
-            - name: KEDAHTTP_OPERATOR_EXTERNAL_SCALER_PORT
+            - name: KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_PORT
               value: "9090"
             - name: KEDA_HTTP_OPERATOR_NAMESPACE
               value: "keda"

--- a/operator/controllers/http/config/config.go
+++ b/operator/controllers/http/config/config.go
@@ -2,15 +2,17 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/caarlos0/env/v11"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // ExternalScaler holds static configuration info for the external scaler
 type ExternalScaler struct {
-	ServiceName string `env:"KEDAHTTP_OPERATOR_EXTERNAL_SCALER_SERVICE,required"`
-	Port        int32  `env:"KEDAHTTP_OPERATOR_EXTERNAL_SCALER_PORT" envDefault:"8091"`
+	ServiceName string `env:"KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_SERVICE,required"`
+	Port        int32  `env:"KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_PORT" envDefault:"8091"`
 }
 
 type Base struct {
@@ -38,6 +40,25 @@ func (e ExternalScaler) HostName(namespace string) string {
 	)
 }
 
+// Deprecated env var names (missing underscore after KEDA).
+// TODO: remove in v0.16.0
+var externalScalerDeprecatedEnvVars = map[string]string{
+	"KEDAHTTP_OPERATOR_EXTERNAL_SCALER_SERVICE": "KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_SERVICE",
+	"KEDAHTTP_OPERATOR_EXTERNAL_SCALER_PORT":    "KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_PORT",
+}
+
 func NewExternalScalerFromEnv() (ExternalScaler, error) {
+	logger := log.Log.WithName("setup")
+	for oldKey, newKey := range externalScalerDeprecatedEnvVars {
+		if v, ok := os.LookupEnv(oldKey); ok {
+			logger.Info("environment variable is deprecated, use the new name instead",
+				"old", oldKey, "new", newKey)
+			if _, set := os.LookupEnv(newKey); !set {
+				if err := os.Setenv(newKey, v); err != nil {
+					logger.Error(err, "failed to set environment variable", "key", newKey)
+				}
+			}
+		}
+	}
 	return env.ParseAs[ExternalScaler]()
 }


### PR DESCRIPTION
Rename `KEDAHTTP_OPERATOR_EXTERNAL_SCALER_SERVICE` and `KEDAHTTP_OPERATOR_EXTERNAL_SCALER_PORT` environment variables to `KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_SERVICE` and `KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_PORT`, fixing the missing underscore after `KEDA` to be consistent with all other `KEDA_HTTP_OPERATOR_*` variables.

For backward compatibility, the old names are still accepted as a fallback: if the old env var is set and the new one is not, its value is copied to the new name. A deprecation warning is logged when old names are detected. The old names will be removed in a future release.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on)

Fixes #