### PR TITLE
docs: reference new e2e test suite in contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ Where component is `General`, `Interceptor`, `Operator`, or `Scaler`. Run `./hac
 - Reference the issue being fixed (e.g., `Fixes #123`).
 - Ensure `make test` passes before submitting.
 - Include documentation updates in the same PR for changes that affect behavior, and if appropriate, in [the KEDA docs repository](https://github.com/kedacore/keda-docs).
-- For end-to-end tests, see [tests/README.md](./tests/README.md).
+- For end-to-end tests, see [Running E2E Tests](./docs/developing.md#running-e2e-tests) in `docs/developing.md`.
 
 ## Developer Certificate of Origin: Signing your work
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -119,6 +119,17 @@ make e2e-test E2E_ARGS="--labels=area=scaling"
 make e2e-test E2E_ARGS="--dry-run"
 ```
 
-The `PROFILE` variable selects a test profile directory under `test/e2e/` (e.g. `PROFILE=tls` runs `./test/e2e/tls/...`). Each subdirectory in `test/e2e/` is a profile.
+The `PROFILE` variable selects a test profile directory under `test/e2e/` (e.g. `PROFILE=tls` runs `./test/e2e/tls/...`).
+Each subdirectory in `test/e2e/` is a profile.
 The `RUN` variable filters tests by name using Go's `-run` flag (supports regex, e.g. `RUN=TestColdStart` or `RUN="TestHost|TestPath"`).
 The `E2E_ARGS` variable passes flags to the [e2e-framework](https://github.com/kubernetes-sigs/e2e-framework) via `-args` (e.g. `--labels`, `--feature`, `--skip-labels`, `--dry-run`).
+
+### Writing a new test
+
+Add your test to the profile whose add-on configuration it needs (or propose a new profile if none fits).
+
+Each test creates a feature spec with setup and assertions, then runs it against the profile's shared `testenv`.
+The [`test/helpers/`](../test/helpers/) package provides a `Framework` that handles the common boilerplate: creating test apps, interceptor routes, scaled objects, sending requests, and waiting for expected replica counts.
+The framework also manages namespace lifecycle, so individual tests don't need explicit cleanup.
+
+See [`test/e2e/default/cold_start_test.go`](../test/e2e/default/cold_start_test.go) for a complete example of this pattern.


### PR DESCRIPTION
The old e2e tests in tests/ are being replaced by the new suite in test/e2e/. CONTRIBUTING.md still pointed to the old tests/README.md.

### Changes 
- Update CONTRIBUTING.md to link to docs/developing.md#running-e2e-tests
- Add "Writing a new test" section to docs/developing.md explaining the test pattern, framework helpers, and linking to an example


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))
