### PR TITLE
fix: tolerate partial interceptor pod failures in scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This changelog keeps track of work items that have been completed and are ready 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
 - **Interceptor**: Fix panic with "invalid concurrent Body.Read call" when reverse proxy fails without consuming the request body ([#1668](https://github.com/kedacore/http-add-on/issues/1668))
 - **Scaler**: Fix incorrect HPA values when both concurrency and requestRate metrics are configured ([#1659](https://github.com/kedacore/http-add-on/issues/1659))
+- **Scaler**: Tolerate partial interceptor pod failures instead of restarting the scaler on a single unreachable endpoint; cache last-known concurrency for unreachable pods to prevent underreporting ([#1667](https://github.com/kedacore/http-add-on/issues/1667))
 
 ### Deprecations
 

--- a/scaler/metrics/instruments.go
+++ b/scaler/metrics/instruments.go
@@ -15,16 +15,18 @@ const (
 	// ServiceName is the OTEL service.name used for both metrics and tracing.
 	ServiceName = "keda-http-external-scaler"
 
-	MetricPingerFetchDuration = "scaler.pinger.fetch.duration"
-	MetricPingerFetchErrors   = "scaler.pinger.fetch.errors"
-	MetricPingerEndpoints     = "scaler.pinger.endpoints"
+	MetricPingerFetchDuration   = "scaler.pinger.fetch.duration"
+	MetricPingerFetchErrors     = "scaler.pinger.fetch.errors"
+	MetricPingerUnreachablePods = "scaler.pinger.unreachable_pods"
+	MetricPingerEndpoints       = "scaler.pinger.endpoints"
 )
 
 // Instruments holds all metric instruments for the external scaler.
 type Instruments struct {
-	pingerFetchDuration api.Float64Histogram
-	pingerFetchErrors   api.Int64Counter
-	pingerEndpoints     api.Int64Gauge
+	pingerFetchDuration   api.Float64Histogram
+	pingerFetchErrors     api.Int64Counter
+	pingerUnreachablePods api.Int64Gauge
+	pingerEndpoints       api.Int64Gauge
 }
 
 // NewNoopInstruments returns Instruments backed by a no-op provider, for use in tests.
@@ -60,6 +62,14 @@ func NewInstruments(provider *sdkmetric.MeterProvider) (*Instruments, error) {
 		return nil, fmt.Errorf("creating pinger fetch errors counter: %w", err)
 	}
 
+	pingerUnreachablePods, err := meter.Int64Gauge(
+		MetricPingerUnreachablePods,
+		api.WithDescription("Number of interceptor pods that were unreachable in the last fetch cycle"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating pinger unreachable pods gauge: %w", err)
+	}
+
 	pingerEndpoints, err := meter.Int64Gauge(
 		MetricPingerEndpoints,
 		api.WithDescription("Number of interceptor endpoints the scaler is polling"),
@@ -69,16 +79,18 @@ func NewInstruments(provider *sdkmetric.MeterProvider) (*Instruments, error) {
 	}
 
 	return &Instruments{
-		pingerFetchDuration: pingerFetchDuration,
-		pingerFetchErrors:   pingerFetchErrors,
-		pingerEndpoints:     pingerEndpoints,
+		pingerFetchDuration:   pingerFetchDuration,
+		pingerFetchErrors:     pingerFetchErrors,
+		pingerUnreachablePods: pingerUnreachablePods,
+		pingerEndpoints:       pingerEndpoints,
 	}, nil
 }
 
 // RecordFetch records a completed pinger fetch cycle.
-func (i *Instruments) RecordFetch(duration time.Duration, endpointCount int, fetchErr error) {
+func (i *Instruments) RecordFetch(duration time.Duration, endpointCount, failedPods int, fetchErr error) {
 	i.pingerFetchDuration.Record(context.Background(), duration.Seconds())
 	i.pingerEndpoints.Record(context.Background(), int64(endpointCount))
+	i.pingerUnreachablePods.Record(context.Background(), int64(failedPods))
 	if fetchErr != nil {
 		i.pingerFetchErrors.Add(context.Background(), 1)
 	}

--- a/scaler/metrics/prometheus_test.go
+++ b/scaler/metrics/prometheus_test.go
@@ -48,8 +48,8 @@ func testRegistry(t *testing.T) (*prometheus.Registry, *Instruments) {
 func TestPrometheus_FetchDuration(t *testing.T) {
 	registry, instruments := testRegistry(t)
 
-	instruments.RecordFetch(50*time.Millisecond, 3, nil)
-	instruments.RecordFetch(200*time.Millisecond, 3, nil)
+	instruments.RecordFetch(50*time.Millisecond, 3, 0, nil)
+	instruments.RecordFetch(200*time.Millisecond, 3, 0, nil)
 
 	expected := `
 		# HELP scaler_pinger_fetch_duration_seconds Duration of a queue pinger fetch cycle across all interceptor pods
@@ -78,9 +78,9 @@ func TestPrometheus_FetchDuration(t *testing.T) {
 func TestPrometheus_FetchErrors(t *testing.T) {
 	registry, instruments := testRegistry(t)
 
-	instruments.RecordFetch(10*time.Millisecond, 2, errors.New("connection refused"))
-	instruments.RecordFetch(10*time.Millisecond, 2, nil)
-	instruments.RecordFetch(10*time.Millisecond, 0, errors.New("no endpoints"))
+	instruments.RecordFetch(10*time.Millisecond, 2, 2, errors.New("connection refused"))
+	instruments.RecordFetch(10*time.Millisecond, 2, 0, nil)
+	instruments.RecordFetch(10*time.Millisecond, 0, 0, errors.New("no endpoints"))
 
 	expected := `
 		# HELP scaler_pinger_fetch_errors_total Total failed queue pinger fetch cycles
@@ -92,10 +92,27 @@ func TestPrometheus_FetchErrors(t *testing.T) {
 	}
 }
 
+func TestPrometheus_UnreachablePods(t *testing.T) {
+	registry, instruments := testRegistry(t)
+
+	instruments.RecordFetch(10*time.Millisecond, 3, 1, nil)
+	instruments.RecordFetch(10*time.Millisecond, 3, 0, nil)
+	instruments.RecordFetch(10*time.Millisecond, 3, 2, nil)
+
+	expected := `
+		# HELP scaler_pinger_unreachable_pods Number of interceptor pods that were unreachable in the last fetch cycle
+		# TYPE scaler_pinger_unreachable_pods gauge
+		scaler_pinger_unreachable_pods 2
+	`
+	if err := testutil.CollectAndCompare(registry, strings.NewReader(expected), "scaler_pinger_unreachable_pods"); err != nil {
+		t.Fatalf("unexpected metrics output:\n%v", err)
+	}
+}
+
 func TestPrometheus_Endpoints(t *testing.T) {
 	registry, instruments := testRegistry(t)
 
-	instruments.RecordFetch(10*time.Millisecond, 5, nil)
+	instruments.RecordFetch(10*time.Millisecond, 5, 0, nil)
 
 	expected := `
 		# HELP scaler_pinger_endpoints Number of interceptor endpoints the scaler is polling

--- a/scaler/queue_pinger.go
+++ b/scaler/queue_pinger.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/kedacore/http-add-on/pkg/k8s"
 	"github.com/kedacore/http-add-on/pkg/queue"
@@ -65,6 +65,12 @@ type queuePinger struct {
 	// so we can compute deltas between consecutive polls.
 	prevPodCounts map[string]map[string]int64
 
+	// cachedPodCounts stores the last successful response from each pod,
+	// used to preserve concurrency for unreachable pods still in the
+	// EndpointSlice. Entries are pruned when the pod leaves the
+	// EndpointSlice.
+	cachedPodCounts map[string]queue.Counts
+
 	// rateBuckets holds per-key windowed ring buffers that accumulate
 	// request deltas for rate computation.
 	rateBuckets map[string]*queue.RequestsBuckets
@@ -81,6 +87,7 @@ func newQueuePinger(lggr logr.Logger, getEndpointsFn k8s.GetEndpointsFunc, ns, s
 		instruments:            instruments,
 		allCounts:              map[string]aggregatedCount{},
 		prevPodCounts:          map[string]map[string]int64{},
+		cachedPodCounts:        map[string]queue.Counts{},
 		rateBuckets:            map[string]*queue.RequestsBuckets{},
 	}
 }
@@ -157,7 +164,8 @@ func (q *queuePinger) fetchAndSaveCounts(ctx context.Context) error {
 
 	fetchStart := time.Now()
 	result, err := fetchCountsPerPod(ctx, q.lggr, q.getEndpointsFn, q.interceptorNS, q.interceptorSvcName, q.adminPort)
-	q.instruments.RecordFetch(time.Since(fetchStart), result.endpointCount, err)
+	failedPods := max(0, result.endpointCount-len(result.perPod))
+	q.instruments.RecordFetch(time.Since(fetchStart), result.endpointCount, failedPods, err)
 	if err != nil {
 		q.lggr.Error(err, "getting request counts")
 		q.status = PingerERROR
@@ -204,12 +212,46 @@ func (q *queuePinger) fetchAndSaveCounts(ctx context.Context) error {
 			agg[key] = ha
 		}
 		q.prevPodCounts[podKey] = newPrev
+		q.cachedPodCounts[podKey] = counts
 	}
 
-	// Prune pods that are no longer reporting.
+	// For unreachable pods still in the EndpointSlice, use cached
+	// concurrency so that partial failures don't cause underreporting.
+	// Only concurrency is replayed — request rate deltas are not
+	// synthesised because we have no way to know what traffic the
+	// unreachable pod handled. This is a deliberate trade-off:
+	// concurrency is a point-in-time gauge (stale > zero), while
+	// rate is a derivative that would be misleading if fabricated.
+	for _, epKey := range result.endpointKeys {
+		if _, reachable := perPod[epKey]; reachable {
+			continue
+		}
+		if cached, ok := q.cachedPodCounts[epKey]; ok {
+			q.lggr.V(1).Info("using cached counts for unreachable pod",
+				"pod", epKey,
+				"cachedHosts", len(cached),
+			)
+			for key, c := range cached {
+				ha := agg[key]
+				ha.concurrency += c.Concurrency
+				agg[key] = ha
+			}
+		}
+	}
+
+	// Prune pods that have left the EndpointSlice entirely.
+	endpointSet := make(map[string]struct{}, len(result.endpointKeys))
+	for _, k := range result.endpointKeys {
+		endpointSet[k] = struct{}{}
+	}
 	for podKey := range q.prevPodCounts {
-		if _, ok := perPod[podKey]; !ok {
+		if _, ok := endpointSet[podKey]; !ok {
 			delete(q.prevPodCounts, podKey)
+		}
+	}
+	for podKey := range q.cachedPodCounts {
+		if _, ok := endpointSet[podKey]; !ok {
+			delete(q.cachedPodCounts, podKey)
 		}
 	}
 
@@ -239,12 +281,19 @@ func (q *queuePinger) fetchAndSaveCounts(ctx context.Context) error {
 // fetchResult holds the outcome of a fetch cycle.
 type fetchResult struct {
 	perPod        map[string]queue.Counts
+	endpointKeys  []string
 	endpointCount int
 }
 
 // fetchCountsPerPod fetches counts from every interceptor pod endpoint
 // and returns the raw per-pod results keyed by pod URL string along with
 // the total number of endpoints that were polled.
+//
+// Individual pod failures are logged and skipped. An error is only
+// returned when no pod could be reached at all, so that a single
+// unreachable interceptor (e.g. during a rolling update or spot-node
+// eviction) does not cause the scaler to report NOT_SERVING and get
+// restarted by Kubernetes.
 func fetchCountsPerPod(ctx context.Context, lggr logr.Logger, endpointsFn k8s.GetEndpointsFunc, ns, svcName, adminPort string) (fetchResult, error) {
 	lggr = lggr.WithName("queuePinger.requestCounts")
 
@@ -257,38 +306,56 @@ func fetchCountsPerPod(ctx context.Context, lggr logr.Logger, endpointsFn k8s.Ge
 		return fetchResult{}, fmt.Errorf("there isn't any valid interceptor endpoint")
 	}
 
+	endpointKeys := make([]string, len(endpointURLs))
+	for i, u := range endpointURLs {
+		endpointKeys[i] = podKey(u)
+	}
+
 	type podResult struct {
 		key    string
 		counts queue.Counts
 	}
 
 	resultCh := make(chan podResult, len(endpointURLs))
-	fetchGrp, _ := errgroup.WithContext(ctx)
+	var failCount atomic.Int32
 
+	var wg sync.WaitGroup
 	for _, endpoint := range endpointURLs {
 		u := endpoint
-		fetchGrp.Go(func() error {
+		wg.Go(func() {
 			counts, err := queue.GetCounts(http.DefaultClient, u)
 			if err != nil {
 				lggr.Error(err, "getting queue counts from interceptor", "interceptorAddress", u.String())
-				return err
+				failCount.Add(1)
+				return
 			}
 			resultCh <- podResult{key: podKey(u), counts: counts}
-			return nil
 		})
 	}
 
-	if err := fetchGrp.Wait(); err != nil {
-		lggr.Error(err, "fetching all counts failed")
-		return fetchResult{endpointCount: len(endpointURLs)}, err
-	}
+	wg.Wait()
 	close(resultCh)
 
 	perPod := make(map[string]queue.Counts, len(endpointURLs))
 	for r := range resultCh {
 		perPod[r.key] = r.counts
 	}
-	return fetchResult{perPod: perPod, endpointCount: len(endpointURLs)}, nil
+
+	if n := failCount.Load(); n > 0 {
+		lggr.Info("some interceptor pods were unreachable",
+			"failedPods", n,
+			"totalPods", len(endpointURLs),
+			"successPods", len(perPod),
+		)
+	}
+
+	if len(perPod) == 0 {
+		return fetchResult{endpointKeys: endpointKeys, endpointCount: len(endpointURLs)}, fmt.Errorf(
+			"all %d interceptor pods were unreachable", len(endpointURLs),
+		)
+	}
+
+	return fetchResult{perPod: perPod, endpointKeys: endpointKeys, endpointCount: len(endpointURLs)}, nil
 }
 
 func podKey(u url.URL) string {

--- a/scaler/queue_pinger_test.go
+++ b/scaler/queue_pinger_test.go
@@ -356,6 +356,160 @@ func TestRateComputationCounterReset(t *testing.T) {
 	r.Greater(pinger.allCounts["host1"].RequestRate, 0.0)
 }
 
+func TestFetchCountsPerPod_PartialFailure(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+	const adminPort = "8081"
+
+	podA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(queue.Counts{
+			"host1": {Concurrency: 5, RequestCount: 100},
+		})
+	}))
+	defer podA.Close()
+
+	// Pod B: unreachable (closed listener, simulates spot node eviction).
+	podBListener, err := net.Listen("tcp", "127.0.0.1:0")
+	r.NoError(err)
+	podBAddr := podBListener.Addr().String()
+	r.NoError(podBListener.Close())
+
+	withPatchedDefaultTransport(t, map[string]string{
+		"pod-a:" + adminPort: podA.Listener.Addr().String(),
+		"pod-b:" + adminPort: podBAddr,
+	})
+
+	endpointsFn := func(context.Context, string, string) (k8s.Endpoints, error) {
+		return k8s.Endpoints{
+			ReadyAddresses: []string{"pod-a", "pod-b"},
+		}, nil
+	}
+
+	result, err := fetchCountsPerPod(ctx, logr.Discard(), endpointsFn, "testns", "testsvc", adminPort)
+	r.NoError(err, "one unreachable pod should not fail the entire fetch")
+	r.Len(result.perPod, 1, "should contain results from the reachable pod only")
+	r.Equal(2, result.endpointCount, "endpointCount should reflect all endpoints")
+	r.ElementsMatch([]string{"pod-a:" + adminPort, "pod-b:" + adminPort}, result.endpointKeys)
+
+	counts := result.perPod["pod-a:"+adminPort]
+	r.Equal(5, counts["host1"].Concurrency)
+	r.Equal(int64(100), counts["host1"].RequestCount)
+}
+
+func TestFetchCountsPerPod_AllPodsUnreachable(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+	const adminPort = "8081"
+
+	// Both pods unreachable.
+	listenerA, err := net.Listen("tcp", "127.0.0.1:0")
+	r.NoError(err)
+	addrA := listenerA.Addr().String()
+	r.NoError(listenerA.Close())
+
+	listenerB, err := net.Listen("tcp", "127.0.0.1:0")
+	r.NoError(err)
+	addrB := listenerB.Addr().String()
+	r.NoError(listenerB.Close())
+
+	withPatchedDefaultTransport(t, map[string]string{
+		"pod-a:" + adminPort: addrA,
+		"pod-b:" + adminPort: addrB,
+	})
+
+	endpointsFn := func(context.Context, string, string) (k8s.Endpoints, error) {
+		return k8s.Endpoints{
+			ReadyAddresses: []string{"pod-a", "pod-b"},
+		}, nil
+	}
+
+	_, err = fetchCountsPerPod(ctx, logr.Discard(), endpointsFn, "testns", "testsvc", adminPort)
+	r.Error(err, "should fail when all pods are unreachable")
+	r.Contains(err.Error(), "all 2 interceptor pods were unreachable")
+}
+
+func TestFetchAndSaveCounts_CachedUnreachablePod(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+	const (
+		ns        = "testns"
+		svcName   = "testsvc"
+		deplName  = "testdepl"
+		adminPort = "8081"
+	)
+
+	podA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(queue.Counts{
+			"host1": {Concurrency: 2, RequestCount: 100},
+		})
+	}))
+	defer podA.Close()
+
+	podBSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(queue.Counts{
+			"host1": {Concurrency: 3, RequestCount: 200},
+		})
+	}))
+	defer podBSrv.Close()
+
+	// Grab pod-b's real address so we can redirect to a closed port later.
+	podBAddr := podBSrv.Listener.Addr().String()
+	closedListener, err := net.Listen("tcp", "127.0.0.1:0")
+	r.NoError(err)
+	closedAddr := closedListener.Addr().String()
+	r.NoError(closedListener.Close())
+
+	withPatchedDefaultTransport(t, map[string]string{
+		"pod-a:" + adminPort: podA.Listener.Addr().String(),
+		"pod-b:" + adminPort: podBAddr,
+	})
+
+	var readyAddrs atomic.Value
+	readyAddrs.Store([]string{"pod-a", "pod-b"})
+
+	pinger := newQueuePinger(
+		logr.Discard(),
+		func(context.Context, string, string) (k8s.Endpoints, error) {
+			addrs := readyAddrs.Load().([]string)
+			return k8s.Endpoints{
+				ReadyAddresses: append([]string(nil), addrs...),
+			}, nil
+		},
+		ns, svcName, deplName, adminPort,
+		metrics.NewNoopInstruments(),
+	)
+
+	// --- Tick 1: both pods reachable ---
+	r.NoError(pinger.fetchAndSaveCounts(ctx))
+	count := pinger.count("host1")
+	r.Equal(5, count.Concurrency, "should sum concurrency from both pods")
+
+	// --- Tick 2: pod-b becomes unreachable, still in EndpointSlice ---
+	withPatchedDefaultTransport(t, map[string]string{
+		"pod-a:" + adminPort: podA.Listener.Addr().String(),
+		"pod-b:" + adminPort: closedAddr,
+	})
+
+	r.NoError(pinger.fetchAndSaveCounts(ctx))
+	count = pinger.count("host1")
+	r.Equal(5, count.Concurrency,
+		"cached concurrency from pod-b should be preserved")
+	r.Contains(pinger.cachedPodCounts, "pod-b:"+adminPort,
+		"cached data should still exist for unreachable pod")
+
+	// --- Tick 3: pod-b removed from EndpointSlice ---
+	readyAddrs.Store([]string{"pod-a"})
+
+	r.NoError(pinger.fetchAndSaveCounts(ctx))
+	count = pinger.count("host1")
+	r.Equal(2, count.Concurrency,
+		"should only have pod-a's concurrency after pod-b leaves EndpointSlice")
+	r.NotContains(pinger.cachedPodCounts, "pod-b:"+adminPort,
+		"cached data should be pruned when pod leaves EndpointSlice")
+	r.NotContains(pinger.prevPodCounts, "pod-b:"+adminPort,
+		"prevPodCounts should be pruned when pod leaves EndpointSlice")
+}
+
 func TestUpdateBucketConfig(t *testing.T) {
 	r := require.New(t)
 	_, pinger, err := newFakeQueuePinger(logr.Discard())


### PR DESCRIPTION
When any single interceptor pod endpoint is temporarily unreachable
(e.g. spot node eviction, rolling update race window), `fetchCountsPerPod`
previously failed the entire metrics fetch because it used `errgroup`,
which returns on the first error. This set `PingerERROR`, the gRPC health
check reported `NOT_SERVING`, and Kubernetes restarted the scaler pod
after ~30s -- destroying all in-memory state (`prevPodCounts`,
`rateBuckets`) and producing zero/incorrect RPS values for up to a full
window duration (default: 1 minute).

This PR makes two changes to address the problem:

### 1. Tolerate partial interceptor pod failures

Replace `errgroup` with `sync.WaitGroup.Go()` (available since Go 1.25)
and buffered channels so that individual pod failures are logged and
skipped. An error is only returned when **all** pods are unreachable.

### 2. Cache last-known counts for unreachable pods

To prevent underreporting (which could cause premature scale-down or
prevent scale-from-zero), the scaler now caches the last successful
response from each interceptor pod. When a pod is unreachable but still
present in the EndpointSlice, its cached concurrency is included in the
aggregated metrics. The cache is pruned when the pod actually leaves
the EndpointSlice.

A new OTel gauge `scaler.pinger.unreachable_pods` reports the number of
interceptor pods that were unreachable in the last fetch cycle, giving
operators visibility into partial degradation before it becomes a total
outage.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] Changelog is updated per our changelog requirements
- [x] Documentation is updated if needed (README.md, keda-docs)

Fixes #1667