### PR TITLE
fix(interceptor): accept TLS12/TLS13 version format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This changelog keeps track of work items that have been completed and are ready 
 ### Fixes
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
+- **Interceptor**: Accept `TLS12`/`TLS13` TLS version format in addition to `1.2`/`1.3` for compatibility with KEDA and the operator ([#1718](https://github.com/kedacore/http-add-on/issues/1718))
 - **Scaler**: Fix scale-from-zero failing with 504 after long idle when using `requestRate` with large `window/granularity` ratios (>2000) ([#1692](https://github.com/kedacore/http-add-on/issues/1692))
 
 ### Deprecations

--- a/interceptor/fuzz_test.go
+++ b/interceptor/fuzz_test.go
@@ -25,6 +25,10 @@ import (
 func FuzzParseTLSVersion(f *testing.F) {
 	f.Add("1.2")
 	f.Add("1.3")
+	f.Add("TLS12")
+	f.Add("TLS13")
+	f.Add("tls12")
+	f.Add("tls13")
 	f.Add("")
 	f.Add("1.0")
 	f.Add("1.1")

--- a/interceptor/tls_config.go
+++ b/interceptor/tls_config.go
@@ -194,16 +194,17 @@ func defaultCertPool(logger logr.Logger) *x509.CertPool {
 	return x509.NewCertPool()
 }
 
-// parseTLSVersion converts a version string ("1.2" or "1.3") to the
-// corresponding crypto/tls constant.
+// parseTLSVersion converts a version string to the corresponding crypto/tls
+// constant. Accepts both short form ("1.2", "1.3") and the format used by
+// KEDA and the operator ("TLS12", "TLS13"). Matching is case-insensitive.
 func parseTLSVersion(v string) (uint16, error) {
-	switch v {
-	case "1.2":
+	switch strings.ToLower(v) {
+	case "1.2", "tls12":
 		return tls.VersionTLS12, nil
-	case "1.3":
+	case "1.3", "tls13":
 		return tls.VersionTLS13, nil
 	default:
-		return 0, fmt.Errorf("unsupported TLS version %q: must be %q or %q", v, "1.2", "1.3")
+		return 0, fmt.Errorf("unsupported TLS version %q: must be \"1.2\"/\"TLS12\" or \"1.3\"/\"TLS13\"", v)
 	}
 }
 

--- a/interceptor/tls_config_test.go
+++ b/interceptor/tls_config_test.go
@@ -202,9 +202,33 @@ func TestBuildTLSConfig_TLSOptions(t *testing.T) {
 			opts:           TLSOptions{MinTLSVersion: "1.2"},
 			wantMinVersion: tls.VersionTLS12,
 		},
+		"min version TLS12": {
+			opts:           TLSOptions{MinTLSVersion: "TLS12"},
+			wantMinVersion: tls.VersionTLS12,
+		},
+		"min version tls12 lowercase": {
+			opts:           TLSOptions{MinTLSVersion: "tls12"},
+			wantMinVersion: tls.VersionTLS12,
+		},
+		"min version TLS13": {
+			opts:           TLSOptions{MinTLSVersion: "TLS13"},
+			wantMinVersion: tls.VersionTLS13,
+		},
 		"max version 1.2": {
 			opts:           TLSOptions{MaxTLSVersion: "1.2"},
 			wantMaxVersion: tls.VersionTLS12,
+		},
+		"max version TLS12": {
+			opts:           TLSOptions{MaxTLSVersion: "TLS12"},
+			wantMaxVersion: tls.VersionTLS12,
+		},
+		"max version tls12 lowercase": {
+			opts:           TLSOptions{MaxTLSVersion: "tls12"},
+			wantMaxVersion: tls.VersionTLS12,
+		},
+		"max version TLS13": {
+			opts:           TLSOptions{MaxTLSVersion: "TLS13"},
+			wantMaxVersion: tls.VersionTLS13,
 		},
 		"invalid min version": {
 			opts:    TLSOptions{MinTLSVersion: "1.1"},


### PR DESCRIPTION
The TLS version parser only accepted "1.2"/"1.3" but KEDA and the operator use "TLS12"/"TLS13". 
This PR aligns the format with what we currently already use in the KEDA ecosystem.

Docs weren't updated as they are still valid and we're just providing another option for configuring this.


### Changes
- Accept both "1.2"/"TLS12" and "1.3"/"TLS13" in parseTLSVersion using case-insensitive comparison
- Add test cases for upper and lowercase TLS version formats
- Add fuzz seeds for TLS12/TLS13 variants
- Update changelog

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

