### PR TITLE
ci: add workflow to block PRs with 'on hold' label

### DIFF
--- a/.github/workflows/on-hold.yml
+++ b/.github/workflows/on-hold.yml
@@ -1,0 +1,22 @@
+name: On Hold
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-hold-label:
+    name: Block PR if on hold
+    runs-on: ubuntu-slim
+    steps:
+      - name: Fail if PR has 'on hold' label
+        if: contains(github.event.pull_request.labels.*.name, 'on hold')
+        run: |
+          echo "::error::This PR is on hold. Remove the 'on hold' label to unblock merging."
+          exit 1


### PR DESCRIPTION
This merge check should prevent an accidential merges of PRs with breaking changes or such meant for later releases like:
- renovate PRs with updates breaking k8s compatibility
- PRs like #1637 which we only want to merge before v1

I didnt actually test the MR but from what I read this should do, see e.g. https://stackoverflow.com/a/59588725

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
