### PR TITLE
fix: drain in-flight requests on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Fixes
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Interceptor**: Fix graceful shutdown so in-flight requests are drained before the process exits. The interceptor now waits for active handlers to complete (bounded by `KEDA_HTTP_DRAIN_TIMEOUT`), marks the readiness probe unhealthy immediately on SIGTERM, and delays listener closure by `KEDA_HTTP_SHUTDOWN_DELAY` to let Kubernetes propagate endpoint removal. ([#1636](https://github.com/kedacore/http-add-on/issues/1636))
 - **Interceptor**: Fix panic with "invalid concurrent Body.Read call" when reverse proxy fails without consuming the request body ([#1668](https://github.com/kedacore/http-add-on/issues/1668))
 - **Scaler**: Fix incorrect HPA values when both concurrency and requestRate metrics are configured ([#1659](https://github.com/kedacore/http-add-on/issues/1659))
 

--- a/config/interceptor/deployment.yaml
+++ b/config/interceptor/deployment.yaml
@@ -70,4 +70,4 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: interceptor
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 45

--- a/interceptor/admin.go
+++ b/interceptor/admin.go
@@ -13,7 +13,10 @@ func BuildAdminHandler(logger logr.Logger, counter queue.Counter, probeHandler h
 	mux := http.NewServeMux()
 
 	mux.Handle("/readyz", probeHandler)
-	mux.Handle("/livez", probeHandler)
+	mux.HandleFunc("/livez", func(w http.ResponseWriter, _ *http.Request) {
+		// Best practice is to always return 200 as this indicates process health
+		w.WriteHeader(http.StatusOK)
+	})
 
 	queue.AddCountsRoute(
 		logger,

--- a/interceptor/admin_test.go
+++ b/interceptor/admin_test.go
@@ -16,7 +16,7 @@ func TestAdminHandler(t *testing.T) {
 	}{
 		"livez": {
 			path:            "/livez",
-			wantProbeCalled: true,
+			wantProbeCalled: false,
 			wantStatus:      http.StatusOK,
 		},
 		"readyz": {

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -21,6 +21,7 @@ type Serving struct {
 	// CacheSyncPeriod is the time interval for the controller-runtime cache to resync.
 	// TODO: consider removing this to use the default value, otherwise align the env var name
 	CacheSyncPeriod time.Duration `env:"KEDA_HTTP_SCALER_CONFIG_MAP_INFORMER_RSYNC_PERIOD" envDefault:"60m"`
+
 	// ProxyTLSEnabled is a flag to specify whether the interceptor proxy should
 	// be running using a TLS enabled server
 	ProxyTLSEnabled bool `env:"KEDA_HTTP_PROXY_TLS_ENABLED" envDefault:"false"`
@@ -47,12 +48,23 @@ type Serving struct {
 	// TLSCurvePreferences is a comma-separated list of elliptic curve names
 	// (e.g. "X25519,CurveP256"). If empty, the default Go curve preferences are used.
 	TLSCurvePreferences string `env:"KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES" envDefault:""`
+
 	// ProfilingAddr if not empty, pprof will be available on this address, assuming host:port here
 	ProfilingAddr string `env:"PROFILING_BIND_ADDRESS" envDefault:""`
 	// EnableColdStartHeader enables/disables the X-KEDA-HTTP-Cold-Start response header
 	EnableColdStartHeader bool `env:"KEDA_HTTP_ENABLE_COLD_START_HEADER" envDefault:"true"`
 	// LogRequests enables/disables logging of incoming requests
 	LogRequests bool `env:"KEDA_HTTP_LOG_REQUESTS" envDefault:"false"`
+
+	// DrainTimeout is the maximum time to wait for in-flight requests to
+	// complete after the proxy listener is closed. If 0, waits indefinitely
+	// (bounded only by terminationGracePeriodSeconds).
+	DrainTimeout time.Duration `env:"KEDA_HTTP_DRAIN_TIMEOUT" envDefault:"30s"`
+	// ShutdownDelay is the time between receiving SIGTERM and closing the proxy
+	// listener. During this window the readiness probe returns 503 while the
+	// server continues serving in-flight and new requests, giving Kubernetes
+	// time to propagate endpoint removal.
+	ShutdownDelay time.Duration `env:"KEDA_HTTP_SHUTDOWN_DELAY" envDefault:"5s"`
 }
 
 // MustParseServing parses standard configs and returns the

--- a/interceptor/handler/probe.go
+++ b/interceptor/handler/probe.go
@@ -10,13 +10,15 @@ import (
 )
 
 type Probe struct {
+	draining       *atomic.Bool
+	hasBeenHealthy atomic.Bool
 	healthCheckers []util.HealthChecker
 	healthy        atomic.Bool
-	hasBeenHealthy atomic.Bool
 }
 
-func NewProbe(healthChecks ...util.HealthChecker) *Probe {
+func NewProbe(draining *atomic.Bool, healthChecks ...util.HealthChecker) *Probe {
 	return &Probe{
+		draining:       draining,
 		healthCheckers: healthChecks,
 	}
 }
@@ -28,7 +30,7 @@ func (ph *Probe) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	sc := http.StatusOK
-	if !ph.healthy.Load() {
+	if ph.draining.Load() || !ph.healthy.Load() {
 		sc = http.StatusServiceUnavailable
 	}
 	w.WriteHeader(sc)
@@ -56,6 +58,10 @@ func (ph *Probe) Start(ctx context.Context) {
 }
 
 func (ph *Probe) check(ctx context.Context) {
+	if ph.draining.Load() {
+		return
+	}
+
 	logger := util.LoggerFromContext(ctx)
 	logger = logger.WithName("Probe")
 
@@ -66,7 +72,7 @@ func (ph *Probe) check(ctx context.Context) {
 			// Log at info level before the first successful check to avoid
 			// noisy error logs during normal startup sequencing.
 			if ph.hasBeenHealthy.Load() {
-				logger.Error(err, "health check function failed")
+				logger.Error(err, "health check failed")
 			} else {
 				logger.Info("waiting for health check to pass", "error", err)
 			}

--- a/interceptor/handler/probe_test.go
+++ b/interceptor/handler/probe_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -44,7 +45,8 @@ func TestProbeServeHTTP(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ph := NewProbe(tt.checkers...)
+			var draining atomic.Bool
+			ph := NewProbe(&draining, tt.checkers...)
 			ph.check(t.Context())
 			assertProbe(t, ph, tt.code)
 		})
@@ -54,8 +56,11 @@ func TestProbeServeHTTP(t *testing.T) {
 func TestProbeHealthyToUnhealthyTransition(t *testing.T) {
 	ctx := t.Context()
 
-	var retErr error
-	ph := NewProbe(util.HealthCheckerFunc(func(_ context.Context) error {
+	var (
+		draining atomic.Bool
+		retErr   error
+	)
+	ph := NewProbe(&draining, util.HealthCheckerFunc(func(_ context.Context) error {
 		return retErr
 	}))
 
@@ -69,8 +74,11 @@ func TestProbeHealthyToUnhealthyTransition(t *testing.T) {
 
 func TestProbePeriodicCheck(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		var count int
-		ph := NewProbe(util.HealthCheckerFunc(func(_ context.Context) error {
+		var (
+			draining atomic.Bool
+			count    int
+		)
+		ph := NewProbe(&draining, util.HealthCheckerFunc(func(_ context.Context) error {
 			count++
 			return nil
 		}))
@@ -92,6 +100,25 @@ func TestProbePeriodicCheck(t *testing.T) {
 			t.Fatalf("after 2nd cycle: count=%d, want 2", count)
 		}
 	})
+}
+
+func TestProbeDraining(t *testing.T) {
+	var draining atomic.Bool
+	ph := NewProbe(&draining, util.HealthCheckerFunc(func(_ context.Context) error {
+		return nil
+	}))
+
+	// Initially healthy after a check.
+	ph.check(t.Context())
+	assertProbe(t, ph, http.StatusOK)
+
+	// After setting draining, probe must return 503.
+	draining.Store(true)
+	assertProbe(t, ph, http.StatusServiceUnavailable)
+
+	// A subsequent health check must NOT flip readiness back to healthy.
+	ph.check(t.Context())
+	assertProbe(t, ph, http.StatusServiceUnavailable)
 }
 
 func assertProbe(t *testing.T, ph *Probe, code int) {

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -3,13 +3,12 @@ package main
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"flag"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec // G108: pprof intentionally exposed, gated by --profiling-addr
 	"os"
-	"runtime"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -47,7 +46,13 @@ var setupLog = ctrl.Log.WithName("setup")
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 
 func main() {
-	defer os.Exit(1)
+	if err := run(); err != nil {
+		setupLog.Error(err, "fatal error")
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	timeoutCfg := config.MustParseTimeouts(setupLog)
 	servingCfg := config.MustParseServing()
 	metricsCfg := observability.MustParseMetricsConfig()
@@ -63,21 +68,14 @@ func main() {
 
 	setupLog.Info(
 		"starting interceptor",
-		"timeoutConfig",
-		timeoutCfg,
-		"servingConfig",
-		servingCfg,
-		"metricsConfig",
-		metricsCfg,
+		"timeoutConfig", timeoutCfg,
+		"servingConfig", servingCfg,
+		"metricsConfig", metricsCfg,
 	)
-
-	proxyTLSEnabled := servingCfg.ProxyTLSEnabled
-	profilingAddr := servingCfg.ProfilingAddr
 
 	provider, err := observability.NewMeterProvider(metrics.ServiceName, metricsCfg)
 	if err != nil {
-		setupLog.Error(err, "failed to create meter provider")
-		runtime.Goexit()
+		return fmt.Errorf("creating meter provider: %w", err)
 	}
 	defer func() {
 		if err := provider.Shutdown(context.Background()); err != nil {
@@ -87,14 +85,11 @@ func main() {
 
 	instruments, err := metrics.NewInstruments(provider)
 	if err != nil {
-		setupLog.Error(err, "failed to create metric instruments")
-		runtime.Goexit()
+		return fmt.Errorf("creating metric instruments: %w", err)
 	}
 
 	cfg := ctrl.GetConfigOrDie()
-
-	ctx := ctrl.SetupSignalHandler()
-	ctx = util.ContextWithLogger(ctx, ctrl.Log)
+	signalCtx := ctrl.SetupSignalHandler()
 
 	cacheOpts := cache.Options{
 		DefaultTransform: cache.TransformStripManagedFields(),
@@ -116,14 +111,12 @@ func main() {
 
 	ctrlCache, err := cache.New(cfg, cacheOpts)
 	if err != nil {
-		setupLog.Error(err, "creating cache")
-		runtime.Goexit()
+		return fmt.Errorf("creating cache: %w", err)
 	}
 
-	readyCache, err := k8s.NewReadyEndpointsCacheWithInformer(ctx, ctrl.Log, ctrlCache)
+	readyCache, err := k8s.NewReadyEndpointsCacheWithInformer(signalCtx, ctrl.Log, ctrlCache)
 	if err != nil {
-		setupLog.Error(err, "creating endpoints cache")
-		runtime.Goexit()
+		return fmt.Errorf("creating endpoints cache: %w", err)
 	}
 
 	queues := queue.NewMemory()
@@ -131,12 +124,10 @@ func main() {
 
 	// Setup informers to signal routing table on IR and HTTPSO changes
 	routeSources := []client.Object{&v1beta1.InterceptorRoute{}, &v1alpha1.HTTPScaledObject{}}
-
 	for _, obj := range routeSources {
-		informer, err := ctrlCache.GetInformer(ctx, obj)
+		informer, err := ctrlCache.GetInformer(signalCtx, obj)
 		if err != nil {
-			setupLog.Error(err, "getting informer", "type", fmt.Sprintf("%T", obj))
-			runtime.Goexit()
+			return fmt.Errorf("getting informer for %T: %w", obj, err)
 		}
 
 		_, err = informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
@@ -145,83 +136,108 @@ func main() {
 			DeleteFunc: func(_ any) { routingTable.Signal() },
 		})
 		if err != nil {
-			setupLog.Error(err, "adding event handlers")
-			runtime.Goexit()
+			return fmt.Errorf("adding event handlers: %w", err)
 		}
 	}
 
-	setupLog.Info("Interceptor starting")
-
-	eg, ctx := errgroup.WithContext(ctx)
-
 	if tracingCfg.Enabled {
-		shutdown, err := tracing.SetupOTelSDK(ctx, tracingCfg)
+		shutdown, err := tracing.SetupOTelSDK(signalCtx, tracingCfg)
 		if err != nil {
-			setupLog.Error(err, "Error setting up tracer")
-			runtime.Goexit()
+			return fmt.Errorf("setting up tracer: %w", err)
 		}
-
 		defer func() {
 			if shutdownErr := shutdown(context.Background()); shutdownErr != nil {
-				setupLog.Error(shutdownErr, "Error during tracer shutdown")
+				setupLog.Error(shutdownErr, "error during tracer shutdown")
 			}
 		}()
 	}
 
-	eg.Go(func() error {
+	var draining atomic.Bool
+	probeHandler := handler.NewProbe(&draining, routingTable)
+
+	// Two separate lifecycles: proxy servers drain before infrastructure shuts
+	// down. This keeps the admin server (readiness probe) alive during proxy
+	// drain so Kubernetes sees 503 rather than connection refused.
+	proxyCtx, cancelProxy := context.WithCancel(context.Background())
+	defer cancelProxy()
+	proxyCtx = util.ContextWithLogger(proxyCtx, ctrl.Log)
+
+	infraCtx, cancelInfra := context.WithCancel(context.Background())
+	defer cancelInfra()
+	infraCtx = util.ContextWithLogger(infraCtx, ctrl.Log)
+
+	proxyEg, proxyCtx := errgroup.WithContext(proxyCtx)
+	infraEg, infraCtx := errgroup.WithContext(infraCtx)
+
+	// If infrastructure dies, bring down proxy too.
+	context.AfterFunc(infraCtx, cancelProxy)
+
+	// --- Infrastructure goroutines (use infraCtx) ---
+
+	infraEg.Go(func() error {
 		setupLog.Info("starting the controller-runtime cache")
-		return ctrlCache.Start(ctx)
+		return ctrlCache.Start(infraCtx)
 	})
 
 	// Wait for cache to sync before starting components that depend on it
-	if !ctrlCache.WaitForCacheSync(ctx) {
-		setupLog.Error(nil, "cache failed to sync")
-		runtime.Goexit()
+	if !ctrlCache.WaitForCacheSync(infraCtx) {
+		return fmt.Errorf("cache failed to sync")
 	}
 
 	// Start the update loop that refreshes the routing table on InterceptorRoute & HTTPSO changes
-	eg.Go(func() error {
+	infraEg.Go(func() error {
 		setupLog.Info("starting the routing table")
-
-		if err := routingTable.Start(ctx); !util.IsIgnoredErr(err) {
-			setupLog.Error(err, "routing table failed")
-			return err
+		if err := routingTable.Start(infraCtx); !util.IsIgnoredErr(err) {
+			return fmt.Errorf("routing table: %w", err)
 		}
+		return nil
+	})
 
+	infraEg.Go(func() error {
+		probeHandler.Start(infraCtx)
 		return nil
 	})
 
 	// start the administrative server. this is the server
 	// that serves the queue size API
-	eg.Go(func() error {
+	infraEg.Go(func() error {
 		setupLog.Info("starting the admin server", "port", servingCfg.AdminPort)
-
-		if err := runAdminServer(ctx, ctrl.Log, servingCfg.AdminPort, queues, routingTable); !util.IsIgnoredErr(err) {
-			setupLog.Error(err, "admin server failed")
-			return err
+		if err := runAdminServer(infraCtx, ctrl.Log, servingCfg.AdminPort, queues, probeHandler); !util.IsIgnoredErr(err) {
+			return fmt.Errorf("admin server: %w", err)
 		}
-
 		return nil
 	})
 
 	if metricsCfg.OtelPrometheusExporterEnabled {
 		// start the prometheus compatible metrics server
 		// serves a prometheus compatible metrics endpoint on the configured port
-		eg.Go(func() error {
-			if err := runMetricsServer(ctx, ctrl.Log, metricsCfg); !util.IsIgnoredErr(err) {
-				setupLog.Error(err, "could not start the Prometheus metrics server")
-				return err
+		infraEg.Go(func() error {
+			if err := runMetricsServer(infraCtx, ctrl.Log, metricsCfg); !util.IsIgnoredErr(err) {
+				return fmt.Errorf("metrics server: %w", err)
 			}
-
 			return nil
 		})
 	}
 
+	if servingCfg.ProfilingAddr != "" {
+		infraEg.Go(func() error {
+			setupLog.Info("enabling pprof for profiling", "address", servingCfg.ProfilingAddr)
+			if err := kedahttp.ServeContext(infraCtx, kedahttp.ServerConfig{
+				Addr:    servingCfg.ProfilingAddr,
+				Handler: http.DefaultServeMux,
+			}); !util.IsIgnoredErr(err) {
+				return fmt.Errorf("pprof server: %w", err)
+			}
+			return nil
+		})
+	}
+
+	// --- Proxy goroutines (use proxyCtx) ---
+
 	// start the proxy servers. This is the server that
 	// accepts, holds and forwards user requests
-	// start a proxy server with TLS
-	if proxyTLSEnabled {
-		eg.Go(func() error {
+	if servingCfg.ProxyTLSEnabled {
+		proxyEg.Go(func() error {
 			tlsCfg, err := BuildTLSConfig(TLSOptions{
 				CertificatePath:    servingCfg.TLSCertPath,
 				KeyPath:            servingCfg.TLSKeyPath,
@@ -233,53 +249,67 @@ func main() {
 				CurvePreferences:   servingCfg.TLSCurvePreferences,
 			}, setupLog)
 			if err != nil {
-				setupLog.Error(err, "failed to configure TLS")
-				return fmt.Errorf("failed to configure TLS: %w", err)
+				return fmt.Errorf("configuring TLS: %w", err)
 			}
 
-			proxyTLSPort := servingCfg.TLSPort
-
-			setupLog.Info("starting the proxy server with TLS enabled", "port", proxyTLSPort)
-
-			if err := runProxyServer(ctx, ctrl.Log, queues, readyCache, routingTable, ctrlCache, timeoutCfg, servingCfg, proxyTLSPort, tlsCfg, tracingCfg, instruments); !util.IsIgnoredErr(err) {
-				setupLog.Error(err, "tls proxy server failed")
-				return err
+			setupLog.Info("starting the proxy server with TLS enabled", "port", servingCfg.TLSPort)
+			if err := runProxyServer(proxyCtx, ctrl.Log, queues, readyCache, routingTable, ctrlCache, timeoutCfg, servingCfg, servingCfg.TLSPort, tlsCfg, tracingCfg, instruments, &draining); !util.IsIgnoredErr(err) {
+				return fmt.Errorf("tls proxy server: %w", err)
 			}
 			return nil
 		})
 	}
 
-	// start a proxy server without TLS.
-	eg.Go(func() error {
-		setupLog.Info("starting the proxy server with TLS disabled", "port", servingCfg.ProxyPort)
-
-		if err := runProxyServer(ctx, ctrl.Log, queues, readyCache, routingTable, ctrlCache, timeoutCfg, servingCfg, servingCfg.ProxyPort, nil, tracingCfg, instruments); !util.IsIgnoredErr(err) {
-			setupLog.Error(err, "proxy server failed")
-			return err
+	proxyEg.Go(func() error {
+		setupLog.Info("starting the proxy server", "port", servingCfg.ProxyPort)
+		if err := runProxyServer(proxyCtx, ctrl.Log, queues, readyCache, routingTable, ctrlCache, timeoutCfg, servingCfg, servingCfg.ProxyPort, nil, tracingCfg, instruments, &draining); !util.IsIgnoredErr(err) {
+			return fmt.Errorf("proxy server: %w", err)
 		}
-
 		return nil
 	})
 
-	if len(profilingAddr) > 0 {
-		eg.Go(func() error {
-			setupLog.Info("enabling pprof for profiling", "address", profilingAddr)
-			srv := &http.Server{
-				Addr:              profilingAddr,
-				ReadHeaderTimeout: time.Minute, // mitigate Slowloris attacks
-			}
-			return srv.ListenAndServe()
-		})
-	}
+	// --- Shutdown sequencing ---
+	//
+	// Pod deletion triggers the EndpointSlice removal and a SIGTERM:
+	//   1. Mark readiness probe unhealthy (503 on /readyz) for external load balancers
+	//   2. Delay the Shutdown e.g. to allow endpoint removal to be propagated to all nodes
+	//   3. Close proxy listener, drain in-flight requests
+	//   4. After proxy drain completes, stop infrastructure
+	go func() {
+		<-signalCtx.Done()
+
+		setupLog.Info("shutdown: starting drain")
+		draining.Store(true)
+
+		if servingCfg.ShutdownDelay > 0 {
+			setupLog.Info("shutdown: delaying shutdown while still accepting new connections", "delay", servingCfg.ShutdownDelay)
+			time.Sleep(servingCfg.ShutdownDelay)
+		}
+
+		setupLog.Info("shutdown: draining proxy connections", "timeout", servingCfg.DrainTimeout)
+		cancelProxy()
+	}()
 
 	build.PrintComponentInfo(ctrl.Log, "Interceptor")
+	setupLog.Info("Interceptor starting")
 
-	if err := eg.Wait(); err != nil && !errors.Is(err, context.Canceled) {
-		setupLog.Error(err, "fatal error")
-		runtime.Goexit()
+	// Wait for proxy to finish (blocks during normal operation).
+	proxyErr := proxyEg.Wait()
+
+	// Proxy drained (or failed), shut down infrastructure.
+	setupLog.Info("shutdown: proxy drained, stopping infrastructure")
+	cancelInfra()
+	infraErr := infraEg.Wait()
+
+	if proxyErr != nil && !util.IsIgnoredErr(proxyErr) {
+		return fmt.Errorf("proxy: %w", proxyErr)
+	}
+	if infraErr != nil && !util.IsIgnoredErr(infraErr) {
+		return fmt.Errorf("infrastructure: %w", infraErr)
 	}
 
 	setupLog.Info("Bye!")
+	return nil
 }
 
 func runAdminServer(
@@ -287,18 +317,18 @@ func runAdminServer(
 	lggr logr.Logger,
 	port int,
 	q queue.Counter,
-	routingTable routing.Table,
+	probeHandler *handler.Probe,
 ) error {
 	lggr = lggr.WithName("runAdminServer")
-
-	probeHandler := handler.NewProbe(routingTable)
-	go probeHandler.Start(ctx)
 
 	adminHandler := BuildAdminHandler(lggr, q, probeHandler)
 
 	addr := fmt.Sprintf("0.0.0.0:%d", port)
 	lggr.Info("admin server starting", "address", addr)
-	return kedahttp.ServeContext(ctx, addr, adminHandler, nil)
+	return kedahttp.ServeContext(ctx, kedahttp.ServerConfig{
+		Addr:    addr,
+		Handler: adminHandler,
+	})
 }
 
 func runMetricsServer(
@@ -310,7 +340,10 @@ func runMetricsServer(
 	addr := fmt.Sprintf("0.0.0.0:%d", metricsCfg.OtelPrometheusExporterPort)
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
-	return kedahttp.ServeContext(ctx, addr, mux, nil)
+	return kedahttp.ServeContext(ctx, kedahttp.ServerConfig{
+		Addr:    addr,
+		Handler: mux,
+	})
 }
 
 func runProxyServer(
@@ -326,6 +359,7 @@ func runProxyServer(
 	tlsCfg *tls.Config,
 	tracingConfig config.Tracing,
 	instruments *metrics.Instruments,
+	draining *atomic.Bool,
 ) error {
 	// Build handler chain using the shared builder
 	rootHandler := BuildProxyHandler(&ProxyHandlerConfig{
@@ -343,5 +377,11 @@ func runProxyServer(
 
 	addr := fmt.Sprintf("0.0.0.0:%d", port)
 	logger.Info("proxy server starting", "address", addr)
-	return kedahttp.ServeContext(ctx, addr, rootHandler, tlsCfg)
+	return kedahttp.ServeContext(ctx, kedahttp.ServerConfig{
+		Addr:         addr,
+		Handler:      rootHandler,
+		TLSConfig:    tlsCfg,
+		DrainTimeout: serving.DrainTimeout,
+		Draining:     draining,
+	})
 }

--- a/pkg/http/drain.go
+++ b/pkg/http/drain.go
@@ -1,0 +1,31 @@
+package http
+
+import (
+	"net/http"
+	"sync/atomic"
+)
+
+// drainHandler sets "Connection: close" on HTTP/1.x responses during shutdown,
+// signaling clients to stop reusing the connection so in-flight requests can drain.
+// HTTP/2 is not handled here because Go's HTTP/2 server already sends GOAWAY frames
+// when the server is shutting down.
+type drainHandler struct {
+	next     http.Handler
+	draining *atomic.Bool
+}
+
+var _ http.Handler = (*drainHandler)(nil)
+
+func newDrainHandler(next http.Handler, draining *atomic.Bool) *drainHandler {
+	return &drainHandler{
+		next:     next,
+		draining: draining,
+	}
+}
+
+func (d *drainHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if d.draining.Load() && r.ProtoMajor == 1 {
+		w.Header().Set("Connection", "close")
+	}
+	d.next.ServeHTTP(w, r)
+}

--- a/pkg/http/drain_test.go
+++ b/pkg/http/drain_test.go
@@ -1,0 +1,55 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDrainHandler(t *testing.T) {
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := map[string]struct {
+		draining   bool
+		protoMajor int
+		wantHeader string
+	}{
+		"not draining": {
+			protoMajor: 1,
+			wantHeader: "",
+		},
+		"draining HTTP/1.1": {
+			draining:   true,
+			protoMajor: 1,
+			wantHeader: "close",
+		},
+		"draining HTTP/2": {
+			draining:   true,
+			protoMajor: 2,
+			wantHeader: "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var draining atomic.Bool
+			if tc.draining {
+				draining.Store(true)
+			}
+
+			h := newDrainHandler(ok, &draining)
+			req := httptest.NewRequest("GET", "/", nil)
+			req.ProtoMajor = tc.protoMajor
+			rec := httptest.NewRecorder()
+
+			h.ServeHTTP(rec, req)
+
+			if got := rec.Header().Get("Connection"); got != tc.wantHeader {
+				t.Errorf("Connection header = %q, want %q", got, tc.wantHeader)
+			}
+		})
+	}
+}

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -3,41 +3,118 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
+	"sync"
+	"sync/atomic"
 	"time"
-
-	"github.com/kedacore/http-add-on/pkg/util"
 )
 
-// ServeContext creates a TCP listener on addr and serves HTTP(S) requests until ctx is cancelled.
-func ServeContext(ctx context.Context, addr string, hdl http.Handler, tlsConfig *tls.Config) error {
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		return fmt.Errorf("listening on %s: %w", addr, err)
-	}
-	return serve(ctx, ln, hdl, tlsConfig)
+// ServerConfig holds the parameters for ListenAndServe.
+type ServerConfig struct {
+	Addr         string
+	Handler      http.Handler
+	TLSConfig    *tls.Config
+	DrainTimeout time.Duration
+	Draining     *atomic.Bool
 }
 
-func serve(ctx context.Context, ln net.Listener, hdl http.Handler, tlsConfig *tls.Config) error {
-	srv := &http.Server{
-		Handler:           hdl,
-		TLSConfig:         tlsConfig,
-		ReadHeaderTimeout: time.Minute, // mitigate Slowloris attacks
+// ServeContext creates a TCP listener on Addr and serves HTTP(S) requests
+// until ctx is cancelled. When ctx is cancelled, it initiates a graceful
+// shutdown, waiting up to DrainTimeout for in-flight requests to complete.
+// If DrainTimeout is 0, it waits indefinitely.
+//
+// While Draining is true, HTTP/1.x responses include a "Connection: close"
+// header, signalling clients to stop reusing the connection.
+func ServeContext(ctx context.Context, cfg ServerConfig) error {
+	ln, err := net.Listen("tcp", cfg.Addr)
+	if err != nil {
+		return fmt.Errorf("listening on %s: %w", cfg.Addr, err)
+	}
+	return serve(ctx, ln, cfg)
+}
+
+// serve creates an HTTP server with handlers and mechanisms to drain open connections on shutdown.
+// The whole draining logic is quite complex e.g. as WebSockets can't be drained like normal HTTP connections.
+// HTTP/1.x clients are signalled via "Connection: close" once Draining is set.
+func serve(ctx context.Context, ln net.Listener, cfg ServerConfig) error {
+	// Provide a local cancel for the context to trigger a shutdown from inside if the server stops e.g. due to errors.
+	ctx, cancel := context.WithCancel(ctx)
+
+	// WebSocket connections are so-called hijacked HTTP connections that we need to 1. track and 2. cancel separately.
+	// 1. http.Server.Shutdown() does not wait for hijacked connections -> track them with a WaitGroup to allow
+	// waiting for all open connections to complete.
+	var connectionTracker sync.WaitGroup
+	trackingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connectionTracker.Add(1)
+		defer connectionTracker.Done()
+		cfg.Handler.ServeHTTP(w, r)
+	})
+
+	var handler http.Handler = trackingHandler
+	if cfg.Draining != nil {
+		handler = newDrainHandler(trackingHandler, cfg.Draining)
 	}
 
+	// 2. Create a BaseContext that can be used to cancel hijacked connections (e.g. WebSockets) after the
+	// http.Server.Shutdown() was triggered.
+	baseCtx, cancelBase := context.WithCancel(context.Background())
+	defer cancelBase()
+
+	// Create the actual server
+	srv := &http.Server{
+		Handler:           handler,
+		TLSConfig:         cfg.TLSConfig,
+		ReadHeaderTimeout: time.Minute, // mitigate Slowloris attacks
+		BaseContext: func(_ net.Listener) context.Context {
+			return baseCtx
+		},
+	}
+
+	// Define the graceful shutdown logic that triggers and waits for the draining.
+	shutdownDone := make(chan struct{})
 	go func() { //nolint:gosec // G118: ctx is already cancelled here; shutdown needs a fresh context
+		defer close(shutdownDone)
+
+		// Wait for the cancellation of the parent context or from this func in case of server errors.
 		<-ctx.Done()
 
-		if err := srv.Shutdown(context.Background()); err != nil {
-			logger := util.LoggerFromContext(ctx)
-			logger.Error(err, "failed shutting down server")
+		drainCtx := context.Background()
+		if cfg.DrainTimeout > 0 {
+			var drainCancel context.CancelFunc
+			drainCtx, drainCancel = context.WithTimeout(drainCtx, cfg.DrainTimeout)
+			defer drainCancel()
+		}
+
+		// Drain regular connections first gracefully, signal hijacked handlers only afterwards.
+		_ = srv.Shutdown(drainCtx)
+		cancelBase()
+
+		// Wait for remaining (hijacked) handlers to finish, bounded by the drain timeout.
+		ch := make(chan struct{})
+		go func() { connectionTracker.Wait(); close(ch) }()
+		select {
+		case <-ch:
+		case <-drainCtx.Done():
 		}
 	}()
 
-	if tlsConfig != nil {
-		return srv.ServeTLS(ln, "", "")
+	// Serve blocks until Shutdown closes the listener or a listener error occurs.
+	var serveErr error
+	if cfg.TLSConfig != nil {
+		serveErr = srv.ServeTLS(ln, "", "")
+	} else {
+		serveErr = srv.Serve(ln)
 	}
-	return srv.Serve(ln)
+
+	// Unblock the shutdown goroutine if Serve returned without ctx being cancelled (e.g. listener error).
+	cancel()
+	<-shutdownDone
+
+	if errors.Is(serveErr, http.ErrServerClosed) {
+		return nil
+	}
+	return serveErr
 }

--- a/pkg/http/server_test.go
+++ b/pkg/http/server_test.go
@@ -1,10 +1,14 @@
 package http
 
 import (
+	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/kedacore/http-add-on/pkg/testutil"
 )
@@ -40,7 +44,10 @@ func TestServe(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 			go func() {
-				_ = serve(t.Context(), ln, hdl, tc.serverTLS)
+				_ = serve(t.Context(), ln, ServerConfig{
+					Handler:   hdl,
+					TLSConfig: tc.serverTLS,
+				})
 			}()
 
 			// Send a test request
@@ -64,5 +71,204 @@ func TestServe(t *testing.T) {
 				t.Fatal("expected TLS connection, but resp.TLS is nil")
 			}
 		})
+	}
+}
+
+func TestServeWaitsForInFlightRequests(t *testing.T) {
+	handlerStarted := make(chan struct{})
+	handlerDone := make(chan struct{})
+
+	hdl := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(handlerStarted)
+		<-handlerDone
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serveReturned := make(chan error, 1)
+	go func() {
+		serveReturned <- serve(ctx, ln, ServerConfig{Handler: hdl})
+	}()
+
+	// Send a request that will block in the handler.
+	var resp *http.Response
+	var reqErr error
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		resp, reqErr = http.Get("http://" + ln.Addr().String()) //nolint:bodyclose // closed below after wg.Wait
+	})
+
+	// Wait for the handler to be processing the request.
+	<-handlerStarted
+
+	// Cancel the context (simulates SIGTERM). This should trigger Shutdown()
+	// which closes the listener, but serve() must NOT return until the
+	// in-flight handler finishes.
+	cancel()
+
+	// Give serve() a moment to (incorrectly) return early.
+	select {
+	case <-serveReturned:
+		t.Fatal("serve() returned while a handler was still in-flight — the shutdown drain is broken")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Let the handler finish.
+	close(handlerDone)
+
+	// Now serve() should return.
+	select {
+	case err := <-serveReturned:
+		if err != nil {
+			t.Fatalf("serve() returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serve() did not return after in-flight handler completed")
+	}
+
+	// The HTTP request should have succeeded.
+	wg.Wait()
+	if reqErr != nil {
+		t.Fatalf("HTTP request failed: %v", reqErr)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestServeWaitsForHijackedConnections(t *testing.T) {
+	handlerStarted := make(chan struct{})
+	ctxCancelled := make(chan struct{})
+	handlerGate := make(chan struct{})
+
+	hdl := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			panic(fmt.Sprintf("hijack failed: %v", err))
+		}
+		defer conn.Close()
+
+		close(handlerStarted)
+
+		// Wait for context cancellation, then signal it happened.
+		<-r.Context().Done()
+		close(ctxCancelled)
+
+		// Simulate cleanup work after context cancellation.
+		<-handlerGate
+	})
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serveReturned := make(chan error, 1)
+	go func() {
+		serveReturned <- serve(ctx, ln, ServerConfig{Handler: hdl})
+	}()
+
+	// Send a raw HTTP request that will be hijacked.
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	<-handlerStarted
+
+	// Cancel context (SIGTERM).
+	cancel()
+
+	// The handler's request context should be cancelled.
+	select {
+	case <-ctxCancelled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("hijacked handler was not notified of shutdown via context cancellation")
+	}
+
+	// serve() must NOT return while the hijacked handler is still running.
+	select {
+	case <-serveReturned:
+		t.Fatal("serve() returned while a hijacked handler was still in-flight")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Let the handler finish.
+	close(handlerGate)
+
+	// Now serve() should return.
+	select {
+	case err := <-serveReturned:
+		if err != nil {
+			t.Fatalf("serve() returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serve() did not return after hijacked handler completed")
+	}
+}
+
+func TestServeDrainTimeout(t *testing.T) {
+	handlerStarted := make(chan struct{})
+
+	// A handler that blocks forever (simulates a hung request).
+	hdl := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(handlerStarted)
+		select {} // block forever
+	})
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	drainTimeout := 200 * time.Millisecond
+
+	serveReturned := make(chan error, 1)
+	go func() {
+		serveReturned <- serve(ctx, ln, ServerConfig{
+			Handler:      hdl,
+			DrainTimeout: drainTimeout,
+		})
+	}()
+
+	// Fire off a request that will hang.
+	go func() {
+		resp, err := http.Get("http://" + ln.Addr().String())
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	<-handlerStarted
+
+	// Cancel context (SIGTERM).
+	cancel()
+
+	// serve() should return around drainTimeout, not hang forever.
+	select {
+	case err := <-serveReturned:
+		if err != nil {
+			t.Fatalf("serve() returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serve() did not return after drain timeout — it hung forever")
 	}
 }

--- a/scaler/main.go
+++ b/scaler/main.go
@@ -245,5 +245,8 @@ func runMetricsServer(ctx context.Context, lggr logr.Logger, metricsCfg observab
 	addr := fmt.Sprintf("0.0.0.0:%d", metricsCfg.OtelPrometheusExporterPort)
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
-	return kedahttp.ServeContext(ctx, addr, mux, nil)
+	return kedahttp.ServeContext(ctx, kedahttp.ServerConfig{
+		Addr:    addr,
+		Handler: mux,
+	})
 }

--- a/test/e2e/default/graceful_shutdown_test.go
+++ b/test/e2e/default/graceful_shutdown_test.go
@@ -1,0 +1,70 @@
+//go:build e2e
+
+package default_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	h "github.com/kedacore/http-add-on/test/helpers"
+)
+
+func TestGracefulShutdown(t *testing.T) {
+	// Not parallel: this test restarts the interceptor pod, which would
+	// disrupt any other tests running concurrently.
+
+	feat := features.New("graceful-shutdown").
+		WithLabel("area", "reliability").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			app := f.CreateTestApp("shutdown-app", h.AppWithReplicas(1))
+			f.CreateInterceptorRoute("shutdown-ir", app,
+				h.IRWithHosts(f.Hostname()),
+			)
+
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname()}, "shutdown-app")
+			return ctx
+		}).
+		Assess("in-flight request survives interceptor restart", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			restartErrCh := make(chan error, 1)
+			go func() {
+				// Give the request time to reach the backend and start waiting
+				time.Sleep(2 * time.Second)
+				restartErrCh <- f.RestartInterceptor()
+			}()
+
+			// Send a slow request that takes 10s to complete. If the interceptor
+			// kills in-flight requests during shutdown, this will fail with a
+			// connection error. The ProxyRequestRaw helper will call t.Fatalf,
+			// which is exactly what we want - a clear test failure.
+			resp := f.ProxyRequestRaw(h.Request{
+				Host:  f.Hostname(),
+				Query: "wait=10s",
+			})
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("expected status 200, got %d; body: %s", resp.StatusCode, string(resp.Body))
+			}
+
+			if err := <-restartErrCh; err != nil {
+				t.Fatalf("failed to restart interceptor: %v", err)
+			}
+			return ctx
+		}).
+		Assess("requests work after restart", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+			f.AssertRouteReachesApp(h.Request{Host: f.Hostname()}, "shutdown-app")
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}

--- a/test/helpers/deployment.go
+++ b/test/helpers/deployment.go
@@ -5,6 +5,7 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -130,6 +131,34 @@ func WithTLSCert(dnsNames []string) PatchDeploymentOption {
 		}
 		return nil
 	}
+}
+
+// RestartInterceptor triggers a rollout restart of the interceptor deployment
+// and waits for the new generation to become fully ready.
+func (f *Framework) RestartInterceptor() error {
+	f.t.Helper()
+
+	dep := &appsv1.Deployment{}
+	if err := f.client.Resources().Get(f.ctx, interceptorDeployment, AddonNamespace, dep); err != nil {
+		return fmt.Errorf("getting interceptor deployment: %w", err)
+	}
+
+	if dep.Spec.Template.Annotations == nil {
+		dep.Spec.Template.Annotations = make(map[string]string)
+	}
+	dep.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+
+	if err := f.client.Resources().Update(f.ctx, dep); err != nil {
+		return fmt.Errorf("updating interceptor deployment: %w", err)
+	}
+
+	if err := wait.For(
+		conditions.New(f.client.Resources()).ResourceMatch(dep, deploymentRolledOut),
+		wait.WithTimeout(defaultWaitTimeout),
+	); err != nil {
+		return fmt.Errorf("interceptor deployment did not recover: %w", err)
+	}
+	return nil
 }
 
 func deploymentRolledOut(object k8s.Object) bool {


### PR DESCRIPTION
The interceptor's serve() fired Shutdown() in a detached goroutine and never waited for it, so in-flight requests were killed right after SIGTERM. This restructures the interceptor to properly sequence shutdown:
1. pod is terminating triggering endpoint deletion
2. we expose readyz as unhealthy for external load balancers
3. we wait a few seconds for endpoint propagation (shutdown delay)
4. we wait for open connections to drain (drain timeout)

The E2E test was verified to fail before implementing the graceful shutdown.

### Test Results

| # | Test | Method | Result |
|---|------|--------|--------|
| 1 | Slow request survives restart | `curl ?wait=25s`, restart 1s in | PASS — HTTP 200 in 25.0s |
| 2 | Sustained load survives restart | 10 concurrent clients, `?wait=1s`, restart at t=5s | PASS — 160/160 HTTP 200, 100% success |
| 3 | Readiness probe returns 503 during shutdown | Port-forward to admin, poll `/readyz` after pod delete | PASS — 200 before, 503 immediately and continuously after SIGTERM |
| 4 | Shutdown log sequencing | Captured logs during drain of 10s request | PASS — see below |
| 5 | Multiple restarts under load | 20 concurrent clients, `?wait=3s`, two restarts at t=3s and t=13s | PASS — 180/180 HTTP 200, 100% success |


### Changes
- Block serve() until Shutdown() completes, with configurable drain timeout
- Drain hijacked (WebSocket) connections via BaseContext cancellation and WaitGroup tracking
- Add ShutdownDelay and DrainTimeout config fields
- Split run() into proxy and infrastructure errgroups for phased shutdown
- Add Probe.Shutdown() to immediately return 503 on SIGTERM
- Replace defer os.Exit(1) + runtime.Goexit() with simpler run() pattern
- Increase terminationGracePeriodSeconds from 10 to 45
- Add e2e test for graceful shutdown and RestartInterceptor helper


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))
	- https://github.com/kedacore/keda-docs/pull/1778
- [x] Update helm chart
	- https://github.com/kedacore/charts/pull/857

Fixes #1636 
