### PR TITLE
fix: use downward API for namespace env vars instead of hardcoded value

### DIFF
--- a/config/operator/deployment.yaml
+++ b/config/operator/deployment.yaml
@@ -36,7 +36,9 @@ spec:
             - name: KEDA_HTTP_OPERATOR_EXTERNAL_SCALER_PORT
               value: "9090"
             - name: KEDA_HTTP_OPERATOR_NAMESPACE
-              value: "keda"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - name: metrics-http
               containerPort: 8080

--- a/config/scaler/deployment.yaml
+++ b/config/scaler/deployment.yaml
@@ -31,7 +31,9 @@ spec:
             - --zap-time-encoding=rfc3339
           env:
             - name: KEDA_HTTP_SCALER_TARGET_ADMIN_NAMESPACE
-              value: "keda"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: KEDA_HTTP_SCALER_TARGET_ADMIN_DEPLOYMENT
               value: "keda-add-ons-http-interceptor"
             - name: KEDA_HTTP_SCALER_TARGET_ADMIN_SERVICE


### PR DESCRIPTION
The environment variables `KEDA_HTTP_OPERATOR_NAMESPACE` and `KEDA_HTTP_SCALER_TARGET_ADMIN_NAMESPACE` had the namespace `keda` hardcoded as a literal value, which breaks deployments in any namespace other than `keda`.

This PR replaces the hardcoded values with `fieldRef` to `metadata.namespace` using the Kubernetes downward API, so the operator and scaler pods automatically discover their own namespace at runtime.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on)

Fixes #