### PR TITLE
fix: don't log error when no interceptor endpoints are ready

### DIFF
--- a/scaler/queue_pinger.go
+++ b/scaler/queue_pinger.go
@@ -289,11 +289,15 @@ type fetchResult struct {
 // and returns the raw per-pod results keyed by pod URL string along with
 // the total number of endpoints that were polled.
 //
+// If there are no ready interceptor endpoints (e.g. during startup
+// before the interceptor passes its readiness probe), an empty result
+// is returned without error.
+//
 // Individual pod failures are logged and skipped. An error is only
-// returned when no pod could be reached at all, so that a single
-// unreachable interceptor (e.g. during a rolling update or spot-node
-// eviction) does not cause the scaler to report NOT_SERVING and get
-// restarted by Kubernetes.
+// returned when endpoints exist but no pod could be reached at all,
+// so that a single unreachable interceptor (e.g. during a rolling
+// update or spot-node eviction) does not cause the scaler to report
+// NOT_SERVING and get restarted by Kubernetes.
 func fetchCountsPerPod(ctx context.Context, lggr logr.Logger, endpointsFn k8s.GetEndpointsFunc, ns, svcName, adminPort string) (fetchResult, error) {
 	lggr = lggr.WithName("queuePinger.requestCounts")
 
@@ -303,7 +307,8 @@ func fetchCountsPerPod(ctx context.Context, lggr logr.Logger, endpointsFn k8s.Ge
 	}
 
 	if len(endpointURLs) == 0 {
-		return fetchResult{}, fmt.Errorf("there isn't any valid interceptor endpoint")
+		lggr.V(1).Info("no interceptor endpoints found")
+		return fetchResult{}, nil
 	}
 
 	endpointKeys := make([]string, len(endpointURLs))

--- a/scaler/queue_pinger_test.go
+++ b/scaler/queue_pinger_test.go
@@ -356,6 +356,21 @@ func TestRateComputationCounterReset(t *testing.T) {
 	r.Greater(pinger.allCounts["host1"].RequestRate, 0.0)
 }
 
+func TestFetchCountsPerPod_NoEndpoints(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	endpointsFn := func(context.Context, string, string) (k8s.Endpoints, error) {
+		return k8s.Endpoints{}, nil
+	}
+
+	result, err := fetchCountsPerPod(ctx, logr.Discard(), endpointsFn, "testns", "testsvc", "8081")
+	r.NoError(err, "no endpoints should not be an error")
+	r.Empty(result.perPod)
+	r.Empty(result.endpointKeys)
+	r.Equal(0, result.endpointCount)
+}
+
 func TestFetchCountsPerPod_PartialFailure(t *testing.T) {
 	r := require.New(t)
 	ctx := t.Context()


### PR DESCRIPTION
During startup the scaler and interceptor are deployed at the same time.
The scaler's controller-runtime cache syncs before the interceptor pod
passes its readiness probe, so the EndpointSlice has no ready addresses
yet. This caused ERROR-level log spam every tick until the interceptor
became ready, and also set the pinger status to `PingerERROR` which
made the health checks report `NOT_SERVING`.

Having zero ready endpoints is a transient but normal condition — return
an empty result with a debug-level log instead of treating it as an error.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

Fixes #