### PR TITLE
feat(operator): add OpenTelemetry distributed tracing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,8 @@ This changelog keeps track of work items that have been completed and are ready 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
 
 ### New
-
 - **General**: Add `coldStart.placeholder` support for returning static HTTP responses during scale-from-zero ([#874](https://github.com/kedacore/http-add-on/issues/874))
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Operator**: Add OpenTelemetry distributed tracing support ([#965](https://github.com/kedacore/http-add-on/issues/965))
 - **Scaler**: Add OpenTelemetry metrics and distributed tracing to the external scaler ([#965](https://github.com/kedacore/http-add-on/issues/965))
 
 ### Improvements

--- a/operator/main.go
+++ b/operator/main.go
@@ -17,8 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
+	"runtime"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -33,12 +35,15 @@ import (
 	httpcontrollers "github.com/kedacore/http-add-on/operator/controllers/http"
 	"github.com/kedacore/http-add-on/operator/controllers/http/config"
 	kedacache "github.com/kedacore/http-add-on/pkg/cache"
+	"github.com/kedacore/http-add-on/pkg/observability"
 )
 
 var (
 	scheme   = kedacache.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
+
+const serviceName = "keda-http-operator"
 
 func init() {
 	// TODO(v1): remove when removing HTTPSO
@@ -49,6 +54,7 @@ func init() {
 // +kubebuilder:rbac:groups=coordination.k8s.io,namespace=keda,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 func main() {
+	defer os.Exit(1)
 	var metricsAddr string
 	var metricsSecure bool
 	var metricsAuth bool
@@ -73,15 +79,30 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	tracingCfg := observability.MustParseTracingConfig()
+
+	if tracingCfg.Enabled {
+		shutdown, err := observability.SetupTracing(context.Background(), serviceName, tracingCfg)
+		if err != nil {
+			setupLog.Error(err, "error setting up tracer")
+			runtime.Goexit()
+		}
+		defer func() {
+			if err := shutdown(context.Background()); err != nil {
+				setupLog.Error(err, "error during tracer shutdown")
+			}
+		}()
+	}
+
 	externalScalerCfg, err := config.NewExternalScalerFromEnv()
 	if err != nil {
 		setupLog.Error(err, "unable to parse external scaler config from environment")
-		os.Exit(1)
+		runtime.Goexit()
 	}
 	baseConfig, err := config.NewBaseFromEnv()
 	if err != nil {
 		setupLog.Error(err, "unable to parse operator config from environment")
-		os.Exit(1)
+		runtime.Goexit()
 	}
 
 	var namespaces map[string]cache.Config
@@ -123,7 +144,7 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
+		runtime.Goexit()
 	}
 
 	if err = (&httpcontrollers.HTTPScaledObjectReconciler{
@@ -134,28 +155,28 @@ func main() {
 		BaseConfig:           baseConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "HTTPScaledObject")
-		os.Exit(1)
+		runtime.Goexit()
 	}
 	if err = (&httpcontrollers.InterceptorRouteReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "InterceptorRoute")
-		os.Exit(1)
+		runtime.Goexit()
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
+		runtime.Goexit()
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
+		runtime.Goexit()
 	}
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
+		runtime.Goexit()
 	}
 }


### PR DESCRIPTION
Add OTEL tracing to the operator using the shared `pkg/observability` package
(introduced in #1634), making it consistent with the interceptor and scaler.

**Tracing:**
- W3C TraceContext + Baggage propagation
- Console, HTTP/protobuf, and gRPC trace exporters

**Configuration env vars** (same as interceptor/scaler):
- `OTEL_EXPORTER_OTLP_TRACES_ENABLED` (default: `false`)
- `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` (default: `console`)

**Why no custom metrics?**
Controller-runtime uses Prometheus natively (not OTEL) and already exposes
comprehensive reconciliation metrics out of the box:
```
controller_runtime_reconcile_total{controller="httpscaledobject",result="success|error|requeue|requeue_after"}
controller_runtime_reconcile_duration_seconds_bucket{controller="..."}
workqueue_depth{name="..."}
```
Users who need OTLP metric export from the operator can use a
Prometheus-to-OTLP bridge (e.g., the OpenTelemetry Collector's Prometheus
receiver).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog has been updated and is aligned with our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [ ] Any necessary documentation is added, such as:
  - [`README.md`](../README.md)
  - [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on)

Part of https://github.com/kedacore/http-add-on/issues/965