### PR TITLE
fix(interceptor): close request body to prevent panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Fixes
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Interceptor**: Fix panic with "invalid concurrent Body.Read call" when reverse proxy fails without consuming the request body ([#1668](https://github.com/kedacore/http-add-on/issues/1668))
 - **Scaler**: Fix incorrect HPA values when both concurrency and requestRate metrics are configured ([#1659](https://github.com/kedacore/http-add-on/issues/1659))
 
 ### Deprecations

--- a/interceptor/handler/upstream.go
+++ b/interceptor/handler/upstream.go
@@ -80,6 +80,12 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		util.LoggerFromContext(ctx).Error(err, "could not enable full duplex on response writer, continuing")
 	}
 
+	// Close the request body to prevent a server panic when it tries to read
+	// the next keep-alive request after EnableFullDuplex (golang/go#68560).
+	if r.Body != nil {
+		defer func() { _ = r.Body.Close() }()
+	}
+
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(url)

--- a/interceptor/handler/upstream_test.go
+++ b/interceptor/handler/upstream_test.go
@@ -2,12 +2,15 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -466,6 +469,55 @@ func TestUpstream_RouteSpecResponseHeaderOverride(t *testing.T) {
 
 	r.Equal(http.StatusGatewayTimeout, res.Code)
 	close(originWaitCh)
+}
+
+// TestFullDuplexBodyPanic verifies that the upstream handler does not trigger
+// a "invalid concurrent Body.Read call" panic (golang/go#68560) when the
+// reverse proxy's RoundTrip fails without consuming the request body.
+//
+// The panic is recovered by the server and logged via its ErrorLog.
+func TestFullDuplexBodyPanic(t *testing.T) {
+	failingTransport := &http.Transport{
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("connection refused")
+		},
+	}
+
+	upstream := NewUpstream(failingTransport, config.Tracing{}, 1*time.Second)
+
+	targetURL, _ := url.Parse("http://fake-backend:8080")
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(util.ContextWithUpstreamURL(r.Context(), targetURL))
+		upstream.ServeHTTP(w, r)
+	})
+
+	var panicked atomic.Bool
+	srv := httptest.NewUnstartedServer(handler)
+	srv.Config.ErrorLog = log.New(panicLogWriter{onPanic: func() { panicked.Store(true) }}, "", 0)
+	srv.Start()
+	defer srv.Close()
+
+	resp, err := srv.Client().Post(srv.URL+"/test", "application/json", strings.NewReader(`{"key":"value"}`))
+	if err == nil {
+		_ = resp.Body.Close()
+	}
+
+	// The panic fires asynchronously after the response is sent.
+	time.Sleep(5 * time.Millisecond)
+
+	if panicked.Load() {
+		t.Fatal("server panicked with 'invalid concurrent Body.Read call' (golang/go#68560)")
+	}
+}
+
+// panicLogWriter detects panics logged by net/http's server error recovery.
+type panicLogWriter struct{ onPanic func() }
+
+func (w panicLogWriter) Write(p []byte) (int, error) {
+	if strings.Contains(string(p), "panic") {
+		w.onPanic()
+	}
+	return len(p), nil
 }
 
 func newTestTransport(dialCtxFunc kedanet.DialContextFunc) *http.Transport {

--- a/test/e2e/default/cold_start_test.go
+++ b/test/e2e/default/cold_start_test.go
@@ -5,6 +5,7 @@ package default_test
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -46,6 +47,18 @@ func TestColdStart(t *testing.T) {
 
 			f.AssertStatus(h.Request{Host: f.Hostname()}, http.StatusOK)
 			f.WaitForReplicas(app, 1)
+
+			return ctx
+		}).
+		Assess("POST with body returns 200", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			f := h.NewFramework(ctx, t)
+
+			f.AssertStatus(h.Request{
+				Method:  http.MethodPost,
+				Host:    f.Hostname(),
+				Headers: map[string]string{"Content-Type": "application/json"},
+				Body:    strings.NewReader(`{"key":"value"}`),
+			}, http.StatusOK)
 
 			return ctx
 		}).


### PR DESCRIPTION
EnableFullDuplex tells Go's HTTP/1.1 server it can write a response while the request body is still streaming. When the reverse proxy's RoundTrip fails without consuming the body (e.g. connection refused during cold start), conn.serve panics with "invalid concurrent Body.Read call" when it peeks for the next keep-alive request (golang/go#68560).

Changes:
- Close request body after EnableFullDuplex to prevent the panic
- Add unit test that reproduces the panic via a failing transport
- Add e2e POST-with-body assess step to TestColdStart
- Add changelog entry


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)


Fixes #1668
