### PR TITLE
chore: pin helm version and add timeouts to e2e helm installs

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -47,6 +47,11 @@ jobs:
 
       - name: Helm install
         uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        env:
+          # renovate: datasource=github-releases depName=helm/helm
+          HELM_VERSION: "v4.2.0"
+        with:
+          version: ${{ env.HELM_VERSION }}
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@${GOTESTSUM_VERSION}
@@ -110,6 +115,11 @@ jobs:
 
       - name: Helm install
         uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        env:
+          # renovate: datasource=github-releases depName=helm/helm
+          HELM_VERSION: "v4.2.0"
+        with:
+          version: ${{ env.HELM_VERSION }}
 
       - name: Create Kind Cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/Makefile
+++ b/Makefile
@@ -181,26 +181,26 @@ e2e-deps-cert-manager:
 	$(call helm-retry,helm upgrade --install cert-manager jetstack/cert-manager \
 		--namespace cert-manager --create-namespace \
 		-f test/fixtures/cert-manager-values.yaml \
-		--version $(CERT_MANAGER_VERSION) --wait)
+		--version $(CERT_MANAGER_VERSION) --wait --timeout 5m)
 
 e2e-deps-jaeger:
 	helm repo add jaegertracing https://jaegertracing.github.io/helm-charts --force-update
 	$(call helm-retry,helm upgrade --install jaeger jaegertracing/jaeger \
 		--namespace jaeger --create-namespace \
-		--version $(JAEGER_VERSION) --wait)
+		--version $(JAEGER_VERSION) --wait --timeout 5m)
 
 e2e-deps-keda:
 	helm repo add kedacore https://kedacore.github.io/charts --force-update
 	$(call helm-retry,helm upgrade --install keda kedacore/keda \
 		--namespace keda --create-namespace \
-		--version $(KEDA_VERSION) --wait)
+		--version $(KEDA_VERSION) --wait --timeout 5m)
 
 e2e-deps-otel-collector:
 	helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts --force-update
 	$(call helm-retry,helm upgrade --install opentelemetry-collector open-telemetry/opentelemetry-collector \
 		--namespace open-telemetry-system --create-namespace \
 		-f test/fixtures/otel-values.yaml \
-		--version $(OTEL_COLLECTOR_VERSION) --wait)
+		--version $(OTEL_COLLECTOR_VERSION) --wait --timeout 5m)
 
 e2e-setup: e2e-deps deploy e2e-test-images ## Full e2e setup: install deps + deploy http-add-on + build test images
 


### PR DESCRIPTION
Helm v4.2.1 has a regression where --wait hangs for the full timeout on fast hook resource deletions.
See https://github.com/helm/helm/issues/32214

This affects our CI right now and causes PRs to be stuck during e2e tests.

### Changes
- Pin helm to v4.2.0 in CI with Renovate tracking
- Add --timeout 5m to all e2e-deps helm install commands

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
