### PR TITLE
refactor: separate TLS policy env vars from per-listener config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Deprecations
 
-- **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Interceptor**: TLS policy env vars renamed from `KEDA_HTTP_PROXY_TLS_*` to `KEDA_HTTP_TLS_*` (`MIN_VERSION`, `MAX_VERSION`, `CIPHER_SUITES`, `CURVE_PREFERENCES`, `SKIP_VERIFY`). Old names still work but log a deprecation warning. ([#1718](https://github.com/kedacore/http-add-on/issues/1718))
 
 ### Other
 

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -31,23 +31,8 @@ type Serving struct {
 	TLSKeyPath string `env:"KEDA_HTTP_PROXY_TLS_KEY_PATH" envDefault:"/certs/tls.key"`
 	// TLSCertStorePaths is a comma separated list of paths to read the certificate/key pairs for the TLS server
 	TLSCertStorePaths string `env:"KEDA_HTTP_PROXY_TLS_CERT_STORE_PATHS" envDefault:""`
-	// TLSSkipVerify is a boolean flag to specify whether the interceptor should skip TLS verification for upstreams
-	TLSSkipVerify bool `env:"KEDA_HTTP_PROXY_TLS_SKIP_VERIFY" envDefault:"false"`
 	// TLSPort is the port that the server should serve on if TLS is enabled
 	TLSPort int `env:"KEDA_HTTP_PROXY_TLS_PORT" envDefault:"8443"`
-	// TLSMinVersion is the minimum TLS version to accept ("1.2" or "1.3").
-	// If empty, the Go default is used (currently TLS 1.2).
-	TLSMinVersion string `env:"KEDA_HTTP_PROXY_TLS_MIN_VERSION" envDefault:""`
-	// TLSMaxVersion is the maximum TLS version to accept ("1.2" or "1.3").
-	// Defaults to the highest version supported by crypto/tls if empty.
-	TLSMaxVersion string `env:"KEDA_HTTP_PROXY_TLS_MAX_VERSION" envDefault:""`
-	// TLSCipherSuites is a comma-separated list of TLS cipher suite names
-	// (e.g. "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384").
-	// If empty, the default Go cipher suites are used.
-	TLSCipherSuites string `env:"KEDA_HTTP_PROXY_TLS_CIPHER_SUITES" envDefault:""`
-	// TLSCurvePreferences is a comma-separated list of elliptic curve names
-	// (e.g. "X25519,CurveP256"). If empty, the default Go curve preferences are used.
-	TLSCurvePreferences string `env:"KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES" envDefault:""`
 
 	// ProfilingAddr if not empty, pprof will be available on this address, assuming host:port here
 	ProfilingAddr string `env:"PROFILING_BIND_ADDRESS" envDefault:""`

--- a/interceptor/config/tls.go
+++ b/interceptor/config/tls.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"github.com/caarlos0/env/v11"
+	"github.com/go-logr/logr"
+)
+
+// TLSPolicy holds TLS policy settings that apply across all components.
+// These are security posture decisions (min version, ciphers, etc.) rather
+// than per-listener wiring (cert paths, ports).
+type TLSPolicy struct {
+	MinVersion       string `env:"KEDA_HTTP_TLS_MIN_VERSION" envDefault:""`
+	MaxVersion       string `env:"KEDA_HTTP_TLS_MAX_VERSION" envDefault:""`
+	CipherSuites     string `env:"KEDA_HTTP_TLS_CIPHER_SUITES" envDefault:""`
+	CurvePreferences string `env:"KEDA_HTTP_TLS_CURVE_PREFERENCES" envDefault:""`
+	SkipVerify       bool   `env:"KEDA_HTTP_TLS_SKIP_VERIFY" envDefault:"false"`
+}
+
+// deprecatedTLSPolicy holds the old KEDA_HTTP_PROXY_TLS_* env vars.
+// When set, they take precedence over the new names.
+// TODO(v1): remove this struct and the fallback logic in MustParseTLSPolicy.
+type deprecatedTLSPolicy struct {
+	MinVersion       string `env:"KEDA_HTTP_PROXY_TLS_MIN_VERSION"`
+	MaxVersion       string `env:"KEDA_HTTP_PROXY_TLS_MAX_VERSION"`
+	CipherSuites     string `env:"KEDA_HTTP_PROXY_TLS_CIPHER_SUITES"`
+	CurvePreferences string `env:"KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES"`
+	SkipVerify       *bool  `env:"KEDA_HTTP_PROXY_TLS_SKIP_VERIFY"`
+}
+
+// MustParseTLSPolicy parses TLS policy from environment variables.
+// Deprecated env vars take precedence over new ones when set, to preserve
+// existing behavior for users who haven't migrated yet.
+func MustParseTLSPolicy(log logr.Logger) TLSPolicy {
+	cfg := env.Must(env.ParseAs[TLSPolicy]())
+
+	deprecated := env.Must(env.ParseAs[deprecatedTLSPolicy]())
+
+	if deprecated.MinVersion != "" {
+		log.Info("WARNING: KEDA_HTTP_PROXY_TLS_MIN_VERSION is deprecated, use KEDA_HTTP_TLS_MIN_VERSION instead")
+		cfg.MinVersion = deprecated.MinVersion
+	}
+
+	if deprecated.MaxVersion != "" {
+		log.Info("WARNING: KEDA_HTTP_PROXY_TLS_MAX_VERSION is deprecated, use KEDA_HTTP_TLS_MAX_VERSION instead")
+		cfg.MaxVersion = deprecated.MaxVersion
+	}
+
+	if deprecated.CipherSuites != "" {
+		log.Info("WARNING: KEDA_HTTP_PROXY_TLS_CIPHER_SUITES is deprecated, use KEDA_HTTP_TLS_CIPHER_SUITES instead")
+		cfg.CipherSuites = deprecated.CipherSuites
+	}
+
+	if deprecated.CurvePreferences != "" {
+		log.Info("WARNING: KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES is deprecated, use KEDA_HTTP_TLS_CURVE_PREFERENCES instead")
+		cfg.CurvePreferences = deprecated.CurvePreferences
+	}
+
+	if deprecated.SkipVerify != nil {
+		log.Info("WARNING: KEDA_HTTP_PROXY_TLS_SKIP_VERIFY is deprecated, use KEDA_HTTP_TLS_SKIP_VERIFY instead")
+		cfg.SkipVerify = *deprecated.SkipVerify
+	}
+
+	return cfg
+}

--- a/interceptor/config/tls_test.go
+++ b/interceptor/config/tls_test.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestMustParseTLSPolicy_DeprecatedOverride(t *testing.T) {
+	t.Setenv("KEDA_HTTP_TLS_MIN_VERSION", "new-min")
+	t.Setenv("KEDA_HTTP_TLS_MAX_VERSION", "new-max")
+	t.Setenv("KEDA_HTTP_TLS_CIPHER_SUITES", "new-cipher")
+	t.Setenv("KEDA_HTTP_TLS_CURVE_PREFERENCES", "new-curve")
+	t.Setenv("KEDA_HTTP_TLS_SKIP_VERIFY", "true")
+
+	t.Setenv("KEDA_HTTP_PROXY_TLS_MIN_VERSION", "deprecated-min")
+	t.Setenv("KEDA_HTTP_PROXY_TLS_MAX_VERSION", "deprecated-max")
+	t.Setenv("KEDA_HTTP_PROXY_TLS_CIPHER_SUITES", "deprecated-cipher")
+	t.Setenv("KEDA_HTTP_PROXY_TLS_CURVE_PREFERENCES", "deprecated-curve")
+	t.Setenv("KEDA_HTTP_PROXY_TLS_SKIP_VERIFY", "false")
+
+	cfg := MustParseTLSPolicy(logr.Discard())
+
+	if cfg.MinVersion != "deprecated-min" {
+		t.Errorf("MinVersion = %q, want %q (deprecated var should take precedence)", cfg.MinVersion, "deprecated-min")
+	}
+	if cfg.MaxVersion != "deprecated-max" {
+		t.Errorf("MaxVersion = %q, want %q (deprecated var should take precedence)", cfg.MaxVersion, "deprecated-max")
+	}
+	if cfg.CipherSuites != "deprecated-cipher" {
+		t.Errorf("CipherSuites = %q, want %q (deprecated var should take precedence)", cfg.CipherSuites, "deprecated-cipher")
+	}
+	if cfg.CurvePreferences != "deprecated-curve" {
+		t.Errorf("CurvePreferences = %q, want %q (deprecated var should take precedence)", cfg.CurvePreferences, "deprecated-curve")
+	}
+	if cfg.SkipVerify {
+		t.Error("SkipVerify = true, want false (deprecated var should take precedence)")
+	}
+}

--- a/interceptor/main.go
+++ b/interceptor/main.go
@@ -53,11 +53,6 @@ func main() {
 }
 
 func run() error {
-	timeoutCfg := config.MustParseTimeouts(setupLog)
-	servingCfg := config.MustParseServing()
-	metricsCfg := observability.MustParseMetricsConfig()
-	tracingCfg := observability.MustParseTracingConfig()
-
 	opts := zap.Options{
 		Development: true,
 	}
@@ -66,10 +61,17 @@ func run() error {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
+	timeoutCfg := config.MustParseTimeouts(setupLog)
+	servingCfg := config.MustParseServing()
+	tlsPolicyCfg := config.MustParseTLSPolicy(setupLog)
+	metricsCfg := observability.MustParseMetricsConfig()
+	tracingCfg := observability.MustParseTracingConfig()
+
 	setupLog.Info(
 		"starting interceptor",
 		"timeoutConfig", timeoutCfg,
 		"servingConfig", servingCfg,
+		"tlsPolicyConfig", tlsPolicyCfg,
 		"metricsConfig", metricsCfg,
 	)
 
@@ -242,11 +244,11 @@ func run() error {
 				CertificatePath:    servingCfg.TLSCertPath,
 				KeyPath:            servingCfg.TLSKeyPath,
 				CertStorePaths:     servingCfg.TLSCertStorePaths,
-				InsecureSkipVerify: servingCfg.TLSSkipVerify,
-				MinTLSVersion:      servingCfg.TLSMinVersion,
-				MaxTLSVersion:      servingCfg.TLSMaxVersion,
-				CipherSuites:       servingCfg.TLSCipherSuites,
-				CurvePreferences:   servingCfg.TLSCurvePreferences,
+				InsecureSkipVerify: tlsPolicyCfg.SkipVerify,
+				MinTLSVersion:      tlsPolicyCfg.MinVersion,
+				MaxTLSVersion:      tlsPolicyCfg.MaxVersion,
+				CipherSuites:       tlsPolicyCfg.CipherSuites,
+				CurvePreferences:   tlsPolicyCfg.CurvePreferences,
 			}, setupLog)
 			if err != nil {
 				return fmt.Errorf("configuring TLS: %w", err)

--- a/test/e2e/tls/main_test.go
+++ b/test/e2e/tls/main_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 	h.PatchInterceptorDeployment(testenv,
 		h.WithTLSCert([]string{"*." + tlsDomain}),
 		h.WithEnvVar("KEDA_HTTP_PROXY_TLS_ENABLED", "true"),
-		h.WithEnvVar("KEDA_HTTP_PROXY_TLS_SKIP_VERIFY", "true"),
+		h.WithEnvVar("KEDA_HTTP_TLS_SKIP_VERIFY", "true"),
 	)
 
 	os.Exit(testenv.Run(m))


### PR DESCRIPTION
TLS policy settings (min version, cipher suites, etc.) used a KEDA_HTTP_PROXY_TLS_* prefix, tying them to the interceptor proxy even though they apply to all TLS connections. Per-listener wiring (certs, port) keeps the KEDA_HTTP_PROXY_TLS_* prefix.

### Changes
- Add TLSPolicy config struct with KEDA_HTTP_TLS_* env vars
- Add deprecated fallback for old KEDA_HTTP_PROXY_TLS_* names
- Remove policy fields from Serving struct
- Move config parsing after ctrl.SetLogger() so deprecation warnings are visible (previously silently dropped by NullLogSink)
- Update e2e test and changelog


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))
	- docs https://github.com/kedacore/keda-docs/pull/1813
	- chart https://github.com/kedacore/charts/pull/887

Fixes #1718