### PR TITLE
chore: exclude gnu.org/make from lychee link checks

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -6,4 +6,5 @@ retry_wait_time = 10 # default: 1s; survive transient network failures
 
 exclude = [
   '^http://opentelemetry-collector\.open-telemetry-system:4318',
+  '^https://www\.gnu\.org/software/make/',                       # often returns 429
 ]


### PR DESCRIPTION
The URL frequently returns 429 Too Many Requests, causing flaky link-check CI runs unrelated to actual broken links.
Example workflow: https://github.com/kedacore/http-add-on/actions/runs/25669416892/attempts/1?pr=1626

### Changes 
- Add https://www.gnu.org/software/make/ to lychee.toml exclude list

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
