### PR TITLE
feat: select backend transport via service appProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This changelog keeps track of work items that have been completed and are ready 
 - **General**: Add `coldStart.placeholder` support for returning static HTTP responses during scale-from-zero ([#874](https://github.com/kedacore/http-add-on/issues/874))
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
 - **Interceptor**: Add HTTP/2 support (h2c and h2 over TLS), enabling autoscaling of gRPC workloads ([#1084](https://github.com/kedacore/http-add-on/issues/1084))
+- **Interceptor**: Select backend transport based on Kubernetes `appProtocol` instead of mirroring the client's protocol. Cleartext backends default to HTTP/1.1 unless the Service port sets `appProtocol: kubernetes.io/h2c`; TLS backends negotiate via ALPN ([#1676](https://github.com/kedacore/http-add-on/issues/1676))
 - **Scaler**: Add OpenTelemetry metrics and distributed tracing to the external scaler ([#965](https://github.com/kedacore/http-add-on/issues/965))
 
 ### Improvements

--- a/interceptor/handler/upstream.go
+++ b/interceptor/handler/upstream.go
@@ -11,11 +11,17 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kedacore/http-add-on/interceptor/config"
+	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
 	kedahttp "github.com/kedacore/http-add-on/pkg/http"
 	"github.com/kedacore/http-add-on/pkg/util"
 )
+
+const appProtocolH2C = "kubernetes.io/h2c"
 
 var (
 	bufferPool = newBufferPool()
@@ -26,18 +32,26 @@ var (
 type Upstream struct {
 	defaultTransportPool   *kedahttp.TransportPool
 	http2OnlyTransportPool *kedahttp.TransportPool
-	tracingCfg             config.Tracing
+	reader                 client.Reader
 	responseHeaderTimeout  time.Duration
+	tracingCfg             config.Tracing
 }
 
-func NewUpstream(baseTransport *http.Transport, tracingCfg config.Tracing, responseHeaderTimeout time.Duration) *Upstream {
+func NewUpstream(baseTransport *http.Transport, reader client.Reader, tracingCfg config.Tracing, responseHeaderTimeout time.Duration) *Upstream {
+	if baseTransport == nil {
+		panic("baseTransport must not be nil")
+	}
+	if reader == nil {
+		panic("reader must not be nil")
+	}
 	defaultTransport, http2OnlyTransport := kedahttp.NewTransports(baseTransport)
 
 	return &Upstream{
 		defaultTransportPool:   kedahttp.NewTransportPool(defaultTransport),
 		http2OnlyTransportPool: kedahttp.NewTransportPool(http2OnlyTransport),
-		tracingCfg:             tracingCfg,
+		reader:                 reader,
 		responseHeaderTimeout:  responseHeaderTimeout,
+		tracingCfg:             tracingCfg,
 	}
 }
 
@@ -65,15 +79,16 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Select transport with per-route or global response header timeout.
+	ir := util.InterceptorRouteFromContext(ctx)
 	responseHeaderTimeout := uh.responseHeaderTimeout
-	if ir := util.InterceptorRouteFromContext(ctx); ir != nil {
+	if ir != nil {
 		if ir.Spec.Timeouts.ResponseHeader != nil {
 			responseHeaderTimeout = ir.Spec.Timeouts.ResponseHeader.Duration
 		}
 	}
 
 	pool := uh.defaultTransportPool
-	if r.ProtoMajor == 2 {
+	if uh.requiresHTTP2(ctx, ir) {
 		pool = uh.http2OnlyTransportPool
 	}
 	transport := pool.Get(responseHeaderTimeout)
@@ -127,4 +142,38 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	proxy.ServeHTTP(w, r)
+}
+
+func (uh *Upstream) requiresHTTP2(ctx context.Context, ir *httpv1beta1.InterceptorRoute) bool {
+	if ir == nil {
+		return false
+	}
+
+	var svc corev1.Service
+	err := uh.reader.Get(ctx, types.NamespacedName{
+		Namespace: ir.Namespace,
+		Name:      ir.Spec.Target.Service,
+	}, &svc)
+	if err != nil {
+		util.LoggerFromContext(ctx).Error(err, "failed to look up Service for appProtocol, using default transport",
+			"service", ir.Spec.Target.Service,
+			"namespace", ir.Namespace,
+		)
+		return false
+	}
+
+	for _, port := range svc.Spec.Ports {
+		if !matchesTargetPort(ir.Spec.Target, port) {
+			continue
+		}
+		return port.AppProtocol != nil && *port.AppProtocol == appProtocolH2C
+	}
+	return false
+}
+
+func matchesTargetPort(target httpv1beta1.TargetRef, port corev1.ServicePort) bool {
+	if target.Port != 0 {
+		return port.Port == target.Port
+	}
+	return port.Name == target.PortName
 }

--- a/interceptor/handler/upstream_test.go
+++ b/interceptor/handler/upstream_test.go
@@ -20,11 +20,15 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kedacore/http-add-on/interceptor/config"
 	"github.com/kedacore/http-add-on/interceptor/tracing"
 	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
+	"github.com/kedacore/http-add-on/pkg/cache"
 	kedanet "github.com/kedacore/http-add-on/pkg/net"
 	"github.com/kedacore/http-add-on/pkg/util"
 )
@@ -160,7 +164,7 @@ func TestForwarderSuccess(t *testing.T) {
 	req = util.RequestWithUpstreamURL(req, forwardURL)
 	timeouts := defaultTimeouts()
 	dialCtxFunc := retryDialContextFunc(timeouts)
-	uh := NewUpstream(newTestTransport(dialCtxFunc), config.Tracing{}, timeouts.ResponseHeader)
+	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader)
 	uh.ServeHTTP(res, req)
 
 	r.True(
@@ -202,7 +206,7 @@ func TestForwarderHeaderTimeout(t *testing.T) {
 	res, req, err := reqAndRes("/testfwd")
 	r.NoError(err)
 	req = util.RequestWithUpstreamURL(req, originURL)
-	uh := NewUpstream(newTestTransport(dialCtxFunc), config.Tracing{}, timeouts.ResponseHeader)
+	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader)
 	uh.ServeHTTP(res, req)
 
 	r.Equal(http.StatusGatewayTimeout, res.Code)
@@ -246,7 +250,7 @@ func TestForwarderWaitsForSlowOrigin(t *testing.T) {
 	res, req, err := reqAndRes(path)
 	r.NoError(err)
 	req = util.RequestWithUpstreamURL(req, originURL)
-	uh := NewUpstream(newTestTransport(dialCtxFunc), config.Tracing{}, timeouts.ResponseHeader)
+	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader)
 	uh.ServeHTTP(res, req)
 	// wait for the goroutine above to finish, with a little cusion
 	ensureSignalBeforeTimeout(originWaitCh, originDelay*2)
@@ -262,6 +266,8 @@ func TestForwarderConnectionRetryAndTimeout(t *testing.T) {
 	const requestTimeout = 500 * time.Millisecond
 	timeouts := defaultTimeouts()
 	dialCtxFunc := retryDialContextFunc(timeouts)
+	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader)
+
 	res, req, err := reqAndRes("/test")
 	r.NoError(err)
 
@@ -270,7 +276,6 @@ func TestForwarderConnectionRetryAndTimeout(t *testing.T) {
 	req = req.WithContext(ctx)
 
 	req = util.RequestWithUpstreamURL(req, noSuchURL)
-	uh := NewUpstream(newTestTransport(dialCtxFunc), config.Tracing{}, timeouts.ResponseHeader)
 
 	start := time.Now()
 	uh.ServeHTTP(res, req)
@@ -318,7 +323,7 @@ func TestForwardRequestRedirectAndHeaders(t *testing.T) {
 	res, req, err := reqAndRes("/testfwd")
 	r.NoError(err)
 	req = util.RequestWithUpstreamURL(req, srvURL)
-	uh := NewUpstream(newTestTransport(dialCtxFunc), config.Tracing{}, timeouts.ResponseHeader)
+	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader)
 	uh.ServeHTTP(res, req)
 	r.Equal(301, res.Code)
 	r.Equal("abc123.com", res.Header().Get("Location"))
@@ -375,7 +380,7 @@ func TestUpstreamPreservesXForwardedHeaders(t *testing.T) {
 			}
 
 			// Configure the Upstream and send a dummy request
-			upstream := NewUpstream(http.DefaultTransport.(*http.Transport), config.Tracing{}, 500*time.Millisecond)
+			upstream := NewUpstream(http.DefaultTransport.(*http.Transport), newFakeClient(), config.Tracing{}, 500*time.Millisecond)
 
 			req := httptest.NewRequest("GET", "/test", nil)
 			if tt.forwardedFor != "" {
@@ -464,7 +469,7 @@ func TestUpstream_RouteSpecResponseHeaderOverride(t *testing.T) {
 	ctx := util.ContextWithInterceptorRoute(req.Context(), ir)
 	req = req.WithContext(ctx)
 
-	uh := NewUpstream(newTestTransport(dialCtxFunc), config.Tracing{}, timeouts.ResponseHeader)
+	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader)
 	uh.ServeHTTP(res, req)
 
 	r.Equal(http.StatusGatewayTimeout, res.Code)
@@ -483,7 +488,7 @@ func TestFullDuplexBodyPanic(t *testing.T) {
 		},
 	}
 
-	upstream := NewUpstream(failingTransport, config.Tracing{}, 1*time.Second)
+	upstream := NewUpstream(failingTransport, newFakeClient(), config.Tracing{}, 1*time.Second)
 
 	targetURL, _ := url.Parse("http://fake-backend:8080")
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -518,6 +523,157 @@ func (w panicLogWriter) Write(p []byte) (int, error) {
 		w.onPanic()
 	}
 	return len(p), nil
+}
+
+func TestUpstream_AppProtocolTransportSelection(t *testing.T) {
+	h2cProto := "kubernetes.io/h2c"
+
+	tests := map[string]struct {
+		appProtocol        *string
+		incomingProtoMajor int
+		wantBackendProto   int
+	}{
+		"h2c appProtocol with HTTP/1 request uses HTTP/2": {
+			appProtocol:        &h2cProto,
+			incomingProtoMajor: 1,
+			wantBackendProto:   2,
+		},
+		"h2c appProtocol with HTTP/2 request uses HTTP/2": {
+			appProtocol:        &h2cProto,
+			incomingProtoMajor: 2,
+			wantBackendProto:   2,
+		},
+		"no appProtocol with HTTP/1 request uses HTTP/1": {
+			appProtocol:        nil,
+			incomingProtoMajor: 1,
+			wantBackendProto:   1,
+		},
+		"no appProtocol with HTTP/2 request uses HTTP/1": {
+			appProtocol:        nil,
+			incomingProtoMajor: 2,
+			wantBackendProto:   1,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var backendProtoMajor int
+			backend := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				backendProtoMajor = r.ProtoMajor
+				w.WriteHeader(http.StatusOK)
+			}))
+			var protocols http.Protocols
+			protocols.SetHTTP1(true)
+			protocols.SetUnencryptedHTTP2(true)
+			backend.Config.Protocols = &protocols
+			backend.Start()
+			defer backend.Close()
+
+			backendURL, err := url.Parse(backend.URL)
+			if err != nil {
+				t.Fatalf("failed to parse backend URL: %v", err)
+			}
+
+			fakeClient := newFakeClient(corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-svc",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{
+						Name:        "grpc",
+						Port:        8080,
+						AppProtocol: tc.appProtocol,
+					}},
+				},
+			})
+
+			ir := &httpv1beta1.InterceptorRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ir",
+					Namespace: "default",
+				},
+				Spec: httpv1beta1.InterceptorRouteSpec{
+					Target: httpv1beta1.TargetRef{
+						Service: "test-svc",
+						Port:    8080,
+					},
+				},
+			}
+
+			upstream := NewUpstream(http.DefaultTransport.(*http.Transport), fakeClient, config.Tracing{}, 5*time.Second)
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.ProtoMajor = tc.incomingProtoMajor
+			ctx := util.ContextWithUpstreamURL(req.Context(), backendURL)
+			ctx = util.ContextWithInterceptorRoute(ctx, ir)
+			req = req.WithContext(ctx)
+
+			rec := httptest.NewRecorder()
+			upstream.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if backendProtoMajor != tc.wantBackendProto {
+				t.Errorf("backend saw HTTP/%d, want HTTP/%d", backendProtoMajor, tc.wantBackendProto)
+			}
+		})
+	}
+}
+
+func TestUpstream_AppProtocolFallbackOnMissingService(t *testing.T) {
+	var backendProtoMajor int
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		backendProtoMajor = r.ProtoMajor
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("failed to parse backend URL: %v", err)
+	}
+
+	fakeClient := newFakeClient()
+
+	ir := &httpv1beta1.InterceptorRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ir",
+			Namespace: "default",
+		},
+		Spec: httpv1beta1.InterceptorRouteSpec{
+			Target: httpv1beta1.TargetRef{
+				Service: "missing-svc",
+				Port:    8080,
+			},
+		},
+	}
+
+	upstream := NewUpstream(http.DefaultTransport.(*http.Transport), fakeClient, config.Tracing{}, 5*time.Second)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	ctx := util.ContextWithUpstreamURL(req.Context(), backendURL)
+	ctx = util.ContextWithInterceptorRoute(ctx, ir)
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	upstream.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	if backendProtoMajor != 1 {
+		t.Errorf("expected fallback to HTTP/1, got HTTP/%d", backendProtoMajor)
+	}
+}
+
+func newFakeClient(objs ...corev1.Service) client.Reader {
+	builder := fake.NewClientBuilder().WithScheme(cache.NewScheme())
+	for i := range objs {
+		builder = builder.WithObjects(&objs[i])
+	}
+	return builder.Build()
 }
 
 func newTestTransport(dialCtxFunc kedanet.DialContextFunc) *http.Transport {
@@ -565,7 +721,7 @@ func serveHTTP(w http.ResponseWriter, r *http.Request) {
 	timeouts := defaultTimeouts()
 	dialCtxFunc := retryDialContextFunc(timeouts)
 	transport := newTestTransport(dialCtxFunc)
-	upstream := NewUpstream(transport, config.Tracing{Enabled: true}, timeouts.ResponseHeader)
+	upstream := NewUpstream(transport, newFakeClient(), config.Tracing{Enabled: true}, timeouts.ResponseHeader)
 
 	upstream.ServeHTTP(w, r)
 }

--- a/interceptor/proxy.go
+++ b/interceptor/proxy.go
@@ -73,7 +73,7 @@ func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
 	// Build handler chain (innermost to outermost)
 	var h http.Handler
 
-	h = handler.NewUpstream(baseTransport, cfg.Tracing, cfg.Timeouts.ResponseHeader)
+	h = handler.NewUpstream(baseTransport, cfg.Reader, cfg.Tracing, cfg.Timeouts.ResponseHeader)
 
 	h = middleware.NewEndpointResolver(h, cfg.ReadyCache, middleware.EndpointResolverConfig{
 		ReadinessTimeout:      cfg.Timeouts.Readiness,

--- a/test/e2e/default/grpc_test.go
+++ b/test/e2e/default/grpc_test.go
@@ -26,6 +26,7 @@ func TestGRPC(t *testing.T) {
 
 			app := f.CreateTestApp("grpc-app",
 				h.AppWithTestImage(h.ImageGRPCEcho),
+				h.AppWithAppProtocol(h.AppProtocolH2C),
 			)
 			ir := f.CreateInterceptorRoute("grpc-ir", app,
 				h.IRWithHosts(f.Hostname()),

--- a/test/e2e/tls/grpc_test.go
+++ b/test/e2e/tls/grpc_test.go
@@ -29,6 +29,7 @@ func TestGRPCOverTLS(t *testing.T) {
 
 			app := f.CreateTestApp(appName,
 				h.AppWithTestImage(h.ImageGRPCEcho),
+				h.AppWithAppProtocol(h.AppProtocolH2C),
 				h.AppWithTLSSecret(certSecretName),
 			)
 			ir := f.CreateInterceptorRoute("grpc-tls-ir", app,

--- a/test/helpers/app.go
+++ b/test/helpers/app.go
@@ -21,13 +21,15 @@ const (
 	defaultPort    = int32(8080)
 	tlsCertsVolume = "tls-certs"
 
-	ImageGRPCEcho = "grpc-echo"
+	AppProtocolH2C = "kubernetes.io/h2c"
+	ImageGRPCEcho  = "grpc-echo"
 )
 
 // TestApp bundles a Deployment and Service for a test backend.
 type TestApp struct {
 	Namespace     string
 	Name          string
+	AppProtocol   *string
 	Image         string
 	Replicas      int32
 	Port          int32
@@ -61,6 +63,11 @@ func AppWithReplicas(n int32) TestAppOption {
 // AppWithPortName sets the service port name.
 func AppWithPortName(name string) TestAppOption {
 	return func(a *TestApp) { a.PortName = name }
+}
+
+// AppWithAppProtocol sets the service port appProtocol (e.g. "kubernetes.io/h2c").
+func AppWithAppProtocol(proto string) TestAppOption {
+	return func(a *TestApp) { a.AppProtocol = &proto }
 }
 
 // AppWithTLSSecret configures the app to serve TLS using the given cert secret.
@@ -163,9 +170,10 @@ func (a *TestApp) Resources() []k8s.Object {
 		Spec: corev1.ServiceSpec{
 			Selector: labels,
 			Ports: []corev1.ServicePort{{
-				Name:       a.PortName,
-				Port:       a.Port,
-				TargetPort: intstr.FromInt32(a.Port),
+				AppProtocol: a.AppProtocol,
+				Name:        a.PortName,
+				Port:        a.Port,
+				TargetPort:  intstr.FromInt32(a.Port),
 			}},
 		},
 	}


### PR DESCRIPTION
The interceptor previously mirrored the client's protocol to the backend. Now it reads the appProtocol field from the target Service port. Cleartext backends default to HTTP/1.1 unless the Service port sets appProtocol: kubernetes.io/h2c; TLS backends negotiate via ALPN.

The previous PR #1655 used the incoming protocol also for outgoing requests instead of defaulting to HTTP1 which basically all ingress controllers are doing. We didn't release the GRPC stuff yet so not really a breaking change.

### Changes
- Replace ProtoMajor-based transport selection with appProtocol lookup
- Add AppWithAppProtocol e2e helper and set it on gRPC test Services


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))
	- see https://github.com/kedacore/keda-docs/pull/1789

Fixes #1676 
