### PR TITLE
fix: propagate InterceptorRoute scaling metric changes to HPA

### DIFF
--- a/operator/apis/http/v1beta1/condition_types.go
+++ b/operator/apis/http/v1beta1/condition_types.go
@@ -10,4 +10,8 @@ const (
 const (
 	// ConditionReasonReconciled indicates reconciliation completed successfully.
 	ConditionReasonReconciled = "Reconciled"
+
+	// ConditionReasonScaledObjectSyncError indicates that the controller failed
+	// to propagate scaling metric changes to one or more ScaledObjects.
+	ConditionReasonScaledObjectSyncError = "ScaledObjectSyncError"
 )

--- a/operator/controllers/http/interceptorroute_controller.go
+++ b/operator/controllers/http/interceptorroute_controller.go
@@ -2,8 +2,13 @@ package http
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,6 +19,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
+	"github.com/kedacore/http-add-on/pkg/k8s"
+)
+
+const (
+	// ScalingMetricHashKey is the trigger metadata key used to store a hash of
+	// the InterceptorRoute's scaling metric spec. Updating this value forces
+	// KEDA to re-reconcile the ScaledObject and refresh the HPA targets.
+	ScalingMetricHashKey = "scalingMetricHash"
 )
 
 // InterceptorRouteReconciler reconciles InterceptorRoute objects.
