### PR TITLE
feat(interceptor): use certwatcher for TLS certificate hot-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 - **Interceptor**: The forwarding transport sets TLS `ServerName` per-dial via `DialTLSContext`, using the original service hostname captured in context, so SNI stays correct when the upstream URL is rewritten to a pod IP. ([#1473](https://github.com/kedacore/http-add-on/issues/1473))
 - **Interceptor**: TLS server name is captured in context by the routing middleware before any URL rewrites, so downstream transports always use the original service hostname for SNI. The routing middleware also resolves the upstream named port into context to drive direct-pod target selection. ([#1473](https://github.com/kedacore/http-add-on/issues/1473))
+- **Interceptor**: Use certwatcher for the default serving certificate, enabling automatic reload on certificate rotation without restarts. ([#1715](https://github.com/kedacore/http-add-on/issues/1715))
 - **Interceptor**: `ReadyEndpointsCache` now tracks full `(ip, port)` pairs per named port from EndpointSlices, enabling direct-pod routing (replaces the previous bool-only ready state). ([#1473](https://github.com/kedacore/http-add-on/issues/1473))
 
 ### Fixes

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -238,7 +238,7 @@ func run() error {
 	// accepts, holds and forwards user requests
 	if servingCfg.ProxyTLSEnabled {
 		proxyEg.Go(func() error {
-			tlsCfg, err := BuildTLSConfig(TLSOptions{
+			tlsCfg, watcher, err := BuildTLSConfig(TLSOptions{
 				CertificatePath:    servingCfg.TLSCertPath,
 				KeyPath:            servingCfg.TLSKeyPath,
 				CertStorePaths:     servingCfg.TLSCertStorePaths,
@@ -250,6 +250,11 @@ func run() error {
 			}, setupLog)
 			if err != nil {
 				return fmt.Errorf("configuring TLS: %w", err)
+			}
+			if watcher != nil {
+				proxyEg.Go(func() error {
+					return watcher.Start(proxyCtx)
+				})
 			}
 
 			setupLog.Info("starting the proxy server with TLS enabled", "port", servingCfg.TLSPort)

--- a/interceptor/tls_config.go
+++ b/interceptor/tls_config.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 )
 
 // TLSOptions holds TLS configuration options for the proxy server.
@@ -27,7 +28,9 @@ type TLSOptions struct {
 
 // BuildTLSConfig creates a tls.Config from the given TLS options.
 // The matching between request and certificate is performed by comparing TLS/SNI server name with x509 SANs.
-func BuildTLSConfig(opts TLSOptions, logger logr.Logger) (*tls.Config, error) {
+// When CertificatePath and KeyPath are set, a certwatcher is created for hot-reload of the default cert.
+// The caller must start the returned watcher with watcher.Start(ctx).
+func BuildTLSConfig(opts TLSOptions, logger logr.Logger) (*tls.Config, *certwatcher.CertWatcher, error) {
 	servingTLS := &tls.Config{
 		RootCAs:            defaultCertPool(logger),
 		InsecureSkipVerify: opts.InsecureSkipVerify, //nolint:gosec // G402: user-configurable
@@ -36,64 +39,70 @@ func BuildTLSConfig(opts TLSOptions, logger logr.Logger) (*tls.Config, error) {
 	if opts.MinTLSVersion != "" {
 		v, err := parseTLSVersion(opts.MinTLSVersion)
 		if err != nil {
-			return nil, fmt.Errorf("invalid TLS min version %q: %w", opts.MinTLSVersion, err)
+			return nil, nil, fmt.Errorf("invalid TLS min version %q: %w", opts.MinTLSVersion, err)
 		}
 		servingTLS.MinVersion = v
 	}
 	if opts.MaxTLSVersion != "" {
 		v, err := parseTLSVersion(opts.MaxTLSVersion)
 		if err != nil {
-			return nil, fmt.Errorf("invalid TLS max version %q: %w", opts.MaxTLSVersion, err)
+			return nil, nil, fmt.Errorf("invalid TLS max version %q: %w", opts.MaxTLSVersion, err)
 		}
 		servingTLS.MaxVersion = v
 	}
 	if opts.CipherSuites != "" {
 		suites, err := parseCipherSuites(opts.CipherSuites)
 		if err != nil {
-			return nil, fmt.Errorf("invalid TLS cipher suites: %w", err)
+			return nil, nil, fmt.Errorf("invalid TLS cipher suites: %w", err)
 		}
 		servingTLS.CipherSuites = suites
 	}
 	if opts.CurvePreferences != "" {
 		curves, err := parseCurvePreferences(opts.CurvePreferences)
 		if err != nil {
-			return nil, fmt.Errorf("invalid TLS curve preferences: %w", err)
+			return nil, nil, fmt.Errorf("invalid TLS curve preferences: %w", err)
 		}
 		servingTLS.CurvePreferences = curves
 	}
-	var defaultCert *tls.Certificate
+
+	var watcher *certwatcher.CertWatcher
 
 	uriDomainsToCerts := make(map[string]tls.Certificate)
 	if opts.CertificatePath != "" && opts.KeyPath != "" {
-		cert, err := addCert(uriDomainsToCerts, opts.CertificatePath, opts.KeyPath, logger)
+		var err error
+		watcher, err = certwatcher.New(opts.CertificatePath, opts.KeyPath)
 		if err != nil {
-			return nil, fmt.Errorf("error adding certificate and key: %w", err)
+			return nil, nil, fmt.Errorf("creating cert watcher: %w", err)
 		}
-		defaultCert = cert
 		rawCert, err := os.ReadFile(opts.CertificatePath)
 		if err != nil {
-			return nil, fmt.Errorf("error reading certificate: %w", err)
+			return nil, nil, fmt.Errorf("error reading certificate: %w", err)
 		}
 		servingTLS.RootCAs.AppendCertsFromPEM(rawCert)
 	}
 
 	if opts.CertStorePaths != "" {
 		if err := loadCertStorePaths(opts.CertStorePaths, uriDomainsToCerts, servingTLS.RootCAs, logger); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
+	// TODO: uriDomainsToCerts is a snapshot from startup — CertStorePaths certs
+	// are not hot-reloaded. Only the default cert (via certwatcher) supports
+	// hot-reload. Add directory-level watching or similar to reload all certs.
 	servingTLS.GetCertificate = func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		// Exact SNI match from the static cert map takes priority
 		if cert, ok := uriDomainsToCerts[hello.ServerName]; ok {
 			return &cert, nil
 		}
-		if defaultCert != nil {
-			return defaultCert, nil
+		// Fall back to certwatcher-managed default cert (hot-reloaded)
+		if watcher != nil {
+			return watcher.GetCertificate(hello)
 		}
 		return nil, fmt.Errorf("no certificate found for %s", hello.ServerName)
 	}
 	servingTLS.Certificates = slices.Collect(maps.Values(uriDomainsToCerts))
-	return servingTLS, nil
+	return servingTLS, watcher, nil
 }
 
 // TODO: loadCertStorePaths mixes serving certs with CA trust. A dedicated
@@ -140,7 +149,7 @@ func loadCertStorePaths(certStorePaths string, certs map[string]tls.Certificate,
 		if !ok {
 			return fmt.Errorf("no key found for certificate %s", certPath)
 		}
-		if _, err := addCert(certs, certPath, keyPath, logger); err != nil {
+		if err := addCert(certs, certPath, keyPath, logger); err != nil {
 			return fmt.Errorf("error adding certificate %s: %w", certPath, err)
 		}
 		rawCert, err := os.ReadFile(certPath) //nolint:gosec // G304: path from configured cert directory
@@ -154,18 +163,18 @@ func loadCertStorePaths(certStorePaths string, certs map[string]tls.Certificate,
 }
 
 // addCert adds a certificate to the map of certificates based on the certificate's SANs.
-func addCert(m map[string]tls.Certificate, certPath, keyPath string, logger logr.Logger) (*tls.Certificate, error) {
+func addCert(m map[string]tls.Certificate, certPath, keyPath string, logger logr.Logger) error {
 	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {
-		return nil, fmt.Errorf("error loading certificate and key: %w", err)
+		return fmt.Errorf("error loading certificate and key: %w", err)
 	}
 	if cert.Leaf == nil {
 		if len(cert.Certificate) == 0 {
-			return nil, fmt.Errorf("no certificate found in certificate chain")
+			return fmt.Errorf("no certificate found in certificate chain")
 		}
 		cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
 		if err != nil {
-			return nil, fmt.Errorf("error parsing certificate: %w", err)
+			return fmt.Errorf("error parsing certificate: %w", err)
 		}
 	}
 	for _, d := range cert.Leaf.DNSNames {
@@ -180,7 +189,7 @@ func addCert(m map[string]tls.Certificate, certPath, keyPath string, logger logr
 		logger.Info("adding certificate", "uri", uri.String())
 		m[uri.String()] = cert
 	}
-	return &cert, nil
+	return nil
 }
 
 // defaultCertPool returns the system cert pool or an empty pool if unavailable.

--- a/interceptor/tls_config_test.go
+++ b/interceptor/tls_config_test.go
@@ -22,7 +22,7 @@ func TestBuildTLSConfig_CertificatePath(t *testing.T) {
 		KeyPath:         filepath.Join(dir, "server.key"),
 	}
 
-	tlsCfg, err := BuildTLSConfig(opts, logr.Discard())
+	tlsCfg, _, err := BuildTLSConfig(opts, logr.Discard())
 	if err != nil {
 		t.Fatalf("failed to build TLS config: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestBuildTLSConfig_CertStorePaths(t *testing.T) {
 
 	opts := TLSOptions{CertStorePaths: dir}
 
-	tlsCfg, err := BuildTLSConfig(opts, logr.Discard())
+	tlsCfg, _, err := BuildTLSConfig(opts, logr.Discard())
 	if err != nil {
 		t.Fatalf("failed to build TLS config: %v", err)
 	}
@@ -53,7 +53,7 @@ func TestBuildTLSConfig_MultipleCertStorePaths(t *testing.T) {
 
 	opts := TLSOptions{CertStorePaths: dir1 + "," + dir2}
 
-	tlsCfg, err := BuildTLSConfig(opts, logr.Discard())
+	tlsCfg, _, err := BuildTLSConfig(opts, logr.Discard())
 	if err != nil {
 		t.Fatalf("failed to build TLS config: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestBuildTLSConfig_FallbackToDefault(t *testing.T) {
 		KeyPath:         filepath.Join(dir, "default.key"),
 	}
 
-	tlsCfg, err := BuildTLSConfig(opts, logr.Discard())
+	tlsCfg, _, err := BuildTLSConfig(opts, logr.Discard())
 	if err != nil {
 		t.Fatalf("failed to build TLS config: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestBuildTLSConfig_FallbackToDefault(t *testing.T) {
 func TestBuildTLSConfig_NoDefaultCert(t *testing.T) {
 	opts := TLSOptions{}
 
-	tlsCfg, err := BuildTLSConfig(opts, logr.Discard())
+	tlsCfg, _, err := BuildTLSConfig(opts, logr.Discard())
 	if err != nil {
 		t.Fatalf("failed to build TLS config: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestBuildTLSConfig_MissingKeyFile(t *testing.T) {
 
 	opts := TLSOptions{CertStorePaths: dir}
 
-	_, err := BuildTLSConfig(opts, logr.Discard())
+	_, _, err := BuildTLSConfig(opts, logr.Discard())
 	if err == nil {
 		t.Error("expected error for missing key file")
 	}
@@ -114,7 +114,7 @@ func TestBuildTLSConfig_PemFormat(t *testing.T) {
 
 	opts := TLSOptions{CertStorePaths: dir}
 
-	tlsCfg, err := BuildTLSConfig(opts, logr.Discard())
+	tlsCfg, _, err := BuildTLSConfig(opts, logr.Discard())
 	if err != nil {
 		t.Fatalf("failed to build TLS config: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestBuildTLSConfig_IPAddressSAN(t *testing.T) {
 
 	opts := TLSOptions{CertStorePaths: dir}
 
-	tlsCfg, err := BuildTLSConfig(opts, logr.Discard())
+	tlsCfg, _, err := BuildTLSConfig(opts, logr.Discard())
 	if err != nil {
 		t.Fatalf("failed to build TLS config: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestBuildTLSConfig_InvalidContent(t *testing.T) {
 
 			opts := TLSOptions{CertStorePaths: dir}
 
-			_, err := BuildTLSConfig(opts, logr.Discard())
+			_, _, err := BuildTLSConfig(opts, logr.Discard())
 			if err == nil {
 				t.Error("expected error for invalid content")
 			}
@@ -175,7 +175,7 @@ func TestBuildTLSConfig_InvalidContent(t *testing.T) {
 func TestBuildTLSConfig_NonExistentCertStorePath(t *testing.T) {
 	opts := TLSOptions{CertStorePaths: "/nonexistent/path/to/certs"}
 
-	_, err := BuildTLSConfig(opts, logr.Discard())
+	_, _, err := BuildTLSConfig(opts, logr.Discard())
 	if err == nil {
 		t.Error("expected error for non-existent cert store path")
 	}
@@ -249,7 +249,7 @@ func TestBuildTLSConfig_TLSOptions(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			tlsCfg, err := BuildTLSConfig(tt.opts, logr.Discard())
+			tlsCfg, _, err := BuildTLSConfig(tt.opts, logr.Discard())
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -272,6 +272,96 @@ func TestBuildTLSConfig_TLSOptions(t *testing.T) {
 				t.Errorf("CurvePreferences = %v, want %v", tlsCfg.CurvePreferences, tt.wantCurves)
 			}
 		})
+	}
+}
+
+func TestBuildTLSConfig_CertwatcherHotReload(t *testing.T) {
+	dir := t.TempDir()
+	writeCert(t, dir, "server", "original.example.com")
+
+	opts := TLSOptions{
+		CertificatePath: filepath.Join(dir, "server.crt"),
+		KeyPath:         filepath.Join(dir, "server.key"),
+	}
+
+	tlsCfg, watcher, err := BuildTLSConfig(opts, logr.Discard())
+	if err != nil {
+		t.Fatalf("failed to build TLS config: %v", err)
+	}
+	go func() {
+		_ = watcher.Start(t.Context())
+	}()
+
+	// Certwatcher serves as default cert for any SNI
+	cert, err := tlsCfg.GetCertificate(&tls.ClientHelloInfo{ServerName: "any.example.com"})
+	if err != nil {
+		t.Fatalf("expected default cert, got error: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("expected non-nil cert")
+	}
+
+	// Overwrite cert on disk with a new SAN
+	writeCert(t, dir, "server", "reloaded.example.com")
+
+	if readErr := watcher.ReadCertificate(); readErr != nil {
+		t.Fatalf("reading certificate: %v", readErr)
+	}
+
+	for _, sni := range []string{
+		"any.example.com",
+		"unchecked.example.com",
+	} {
+		cert, err = tlsCfg.GetCertificate(&tls.ClientHelloInfo{ServerName: sni})
+		if err != nil {
+			t.Fatalf("expected reloaded cert for SNI %q, got error: %v", sni, err)
+		}
+		if cert.Leaf == nil {
+			t.Fatalf("expected parsed leaf certificate for SNI %q", sni)
+		}
+		if !slices.Contains(cert.Leaf.DNSNames, "reloaded.example.com") {
+			t.Errorf("expected reloaded cert for SNI %q, got %v", sni, cert.Leaf.DNSNames)
+		}
+	}
+}
+
+func TestBuildTLSConfig_SNIPriorityOverDefault(t *testing.T) {
+	defaultCertDir := t.TempDir()
+	writeCert(t, defaultCertDir, "default", "default.example.com")
+
+	sniCertDir := t.TempDir()
+	writeCert(t, sniCertDir, "sni", "specific.example.com")
+
+	opts := TLSOptions{
+		CertificatePath: filepath.Join(defaultCertDir, "default.crt"),
+		KeyPath:         filepath.Join(defaultCertDir, "default.key"),
+		CertStorePaths:  sniCertDir,
+	}
+
+	tlsCfg, _, err := BuildTLSConfig(opts, logr.Discard())
+	if err != nil {
+		t.Fatalf("failed to build TLS config: %v", err)
+	}
+
+	// SNI match should return the store cert
+	cert, err := tlsCfg.GetCertificate(&tls.ClientHelloInfo{ServerName: "specific.example.com"})
+	if err != nil {
+		t.Fatalf("expected SNI cert, got error: %v", err)
+	}
+	if cert.Leaf == nil {
+		t.Fatal("expected parsed leaf")
+	}
+	if cert.Leaf.DNSNames[0] != "specific.example.com" {
+		t.Errorf("expected SNI cert for specific.example.com, got %v", cert.Leaf.DNSNames)
+	}
+
+	// Unknown SNI should fall back to certwatcher default
+	cert, err = tlsCfg.GetCertificate(&tls.ClientHelloInfo{ServerName: "unknown.example.com"})
+	if err != nil {
+		t.Fatalf("expected default cert, got error: %v", err)
+	}
+	if cert == nil {
+		t.Fatal("expected non-nil default cert")
 	}
 }
 


### PR DESCRIPTION
BuildTLSConfig now returns a certwatcher.CertWatcher alongside the tls.Config. The watcher monitors the default cert files for changes and provides updated certificates via GetCertificate, enabling automatic reload on certificate rotation without pod restarts.

### Changes
- BuildTLSConfig returns (*tls.Config, *certwatcher.CertWatcher, error)
- GetCertificate falls back to certwatcher for the default cert while preserving exact SNI matching from CertStorePaths
- Caller starts the watcher via proxyEg errgroup
- addCert no longer returns the certificate pointer

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

Fixes #1715 
