### PR TITLE
Replace gorilla/websocket with coder/websocket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ tool sigs.k8s.io/controller-tools/cmd/controller-gen
 require (
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cert-manager/cert-manager v1.19.5
+	github.com/coder/websocket v1.8.12
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0
 	github.com/kedacore/keda/v2 v2.18.3
 	github.com/onsi/ginkgo/v2 v2.28.3
@@ -79,6 +79,7 @@ require (
 	github.com/google/gnostic-models v0.7.1 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/cert-manager/cert-manager v1.19.5 h1:g/R078N+wd5NFd2EUEAf4seaW8vhPek/
 github.com/cert-manager/cert-manager v1.19.5/go.mod h1:fb7XyBairtEkSutiyJUKJGngt1Z/3oRjn8h0jIjfw6o=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/test/e2e/default/websocket_test.go
+++ b/test/e2e/default/websocket_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
@@ -35,13 +35,16 @@ func TestWebSocket(t *testing.T) {
 			conn := f.WebSocketDial(f.Hostname(), "/echo")
 
 			msg := "hello from e2e"
-			if err := conn.WriteMessage(websocket.TextMessage, []byte(msg)); err != nil {
+			if err := conn.Write(ctx, websocket.MessageText, []byte(msg)); err != nil {
 				t.Fatalf("failed to write WebSocket message: %v", err)
 			}
 
-			_, received, err := conn.ReadMessage()
+			msgType, received, err := conn.Read(ctx)
 			if err != nil {
 				t.Fatalf("failed to read WebSocket message: %v", err)
+			}
+			if msgType != websocket.MessageText {
+				t.Errorf("expected message type %v, got %v", websocket.MessageText, msgType)
 			}
 			if string(received) != msg {
 				t.Errorf("expected echo %q, got %q", msg, string(received))

--- a/test/helpers/traffic.go
+++ b/test/helpers/traffic.go
@@ -4,6 +4,7 @@ package helpers
 
 import (
 	"cmp"
+	"context"
 	"crypto/tls"
 	"io"
 	"net"
@@ -12,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 )
 
 type Request struct {
@@ -142,20 +143,24 @@ func (f *Framework) AssertStatus(r Request, expectedStatus int) {
 func (f *Framework) WebSocketDial(host, path string) *websocket.Conn {
 	f.t.Helper()
 
-	dialer := websocket.Dialer{
-		HandshakeTimeout: 45 * time.Second,
-		NetDialContext: (&net.Dialer{
-			Timeout: 10 * time.Second,
-		}).DialContext,
-	}
+	ctx, cancel := context.WithTimeout(f.ctx, 45*time.Second)
+	defer cancel()
 
-	wsURL := url.URL{Scheme: "ws", Host: f.proxyAddr, Path: path}
-	conn, resp, err := dialer.Dial(wsURL.String(), http.Header{"Host": []string{host}})
+	wsURL := url.URL{Scheme: "ws", Host: host, Path: path}
+	//nolint:bodyclose // coder/websocket.Dial documentation: "You never need to close resp.Body yourself"
+	conn, _, err := websocket.Dial(ctx, wsURL.String(), &websocket.DialOptions{
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+					return (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, network, f.proxyAddr)
+				},
+			},
+		},
+	})
 	if err != nil {
 		f.t.Fatalf("WebSocket dial to %s%s failed: %v", host, path, err)
 	}
-	_ = resp.Body.Close()
-	f.t.Cleanup(func() { _ = conn.Close() })
+	f.t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
 
 	return conn
 }


### PR DESCRIPTION
- Updated go.mod to use github.com/coder/websocket v1.8.12
- Migrated test/helpers/traffic.go to use coder/websocket API
- Updated test/e2e/default/websocket_test.go to use new API
- Added context support for WebSocket operations
- Improved close handling with proper status codes

Fixes #1617 

- [x] dummy checkbox
