### PR TITLE
fix: prevent requestRate rounding to zero after long idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Fixes
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Scaler**: Fix scale-from-zero failing with 504 after long idle when using `requestRate` with large `window/granularity` ratios (>2000) ([#1692](https://github.com/kedacore/http-add-on/issues/1692))
 
 ### Deprecations
 

--- a/pkg/queue/bucketing.go
+++ b/pkg/queue/bucketing.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const precision = 3
+const precision = 6
 
 // RequestsBuckets keeps buckets that have been collected at a certain time.
 type RequestsBuckets struct {

--- a/pkg/queue/bucketing_test.go
+++ b/pkg/queue/bucketing_test.go
@@ -370,6 +370,24 @@ func TestRequestsBucketsHoles(t *testing.T) {
 	}
 }
 
+func TestWindowAveragePositiveAfterLongIdle(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	buckets := NewRequestsBuckets(time.Hour, granularity)
+
+	// Simulate 45 minutes of idle polling (delta=0 each second).
+	for i := range 2700 {
+		buckets.Record(now.Add(time.Duration(i)*time.Second), 0)
+	}
+
+	// A single request arrives after the long idle period.
+	at := now.Add(2700 * time.Second)
+	buckets.Record(at, 1)
+	avg := buckets.WindowAverage(at)
+	if avg <= 0 {
+		t.Errorf("WindowAverage after long idle + 1 request = %v, want > 0", avg)
+	}
+}
+
 func BenchmarkWindowAverage(b *testing.B) {
 	// Window lengths in secs.
 	for _, wl := range []int{30, 60, 120, 240, 600} {


### PR DESCRIPTION
The bucketing code copied from Knative in PR #961 used precision=3 for rounding WindowAverage, but Knative raised this to 6 in January 2020 to handle edge cases with large window/granularity ratios. With precision=3 and a ratio above 2000 (e.g. window=1h, granularity=1s), a single request after ~33 minutes of idle produces an average that rounds to zero, preventing scale-from-zero activation.

### Changes
- Raise precision constant from 3 to 6 to match Knative upstream
- Add regression test for single request after long idle with 1h window


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

Fixes #1692 