### PR TITLE
fix: filter GetMetrics response by requested metric name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Fixes
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Scaler**: Fix incorrect HPA values when both concurrency and requestRate metrics are configured ([#1659](https://github.com/kedacore/http-add-on/issues/1659))
 
 ### Deprecations
 

--- a/scaler/handlers.go
+++ b/scaler/handlers.go
@@ -223,18 +223,25 @@ func (e *scalerHandler) GetMetrics(ctx context.Context, metricRequest *externals
 
 		count := e.pinger.count(key)
 
+		// KEDA sets metricName per metric; empty means return all (used by IsActive).
+		requestedMetric := metricRequest.GetMetricName()
+
 		var metricValues []*externalscaler.MetricValue
-		if ir.Spec.ScalingMetric.Concurrency != nil {
+		if ir.Spec.ScalingMetric.Concurrency != nil && (requestedMetric == "" || requestedMetric == ConcurrencyMetricName(irName)) {
 			metricValues = append(metricValues, &externalscaler.MetricValue{
 				MetricName:       ConcurrencyMetricName(irName),
 				MetricValueFloat: float64(count.Concurrency),
 			})
 		}
-		if ir.Spec.ScalingMetric.RequestRate != nil {
+		if ir.Spec.ScalingMetric.RequestRate != nil && (requestedMetric == "" || requestedMetric == RateMetricName(irName)) {
 			metricValues = append(metricValues, &externalscaler.MetricValue{
 				MetricName:       RateMetricName(irName),
 				MetricValueFloat: count.RequestRate,
 			})
+		}
+
+		if requestedMetric != "" && len(metricValues) == 0 {
+			lggr.V(1).Info("requested metric not found", "metricName", requestedMetric, "interceptorRouteName", irName)
 		}
 
 		return &externalscaler.GetMetricsResponse{

--- a/scaler/handlers_test.go
+++ b/scaler/handlers_test.go
@@ -235,6 +235,69 @@ func TestGetMetrics(t *testing.T) {
 			t.Fatal("expected error, got nil")
 		}
 	})
+
+	t.Run("filters by requested metric name", func(t *testing.T) {
+		ir := newTestInterceptorRoute(httpv1beta1.ScalingMetricSpec{
+			Concurrency: &httpv1beta1.ConcurrencyTargetSpec{TargetValue: 3},
+			RequestRate: &httpv1beta1.RequestRateTargetSpec{TargetValue: 4},
+		})
+		hdl := newTestScalerHandler(t, ir, aggregatedCount{Concurrency: 12, RequestRate: 24})
+
+		tests := map[string]struct {
+			metricName string
+			want       []*externalscaler.MetricValue
+		}{
+			"request concurrency only": {
+				metricName: testIRConcurrencyMetric,
+				want: []*externalscaler.MetricValue{
+					{MetricName: testIRConcurrencyMetric, MetricValueFloat: 12},
+				},
+			},
+			"request rate only": {
+				metricName: testIRRateMetric,
+				want: []*externalscaler.MetricValue{
+					{MetricName: testIRRateMetric, MetricValueFloat: 24},
+				},
+			},
+			"empty metric name returns all": {
+				metricName: "",
+				want: []*externalscaler.MetricValue{
+					{MetricName: testIRConcurrencyMetric, MetricValueFloat: 12},
+					{MetricName: testIRRateMetric, MetricValueFloat: 24},
+				},
+			},
+			"unknown metric name returns empty": {
+				metricName: "http_test-ir_unknown",
+				want:       []*externalscaler.MetricValue{},
+			},
+		}
+		for name, tc := range tests {
+			t.Run(name, func(t *testing.T) {
+				req := &externalscaler.GetMetricsRequest{
+					ScaledObjectRef: testScaledObjectRef,
+					MetricName:      tc.metricName,
+				}
+				resp, err := hdl.GetMetrics(t.Context(), req)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				values := resp.GetMetricValues()
+				if got, want := len(values), len(tc.want); got != want {
+					t.Fatalf("got %d metric values, want %d", got, want)
+				}
+
+				for i, v := range values {
+					if got, want := v.MetricName, tc.want[i].MetricName; got != want {
+						t.Errorf("values[%d].MetricName = %q, want %q", i, got, want)
+					}
+					if got, want := v.MetricValueFloat, tc.want[i].MetricValueFloat; got != want {
+						t.Errorf("values[%d].MetricValueFloat = %v, want %v", i, got, want)
+					}
+				}
+			})
+		}
+	})
 }
 
 func TestIsActive(t *testing.T) {


### PR DESCRIPTION
When both concurrency and requestRate metrics are configured, KEDA calls GetMetrics once per metric with the specific name. The scaler returned all metrics regardless. KEDA then iterates over every returned value and creates an HPA metric for each, all stamped with the requested name — so both concurrency and rate values end up reported under the same metric, causing incorrect HPA scaling.

### Changes:
- Filter metricValues by GetMetricsRequest.MetricName
- Log at debug level when a requested metric is not found
- Add tests for metric name filtering, empty name, and unknown name

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

Fixes #1659 
