### PR TITLE
perf: strip managed fields from controller-runtime cache

### DIFF
--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -94,8 +94,9 @@ func main() {
 	ctx = util.ContextWithLogger(ctx, ctrl.Log)
 
 	cacheOpts := cache.Options{
-		Scheme:     kedacache.NewScheme(),
-		SyncPeriod: &servingCfg.CacheSyncPeriod,
+		DefaultTransform: cache.TransformStripManagedFields(),
+		Scheme:           kedacache.NewScheme(),
+		SyncPeriod:       &servingCfg.CacheSyncPeriod,
 	}
 	if servingCfg.WatchNamespace != "" {
 		cacheOpts.DefaultNamespaces = map[string]cache.Config{

--- a/operator/main.go
+++ b/operator/main.go
@@ -118,6 +118,7 @@ func main() {
 		RetryPeriod:                   baseConfig.RetryPeriod,
 		Cache: cache.Options{
 			DefaultNamespaces: namespaces,
+			DefaultTransform:  cache.TransformStripManagedFields(),
 		},
 	})
 	if err != nil {

--- a/scaler/main.go
+++ b/scaler/main.go
@@ -60,8 +60,9 @@ func main() {
 	}
 
 	ctrlCache, err := cache.New(k8sCfg, cache.Options{
-		Scheme:     kedacache.NewScheme(),
-		SyncPeriod: &cfg.CacheSyncPeriod,
+		DefaultTransform: cache.TransformStripManagedFields(),
+		Scheme:           kedacache.NewScheme(),
+		SyncPeriod:       &cfg.CacheSyncPeriod,
 	})
 	if err != nil {
 		setupLog.Error(err, "creating cache")


### PR DESCRIPTION
Based on https://github.com/kedacore/keda/pull/7748 from @Fedosin but reduced to just stripping the managed fields we 100% don't need.

Managed fields metadata is stored on every cached Kubernetes object but never used by the add-on. Stripping them via TransformStripManagedFields reduces memory consumption.

### Changes
- Add DefaultTransform: cache.TransformStripManagedFields() to cache options in interceptor, operator, and scaler


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
