### PR TITLE
ci: pin Helm version in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark-tests.yaml
+++ b/.github/workflows/benchmark-tests.yaml
@@ -28,6 +28,11 @@ jobs:
 
       - name: Helm install
         uses: Azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        env:
+          # renovate: datasource=github-releases depName=helm/helm
+          HELM_VERSION: "v4.2.2"
+        with:
+          version: ${{ env.HELM_VERSION }}
 
       - name: Create Kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0


### PR DESCRIPTION
The benchmark workflow added in #1675 didn't include the Helm version pinning from #1686. This left Helm unpinned, resolving to v4.2.1 where cert-manager's --wait --timeout 5m blocked for ~40 min instead of respecting the timeout.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
