### PR TITLE
feat: add s390x to release platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### New
 
+- **General**: Add s390x to supported release platforms ([#1662](https://github.com/kedacore/http-add-on/issues/1662))
 - **General**: Add `coldStart.placeholder` support for returning static HTTP responses during scale-from-zero ([#874](https://github.com/kedacore/http-add-on/issues/874))
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
 - **Scaler**: Add OpenTelemetry metrics and distributed tracing to the external scaler ([#965](https://github.com/kedacore/http-add-on/issues/965))

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ IMAGE_OPERATOR_SHA_TAG     ?= $(IMAGE_OPERATOR):$(GIT_COMMIT_SHORT)
 IMAGE_INTERCEPTOR_SHA_TAG  ?= $(IMAGE_INTERCEPTOR):$(GIT_COMMIT_SHORT)
 IMAGE_SCALER_SHA_TAG       ?= $(IMAGE_SCALER):$(GIT_COMMIT_SHORT)
 
-KO_RELEASE_PLATFORMS ?= linux/amd64,linux/arm64
+KO_RELEASE_PLATFORMS ?= linux/amd64,linux/arm64,linux/s390x
 
 # renovate: datasource=helm depName=cert-manager registryUrl=https://charts.jetstack.io
 CERT_MANAGER_VERSION ?= v1.20.2


### PR DESCRIPTION
Simply cross building for s390x is IMO good enough as well as we don't expect that our quite normal go code suddenly would not work on that platform anymore.
We test amd64 and arm64 in CI already, it is extremely unlikely that s390x would not work considering we dont use any unsafe/C code or anything archtiecture specific.

### Changes:
- Add linux/s390x to KO_RELEASE_PLATFORMS in Makefile


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on)) 
  - see https://github.com/kedacore/keda-docs/pull/1783

Fixes #1662
