### PR TITLE
fix: allow timer jitter in TestForwarderConnectionRetryAndTimeout

### DIFF
--- a/interceptor/handler/upstream_test.go
+++ b/interceptor/handler/upstream_test.go
@@ -282,10 +282,11 @@ func TestForwarderConnectionRetryAndTimeout(t *testing.T) {
 	elapsed := time.Since(start)
 	log.Printf("forwardRequest took %s", elapsed)
 
+	const timerJitter = 5 * time.Millisecond
 	r.GreaterOrEqualf(
 		elapsed,
-		requestTimeout,
-		"proxy returned after %s, expected not to return until %s",
+		requestTimeout-timerJitter,
+		"proxy returned after %s, expected not to return until ~%s",
 		elapsed,
 		requestTimeout,
 	)


### PR DESCRIPTION
`TestForwarderConnectionRetryAndTimeout` sets a 500ms context timeout
and then asserts `elapsed >= 500ms`. On busy CI runners Go timers can
fire slightly before the deadline — the failing run saw `499.495ms`.

Add a 5ms tolerance so sub-millisecond timer drift does not cause
spurious failures.

[Example](https://github.com/kedacore/http-add-on/actions/runs/27939602469/job/82669489628?pr=1695) of a failed test.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

Fixes #