### PR TITLE
chore: flatten nested checklist in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,10 +8,8 @@ _Provide a description of what has been changed_
 
 ### Checklist
 
-- [ ] Commits are signed with Developer Certificate of Origin (DCO)
-- [ ] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
-- [ ] Any necessary documentation is added, such as:
-  - [`README.md`](../README.md)
-  - [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on)
+- [ ] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
+- [ ] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
+- [ ] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))
 
 Fixes #


### PR DESCRIPTION
The task-list-completed GitHub check doesn't handle parent checkbox items with nested sub-items — it counts the parent as incomplete regardless of sub-item state.
Check the status of `task-list-completed` in this PR - it passes despite it being unchecked.

We could also fix it in the repo of task-list-completed but IMO this is a bit simpler 😅 

Changes:
- Inline documentation sub-items into a single flat checkbox item


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on)