@@ -25,13 +38,14 @@ type InterceptorRouteReconciler struct {
 // +kubebuilder:rbac:groups=http.keda.sh,resources=interceptorroutes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=http.keda.sh,resources=interceptorroutes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=http.keda.sh,resources=interceptorroutes/finalizers,verbs=update
+// +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch;update;patch
 
 func (r *InterceptorRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	var ir httpv1beta1.InterceptorRoute
 	if err := r.Get(ctx, req.NamespacedName, &ir); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 
@@ -39,8 +53,22 @@ func (r *InterceptorRouteReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	// We only set the Ready condition right now keeping this reconciler basically as a placeholder.
-	// TODO(v1): decide if we want to keep and extend or remove this reconciler
+	if err := r.syncScaledObjects(ctx, &ir); err != nil {
+		logger.Error(err, "Failed to sync ScaledObjects")
+
+		meta.SetStatusCondition(&ir.Status.Conditions, metav1.Condition{
+			Type:               httpv1beta1.ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: ir.Generation,
+			Reason:             httpv1beta1.ConditionReasonScaledObjectSyncError,
+			Message:            fmt.Sprintf("Failed to sync ScaledObjects: %v", err),
+		})
+		if statusErr := r.Client.Status().Update(ctx, &ir); statusErr != nil {
+			logger.Error(statusErr, "Failed to update status")
+		}
+		return ctrl.Result{}, err
+	}
+
 	meta.SetStatusCondition(&ir.Status.Conditions, metav1.Condition{
 		Type:               httpv1beta1.ConditionTypeReady,
 		Status:             metav1.ConditionTrue,
@@ -54,6 +82,81 @@ func (r *InterceptorRouteReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// syncScaledObjects finds ScaledObjects whose triggers reference this
+// InterceptorRoute and patches their trigger metadata with a hash of
+// the current scaling metric spec. The spec change bumps the ScaledObject
+// generation, which causes KEDA to rebuild its scaler cache, re-invoke
+// GetMetricSpec on the external scaler, and update the HPA targets.
+func (r *InterceptorRouteReconciler) syncScaledObjects(ctx context.Context, ir *httpv1beta1.InterceptorRoute) error {
+	logger := log.FromContext(ctx)
+
+	hash, err := scalingMetricHash(ir.Spec.ScalingMetric)
+	if err != nil {
+		return fmt.Errorf("computing scaling metric hash: %w", err)
+	}
+
+	var scaledObjects kedav1alpha1.ScaledObjectList
+	if err := r.List(ctx, &scaledObjects, client.InNamespace(ir.Namespace)); err != nil {
+		return fmt.Errorf("listing ScaledObjects: %w", err)
+	}
+
+	var errs []error
+	for i := range scaledObjects.Items {
+		so := &scaledObjects.Items[i]
+		base := so.DeepCopy()
+		if !updateTriggerMetadataHash(so, ir.Name, hash) {
+			continue
+		}
+
+		logger.Info("Updating ScaledObject trigger metadata",
+			"scaledObject", so.Name,
+			"scalingMetricHash", hash,
+		)
+		if err := r.Patch(ctx, so, client.MergeFrom(base)); err != nil {
+			if k8serrors.IsNotFound(err) {
+				logger.V(1).Info("ScaledObject deleted before patch, skipping",
+					"scaledObject", so.Name)
+				continue
+			}
+			errs = append(errs, fmt.Errorf("patching ScaledObject %s: %w", so.Name, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// updateTriggerMetadataHash sets ScalingMetricHashKey in every trigger that
+// references the given InterceptorRoute. Returns true when at least one
+// trigger was modified.
+func updateTriggerMetadataHash(so *kedav1alpha1.ScaledObject, irName, hash string) bool {
+	modified := false
+	for j := range so.Spec.Triggers {
+		trigger := &so.Spec.Triggers[j]
+		if trigger.Metadata == nil {
+			continue
+		}
+		if trigger.Metadata[k8s.InterceptorRouteKey] != irName {
+			continue
+		}
+		if trigger.Metadata[ScalingMetricHashKey] == hash {
+			continue
+		}
+		trigger.Metadata[ScalingMetricHashKey] = hash
+		modified = true
+	}
+	return modified
+}
+
+// scalingMetricHash returns a hex-encoded SHA-256 digest of the JSON
+// representation of the given ScalingMetricSpec.
+func scalingMetricHash(spec httpv1beta1.ScalingMetricSpec) (string, error) {
+	data, err := json.Marshal(spec)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(data)), nil
 }
 
 func (r *InterceptorRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/operator/controllers/http/interceptorroute_controller_test.go
+++ b/operator/controllers/http/interceptorroute_controller_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"testing"
 
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -12,11 +13,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
+	"github.com/kedacore/http-add-on/pkg/k8s"
 )
 
-func TestInterceptorRouteReconcile_NotFound(t *testing.T) {
+func newInterceptorRouteTestScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(httpv1beta1.AddToScheme(scheme))
+	utilruntime.Must(kedav1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func TestInterceptorRouteReconcile_NotFound(t *testing.T) {
+	scheme := newInterceptorRouteTestScheme()
 
 	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
@@ -41,8 +49,7 @@ func TestInterceptorRouteReconcile_NotFound(t *testing.T) {
 }
 
 func TestInterceptorRouteReconcile_SetsReadyCondition(t *testing.T) {
-	scheme := runtime.NewScheme()
-	utilruntime.Must(httpv1beta1.AddToScheme(scheme))
+	scheme := newInterceptorRouteTestScheme()
 
 	ir := &httpv1beta1.InterceptorRoute{
 		ObjectMeta: metav1.ObjectMeta{
@@ -53,6 +60,11 @@ func TestInterceptorRouteReconcile_SetsReadyCondition(t *testing.T) {
 			Target: httpv1beta1.TargetRef{
 				Service: "test-service",
 				Port:    8080,
+			},
+			ScalingMetric: httpv1beta1.ScalingMetricSpec{
+				Concurrency: &httpv1beta1.ConcurrencyTargetSpec{
+					TargetValue: 5,
+				},
 			},
 		},
 	}
@@ -93,5 +105,362 @@ func TestInterceptorRouteReconcile_SetsReadyCondition(t *testing.T) {
 	}
 	if cond.Reason != httpv1beta1.ConditionReasonReconciled {
 		t.Errorf("got Ready reason %q, want %q", cond.Reason, httpv1beta1.ConditionReasonReconciled)
+	}
+}
+
+func TestInterceptorRouteReconcile_SyncsScaledObjectTriggerMetadata(t *testing.T) {
+	scheme := newInterceptorRouteTestScheme()
+
+	ir := &httpv1beta1.InterceptorRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "my-route",
+		},
+		Spec: httpv1beta1.InterceptorRouteSpec{
+			Target: httpv1beta1.TargetRef{
+				Service: "my-svc",
+				Port:    8080,
+			},
+			ScalingMetric: httpv1beta1.ScalingMetricSpec{
+				Concurrency: &httpv1beta1.ConcurrencyTargetSpec{
+					TargetValue: 5,
+				},
+			},
+		},
+	}
+
+	so := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "my-so",
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: "my-deploy"},
+			Triggers: []kedav1alpha1.ScaleTriggers{
+				{
+					Type: "external-push",
+					Metadata: map[string]string{
+						k8s.ScalerAddressKey:    "scaler:9090",
+						k8s.InterceptorRouteKey: "my-route",
+					},
+				},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(ir, so).
+		WithStatusSubresource(ir).
+		Build()
+
+	reconciler := &InterceptorRouteReconciler{
+		Client: cl,
+		Scheme: cl.Scheme(),
+	}
+
+	nn := types.NamespacedName{Namespace: ir.Namespace, Name: ir.Name}
+	if _, err := reconciler.Reconcile(t.Context(), ctrl.Request{NamespacedName: nn}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updatedSO kedav1alpha1.ScaledObject
+	if err := cl.Get(t.Context(), types.NamespacedName{Namespace: so.Namespace, Name: so.Name}, &updatedSO); err != nil {
+		t.Fatalf("unexpected error getting ScaledObject: %v", err)
+	}
+
+	wantHash, err := scalingMetricHash(ir.Spec.ScalingMetric)
+	if err != nil {
+		t.Fatalf("unexpected error computing hash: %v", err)
+	}
+
+	gotHash := updatedSO.Spec.Triggers[0].Metadata[ScalingMetricHashKey]
+	if gotHash != wantHash {
+		t.Errorf("got scalingMetricHash %q, want %q", gotHash, wantHash)
+	}
+}
+
+func TestInterceptorRouteReconcile_SkipsUnrelatedScaledObjects(t *testing.T) {
+	scheme := newInterceptorRouteTestScheme()
+
+	ir := &httpv1beta1.InterceptorRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "my-route",
+		},
+		Spec: httpv1beta1.InterceptorRouteSpec{
+			Target: httpv1beta1.TargetRef{
+				Service: "my-svc",
+				Port:    8080,
+			},
+			ScalingMetric: httpv1beta1.ScalingMetricSpec{
+				Concurrency: &httpv1beta1.ConcurrencyTargetSpec{
+					TargetValue: 10,
+				},
+			},
+		},
+	}
+
+	unrelatedSO := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "unrelated-so",
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: "other-deploy"},
+			Triggers: []kedav1alpha1.ScaleTriggers{
+				{
+					Type: "external-push",
+					Metadata: map[string]string{
+						k8s.ScalerAddressKey:    "scaler:9090",
+						k8s.InterceptorRouteKey: "other-route",
+					},
+				},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(ir, unrelatedSO).
+		WithStatusSubresource(ir).
+		Build()
+
+	reconciler := &InterceptorRouteReconciler{
+		Client: cl,
+		Scheme: cl.Scheme(),
+	}
+
+	nn := types.NamespacedName{Namespace: ir.Namespace, Name: ir.Name}
+	if _, err := reconciler.Reconcile(t.Context(), ctrl.Request{NamespacedName: nn}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updatedSO kedav1alpha1.ScaledObject
+	if err := cl.Get(t.Context(), types.NamespacedName{Namespace: unrelatedSO.Namespace, Name: unrelatedSO.Name}, &updatedSO); err != nil {
+		t.Fatalf("unexpected error getting ScaledObject: %v", err)
+	}
+
+	if _, ok := updatedSO.Spec.Triggers[0].Metadata[ScalingMetricHashKey]; ok {
+		t.Error("unrelated ScaledObject should not have scalingMetricHash set")
+	}
+}
+
+func TestInterceptorRouteReconcile_NoUpdateWhenHashUnchanged(t *testing.T) {
+	scheme := newInterceptorRouteTestScheme()
+
+	ir := &httpv1beta1.InterceptorRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "my-route",
+		},
+		Spec: httpv1beta1.InterceptorRouteSpec{
+			Target: httpv1beta1.TargetRef{
+				Service: "my-svc",
+				Port:    8080,
+			},
+			ScalingMetric: httpv1beta1.ScalingMetricSpec{
+				Concurrency: &httpv1beta1.ConcurrencyTargetSpec{
+					TargetValue: 5,
+				},
+			},
+		},
+	}
+
+	hash, _ := scalingMetricHash(ir.Spec.ScalingMetric)
+
+	so := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "default",
+			Name:            "my-so",
+			ResourceVersion: "100",
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			ScaleTargetRef: &kedav1alpha1.ScaleTarget{Name: "my-deploy"},
+			Triggers: []kedav1alpha1.ScaleTriggers{
+				{
+					Type: "external-push",
+					Metadata: map[string]string{
+						k8s.ScalerAddressKey:    "scaler:9090",
+						k8s.InterceptorRouteKey: "my-route",
+						ScalingMetricHashKey:    hash,
+					},
+				},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(ir, so).
+		WithStatusSubresource(ir).
+		Build()
+
+	reconciler := &InterceptorRouteReconciler{
+		Client: cl,
+		Scheme: cl.Scheme(),
+	}
+
+	nn := types.NamespacedName{Namespace: ir.Namespace, Name: ir.Name}
+	if _, err := reconciler.Reconcile(t.Context(), ctrl.Request{NamespacedName: nn}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updatedSO kedav1alpha1.ScaledObject
+	if err := cl.Get(t.Context(), types.NamespacedName{Namespace: so.Namespace, Name: so.Name}, &updatedSO); err != nil {
+		t.Fatalf("unexpected error getting ScaledObject: %v", err)
+	}
+
+	if updatedSO.ResourceVersion != so.ResourceVersion {
+		t.Error("ScaledObject should not have been updated when hash is unchanged")
+	}
+}
+
+func TestUpdateTriggerMetadataHash(t *testing.T) {
+	tests := []struct {
+		name         string
+		triggers     []kedav1alpha1.ScaleTriggers
+		irName       string
+		hash         string
+		wantModified bool
+		wantHash     string
+	}{
+		{
+			name: "updates matching trigger",
+			triggers: []kedav1alpha1.ScaleTriggers{
+				{
+					Type: "external-push",
+					Metadata: map[string]string{
+						k8s.InterceptorRouteKey: "my-route",
+					},
+				},
+			},
+			irName:       "my-route",
+			hash:         "abc123",
+			wantModified: true,
+			wantHash:     "abc123",
+		},
+		{
+			name: "skips non-matching trigger",
+			triggers: []kedav1alpha1.ScaleTriggers{
+				{
+					Type: "external-push",
+					Metadata: map[string]string{
+						k8s.InterceptorRouteKey: "other-route",
+					},
+				},
+			},
+			irName:       "my-route",
+			hash:         "abc123",
+			wantModified: false,
+		},
+		{
+			name: "skips trigger with nil metadata",
+			triggers: []kedav1alpha1.ScaleTriggers{
+				{Type: "external-push"},
+			},
+			irName:       "my-route",
+			hash:         "abc123",
+			wantModified: false,
+		},
+		{
+			name: "no-op when hash already matches",
+			triggers: []kedav1alpha1.ScaleTriggers{
+				{
+					Type: "external-push",
+					Metadata: map[string]string{
+						k8s.InterceptorRouteKey: "my-route",
+						ScalingMetricHashKey:    "abc123",
+					},
+				},
+			},
+			irName:       "my-route",
+			hash:         "abc123",
+			wantModified: false,
+		},
+		{
+			name: "updates only matching trigger among many",
+			triggers: []kedav1alpha1.ScaleTriggers{
+				{
+					Type: "cpu",
+					Metadata: map[string]string{
+						"type": "Utilization",
+					},
+				},
+				{
+					Type: "external-push",
+					Metadata: map[string]string{
+						k8s.InterceptorRouteKey: "my-route",
+					},
+				},
+			},
+			irName:       "my-route",
+			hash:         "def456",
+			wantModified: true,
+			wantHash:     "def456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			so := &kedav1alpha1.ScaledObject{
+				Spec: kedav1alpha1.ScaledObjectSpec{
+					Triggers: tt.triggers,
+				},
+			}
+
+			got := updateTriggerMetadataHash(so, tt.irName, tt.hash)
+			if got != tt.wantModified {
+				t.Errorf("updateTriggerMetadataHash() = %v, want %v", got, tt.wantModified)
+			}
+
+			if tt.wantModified {
+				for _, trigger := range so.Spec.Triggers {
+					if trigger.Metadata[k8s.InterceptorRouteKey] == tt.irName {
+						if trigger.Metadata[ScalingMetricHashKey] != tt.wantHash {
+							t.Errorf("got hash %q, want %q", trigger.Metadata[ScalingMetricHashKey], tt.wantHash)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestScalingMetricHash_Deterministic(t *testing.T) {
+	spec := httpv1beta1.ScalingMetricSpec{
+		Concurrency: &httpv1beta1.ConcurrencyTargetSpec{
+			TargetValue: 5,
+		},
+	}
+
+	h1, err := scalingMetricHash(spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	h2, err := scalingMetricHash(spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if h1 != h2 {
+		t.Errorf("hash should be deterministic: %q != %q", h1, h2)
+	}
+}
+
+func TestScalingMetricHash_DiffersOnChange(t *testing.T) {
+	spec1 := httpv1beta1.ScalingMetricSpec{
+		Concurrency: &httpv1beta1.ConcurrencyTargetSpec{
+			TargetValue: 5,
+		},
+	}
+	spec2 := httpv1beta1.ScalingMetricSpec{
+		Concurrency: &httpv1beta1.ConcurrencyTargetSpec{
+			TargetValue: 6,
+		},
+	}
+
+	h1, _ := scalingMetricHash(spec1)
+	h2, _ := scalingMetricHash(spec2)
+
+	if h1 == h2 {
+		t.Error("different specs should produce different hashes")
 	}
 }

--- a/test/e2e/default/metric_update_test.go
+++ b/test/e2e/default/metric_update_test.go
@@ -1,0 +1,53 @@
+//go:build e2e
+
+package default_test
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
+	h "github.com/kedacore/http-add-on/test/helpers"
+)
+
+func TestMetricUpdate(t *testing.T) {
+	t.Parallel()
+
+	var ir *httpv1beta1.InterceptorRoute
+
+	feat := features.New("metric-update").
+		WithLabel("area", "scaling").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			app := f.CreateTestApp("metric-update-app")
+			ir = f.CreateInterceptorRoute("metric-update-ir", app,
+				h.IRWithHosts(f.Hostname()),
+				h.IRWithConcurrency(5),
+			)
+			f.CreateScaledObject("metric-update-so", app, ir)
+
+			return ctx
+		}).
+		Assess("HPA has initial target value", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			f.WaitForHPAMetricTarget("metric-update-so", 5)
+
+			return ctx
+		}).
+		Assess("HPA target updates after IR metric change", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			f.UpdateInterceptorRoute(ir, h.IRWithConcurrency(10))
+			f.WaitForHPAMetricTarget("metric-update-so", 10)
+
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}

--- a/test/helpers/wait.go
+++ b/test/helpers/wait.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/wait"
@@ -62,6 +64,44 @@ func (f *Framework) WaitForMinReplicas(app *TestApp, minReplicas int32) {
 	if err != nil {
 		f.t.Fatalf("timed out waiting for %s/%s to reach at least %d replicas: %v",
 			app.Namespace, app.Name, minReplicas, err)
+	}
+}
+
+// WaitForHPAMetricTarget polls the HPA created by KEDA for the given
+// ScaledObject until every external metric has the expected AverageValue.
+func (f *Framework) WaitForHPAMetricTarget(soName string, expected int32) {
+	f.t.Helper()
+
+	hpaName := "keda-hpa-" + soName
+	want := resource.NewMilliQuantity(int64(expected)*1000, resource.DecimalSI)
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      hpaName,
+			Namespace: f.namespace,
+		},
+	}
+
+	err := wait.For(
+		conditions.New(f.client.Resources()).ResourceMatch(hpa, func(object k8s.Object) bool {
+			h := object.(*autoscalingv2.HorizontalPodAutoscaler)
+			found := false
+			for _, m := range h.Spec.Metrics {
+				if m.Type != autoscalingv2.ExternalMetricSourceType || m.External == nil {
+					continue
+				}
+				found = true
+				if m.External.Target.AverageValue == nil || m.External.Target.AverageValue.Cmp(*want) != 0 {
+					return false
+				}
+			}
+			return found
+		}),
+		wait.WithTimeout(defaultWaitTimeout),
+	)
+	if err != nil {
+		f.t.Fatalf("timed out waiting for HPA %s/%s to have metric target %d: %v",
+			f.namespace, hpaName, expected, err)
 	}
 }
 


### PR DESCRIPTION
When an InterceptorRoute's `scalingMetric` is modified (e.g. changing
`concurrency.targetValue` from 5 to 6), the associated HPA is not updated.
This happens because KEDA only rebuilds its scaler cache when the ScaledObject's
generation changes, and the user-managed ScaledObject itself never changes.

The fix extends the `InterceptorRouteReconciler` to find ScaledObjects whose
triggers reference the changed InterceptorRoute and patch their trigger metadata
with a SHA-256 hash of the current `ScalingMetricSpec`. This spec change bumps
the ScaledObject generation, causing KEDA to re-invoke `GetMetricSpec` on the
external scaler and refresh the HPA target values.

An e2e test is included that creates an InterceptorRoute with `concurrency: 5`,
verifies the HPA target, updates the InterceptorRoute to `concurrency: 10`, and
asserts the HPA target is refreshed accordingly.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [ ] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [ ] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

Fixes #1656