### PR TITLE
fix(scaler): bound queue counts requests to interceptor pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
 - **Interceptor**: Accept `TLS12`/`TLS13` TLS version format in addition to `1.2`/`1.3` for compatibility with KEDA and the operator ([#1718](https://github.com/kedacore/http-add-on/issues/1718))
+- **Scaler**: Bound each queue counts request to an interceptor pod by `KEDA_HTTP_QUEUE_TICK_DURATION` (minimum `250ms`), so one unresponsive interceptor can no longer stall metric collection ([#1730](https://github.com/kedacore/http-add-on/issues/1730))
 - **Scaler**: Fix scale-from-zero failing with 504 after long idle when using `requestRate` with large `window/granularity` ratios (>2000) ([#1692](https://github.com/kedacore/http-add-on/issues/1692))
 
 ### Deprecations

--- a/pkg/queue/queue_rpc.go
+++ b/pkg/queue/queue_rpc.go
@@ -1,8 +1,10 @@
 package queue
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -10,6 +12,11 @@ import (
 )
 
 const countsPath = "/queue"
+
+// maxCountsResponseSize bounds the response body accepted from an interceptor.
+// The payload grows with the number of routes; 10 MiB holds well over 100k of
+// them while still capping the memory a misbehaving interceptor can cost us.
+const maxCountsResponseSize = 10 << 20
 
 func AddCountsRoute(lggr logr.Logger, mux *http.ServeMux, q CountReader) {
 	lggr = lggr.WithName("pkg.queue.AddCountsRoute")
@@ -40,21 +47,37 @@ func newSizeHandler(
 	})
 }
 
-// GetQueueCounts issues an RPC call to get the queue counts
-// from the given hostAndPort. Note that the hostAndPort should
-// not end with a "/" and shouldn't include a path.
+// GetCounts issues an RPC call to get the queue counts from the given
+// interceptor. Note that interceptorURL should not end with a "/" and
+// shouldn't include a path.
+//
+// The call is bounded by ctx and by httpCl.Timeout. Callers must ensure at
+// least one of them is set: an interceptor that accepts the connection but
+// never responds would otherwise block the caller indefinitely.
 func GetCounts(
+	ctx context.Context,
 	httpCl *http.Client,
 	interceptorURL url.URL,
 ) (Counts, error) {
 	interceptorURL.Path = countsPath
-	resp, err := httpCl.Get(interceptorURL.String())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, interceptorURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("building the queue counts request for %s: %w", interceptorURL.String(), err)
+	}
+
+	resp, err := httpCl.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("requesting the queue counts from %s: %w", interceptorURL.String(), err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("requesting the queue counts from %s: unexpected status %s", interceptorURL.String(), resp.Status)
+	}
+
 	var counts Counts
-	if err := json.NewDecoder(resp.Body).Decode(&counts); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxCountsResponseSize)).Decode(&counts); err != nil {
 		return nil, fmt.Errorf("decoding response from the interceptor at %s: %w", interceptorURL.String(), err)
 	}
 

--- a/pkg/queue/queue_rpc_test.go
+++ b/pkg/queue/queue_rpc_test.go
@@ -1,9 +1,14 @@
 package queue
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
@@ -65,7 +70,7 @@ func TestQueueSizeHandlerIntegration(t *testing.T) {
 	r.NoError(err)
 	defer srv.Close()
 	httpCl := srv.Client()
-	counts, err := GetCounts(httpCl, *url)
+	counts, err := GetCounts(t.Context(), httpCl, *url)
 	r.NoError(err)
 	r.Len(counts, 1)
 	for _, val := range counts {
@@ -73,4 +78,62 @@ func TestQueueSizeHandlerIntegration(t *testing.T) {
 	}
 	reqs := hdl.IncomingRequests()
 	r.Len(reqs, 1)
+}
+
+// TestGetCountsUnresponsiveInterceptor pins down the contract the scaler relies
+// on: an interceptor that accepts the connection but never answers must fail
+// the request rather than block the caller forever.
+func TestGetCountsUnresponsiveInterceptor(t *testing.T) {
+	r := require.New(t)
+	const timeout = 100 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	r.NoError(err)
+
+	start := time.Now()
+	_, err = GetCounts(t.Context(), &http.Client{Timeout: timeout}, *srvURL)
+	r.Error(err)
+	r.Less(time.Since(start), 10*timeout, "the request must be bounded by the client timeout")
+}
+
+func TestGetCountsCancelledContext(t *testing.T) {
+	r := require.New(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	r.NoError(err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err = GetCounts(ctx, srv.Client(), *srvURL)
+	r.ErrorIs(err, context.Canceled)
+}
+
+func TestGetCountsNonOKStatus(t *testing.T) {
+	r := require.New(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "error getting queue size", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	r.NoError(err)
+
+	_, err = GetCounts(t.Context(), srv.Client(), *srvURL)
+	r.Error(err)
+	r.Contains(err.Error(), "unexpected status")
 }

--- a/scaler/config.go
+++ b/scaler/config.go
@@ -26,7 +26,10 @@ type config struct {
 	// CacheSyncPeriod is the time interval for the controller-runtime cache to resync.
 	// TODO: consider removing this to use the default value, otherwise align the env var name
 	CacheSyncPeriod time.Duration `env:"KEDA_HTTP_SCALER_CONFIG_MAP_INFORMER_RSYNC_PERIOD" envDefault:"60m"`
-	// QueueTickDuration is the duration between queue requests
+	// QueueTickDuration is the duration between queue requests. It also bounds
+	// each individual request to an interceptor pod: there is no point waiting
+	// longer than the interval after which we ask again, since the next tick
+	// supersedes the answer. See minFetchTimeout for the lower clamp.
 	QueueTickDuration time.Duration `env:"KEDA_HTTP_QUEUE_TICK_DURATION" envDefault:"500ms"`
 	// ProfilingAddr if not empty, pprof will be available on this address, assuming host:port here
 	ProfilingAddr string `env:"PROFILING_BIND_ADDRESS" envDefault:""`

--- a/scaler/main.go
+++ b/scaler/main.go
@@ -99,7 +99,7 @@ func run() error {
 		return fmt.Errorf("creating cache: %w", err)
 	}
 
-	pinger := newQueuePinger(ctrl.Log, k8s.EndpointsFuncForControllerClient(ctrlCache), namespace, svcName, deplName, targetPortStr, instruments)
+	pinger := newQueuePinger(ctrl.Log, k8s.EndpointsFuncForControllerClient(ctrlCache), namespace, svcName, deplName, targetPortStr, cfg.QueueTickDuration, instruments)
 
 	ctx := ctrl.SetupSignalHandler()
 	ctx = util.ContextWithLogger(ctx, setupLog)

--- a/scaler/queue_pinger.go
+++ b/scaler/queue_pinger.go
@@ -95,9 +95,7 @@ func newQueuePinger(lggr logr.Logger, getEndpointsFn k8s.GetEndpointsFunc, ns, s
 		interceptorSvcName:     svcName,
 		interceptorServiceName: deplName,
 		adminPort:              adminPort,
-		// Transport is deliberately left nil so the client resolves
-		// http.DefaultTransport per request, keeping its connection pool
-		// shared across ticks.
+		// Leave Transport nil to preserve the existing http.DefaultTransport behavior.
 		httpCl:          &http.Client{Timeout: fetchTimeout},
 		lggr:            lggr,
 		instruments:     instruments,

--- a/scaler/queue_pinger.go
+++ b/scaler/queue_pinger.go
@@ -28,6 +28,13 @@ const (
 
 	defaultWindow      = time.Minute
 	defaultGranularity = time.Second
+
+	// minFetchTimeout is the lower clamp on a single queue counts request.
+	// The timeout tracks the tick duration, but a very short tick must not
+	// make healthy pods on a loaded node look unreachable: that would drop
+	// their request-rate deltas, which are never synthesised for pods we
+	// could not reach, and quietly under-report the rate.
+	minFetchTimeout = 250 * time.Millisecond
 )
 
 // aggregatedCount holds the scaler's computed view of a single
@@ -46,7 +53,7 @@ type aggregatedCount struct {
 //
 // Sample usage:
 //
-//	pinger := newQueuePinger(lggr, getEndpointsFn, ns, svcName, deplName, adminPort, instruments)
+//	pinger := newQueuePinger(lggr, getEndpointsFn, ns, svcName, deplName, adminPort, fetchTimeout, instruments)
 //	go pinger.start(ctx, ticker)
 type queuePinger struct {
 	getEndpointsFn         k8s.GetEndpointsFunc
@@ -54,6 +61,7 @@ type queuePinger struct {
 	interceptorSvcName     string
 	interceptorServiceName string
 	adminPort              string
+	httpCl                 *http.Client
 	pingMut                sync.RWMutex
 	lastPingTime           time.Time
 	allCounts              map[string]aggregatedCount
@@ -76,19 +84,27 @@ type queuePinger struct {
 	rateBuckets map[string]*queue.RequestsBuckets
 }
 
-func newQueuePinger(lggr logr.Logger, getEndpointsFn k8s.GetEndpointsFunc, ns, svcName, deplName, adminPort string, instruments *metrics.Instruments) *queuePinger {
+// newQueuePinger builds a pinger that polls interceptor pods for queue counts.
+// fetchTimeout bounds each individual request and is normally the tick
+// duration, clamped up to minFetchTimeout.
+func newQueuePinger(lggr logr.Logger, getEndpointsFn k8s.GetEndpointsFunc, ns, svcName, deplName, adminPort string, fetchTimeout time.Duration, instruments *metrics.Instruments) *queuePinger {
+	fetchTimeout = max(fetchTimeout, minFetchTimeout)
 	return &queuePinger{
 		getEndpointsFn:         getEndpointsFn,
 		interceptorNS:          ns,
 		interceptorSvcName:     svcName,
 		interceptorServiceName: deplName,
 		adminPort:              adminPort,
-		lggr:                   lggr,
-		instruments:            instruments,
-		allCounts:              map[string]aggregatedCount{},
-		prevPodCounts:          map[string]map[string]int64{},
-		cachedPodCounts:        map[string]queue.Counts{},
-		rateBuckets:            map[string]*queue.RequestsBuckets{},
+		// Transport is deliberately left nil so the client resolves
+		// http.DefaultTransport per request, keeping its connection pool
+		// shared across ticks.
+		httpCl:          &http.Client{Timeout: fetchTimeout},
+		lggr:            lggr,
+		instruments:     instruments,
+		allCounts:       map[string]aggregatedCount{},
+		prevPodCounts:   map[string]map[string]int64{},
+		cachedPodCounts: map[string]queue.Counts{},
+		rateBuckets:     map[string]*queue.RequestsBuckets{},
 	}
 }
 
@@ -163,7 +179,7 @@ func (q *queuePinger) fetchAndSaveCounts(ctx context.Context) error {
 	defer q.pingMut.Unlock()
 
 	fetchStart := time.Now()
-	result, err := fetchCountsPerPod(ctx, q.lggr, q.getEndpointsFn, q.interceptorNS, q.interceptorSvcName, q.adminPort)
+	result, err := fetchCountsPerPod(ctx, q.lggr, q.httpCl, q.getEndpointsFn, q.interceptorNS, q.interceptorSvcName, q.adminPort)
 	failedPods := max(0, result.endpointCount-len(result.perPod))
 	q.instruments.RecordFetch(time.Since(fetchStart), result.endpointCount, failedPods, err)
 	if err != nil {
@@ -298,7 +314,12 @@ type fetchResult struct {
 // so that a single unreachable interceptor (e.g. during a rolling
 // update or spot-node eviction) does not cause the scaler to report
 // NOT_SERVING and get restarted by Kubernetes.
-func fetchCountsPerPod(ctx context.Context, lggr logr.Logger, endpointsFn k8s.GetEndpointsFunc, ns, svcName, adminPort string) (fetchResult, error) {
+//
+// A pod that accepts the connection but never answers is treated the same as
+// an unreachable one: httpCl.Timeout bounds every request so that one wedged
+// interceptor cannot stall the fetch, and with it the scaler's whole metric
+// pipeline.
+func fetchCountsPerPod(ctx context.Context, lggr logr.Logger, httpCl *http.Client, endpointsFn k8s.GetEndpointsFunc, ns, svcName, adminPort string) (fetchResult, error) {
 	lggr = lggr.WithName("queuePinger.requestCounts")
 
 	endpointURLs, err := k8s.EndpointsForService(ctx, ns, svcName, adminPort, endpointsFn)
@@ -328,7 +349,7 @@ func fetchCountsPerPod(ctx context.Context, lggr logr.Logger, endpointsFn k8s.Ge
 	for _, endpoint := range endpointURLs {
 		u := endpoint
 		wg.Go(func() {
-			counts, err := queue.GetCounts(http.DefaultClient, u)
+			counts, err := queue.GetCounts(ctx, httpCl, u)
 			if err != nil {
 				lggr.Error(err, "getting queue counts from interceptor", "interceptorAddress", u.String())
 				failCount.Add(1)

--- a/scaler/queue_pinger_test.go
+++ b/scaler/queue_pinger_test.go
@@ -21,6 +21,15 @@ import (
 	"github.com/kedacore/http-add-on/scaler/metrics"
 )
 
+// testFetchTimeout is generous enough that a loaded CI machine will not make
+// well-behaved fake interceptors look unreachable. Tests that exercise the
+// timeout itself set their own, much shorter, value.
+const testFetchTimeout = 5 * time.Second
+
+func testHTTPClient() *http.Client {
+	return &http.Client{Timeout: testFetchTimeout}
+}
+
 func TestCounts(t *testing.T) {
 	r := require.New(t)
 	ctx, cancel := context.WithCancel(t.Context())
@@ -56,6 +65,7 @@ func TestCounts(t *testing.T) {
 		svcName,
 		deplName,
 		srvURL.Port(),
+		testFetchTimeout,
 		metrics.NewNoopInstruments(),
 	)
 
@@ -108,6 +118,7 @@ func TestFetchAndSaveCounts(t *testing.T) {
 		svcName,
 		deplName,
 		srvURL.Port(),
+		testFetchTimeout,
 		metrics.NewNoopInstruments(),
 	)
 
@@ -149,6 +160,7 @@ func TestFetchCountsPerPod(t *testing.T) {
 	result, err := fetchCountsPerPod(
 		ctx,
 		logr.Discard(),
+		testHTTPClient(),
 		endpointsFn,
 		ns,
 		svcName,
@@ -223,6 +235,7 @@ func TestFetchAndSaveCounts_MultiPodLifecycle(t *testing.T) {
 		svcName,
 		deplName,
 		adminPort,
+		testFetchTimeout,
 		metrics.NewNoopInstruments(),
 	)
 
@@ -291,6 +304,7 @@ func TestRateComputation(t *testing.T) {
 		svcName,
 		deplName,
 		srvURL.Port(),
+		testFetchTimeout,
 		metrics.NewNoopInstruments(),
 	)
 
@@ -341,6 +355,7 @@ func TestRateComputationCounterReset(t *testing.T) {
 		svcName,
 		deplName,
 		srvURL.Port(),
+		testFetchTimeout,
 		metrics.NewNoopInstruments(),
 	)
 
@@ -364,7 +379,7 @@ func TestFetchCountsPerPod_NoEndpoints(t *testing.T) {
 		return k8s.Endpoints{}, nil
 	}
 
-	result, err := fetchCountsPerPod(ctx, logr.Discard(), endpointsFn, "testns", "testsvc", "8081")
+	result, err := fetchCountsPerPod(ctx, logr.Discard(), testHTTPClient(), endpointsFn, "testns", "testsvc", "8081")
 	r.NoError(err, "no endpoints should not be an error")
 	r.Empty(result.perPod)
 	r.Empty(result.endpointKeys)
@@ -400,7 +415,7 @@ func TestFetchCountsPerPod_PartialFailure(t *testing.T) {
 		}, nil
 	}
 
-	result, err := fetchCountsPerPod(ctx, logr.Discard(), endpointsFn, "testns", "testsvc", adminPort)
+	result, err := fetchCountsPerPod(ctx, logr.Discard(), testHTTPClient(), endpointsFn, "testns", "testsvc", adminPort)
 	r.NoError(err, "one unreachable pod should not fail the entire fetch")
 	r.Len(result.perPod, 1, "should contain results from the reachable pod only")
 	r.Equal(2, result.endpointCount, "endpointCount should reflect all endpoints")
@@ -438,9 +453,164 @@ func TestFetchCountsPerPod_AllPodsUnreachable(t *testing.T) {
 		}, nil
 	}
 
-	_, err = fetchCountsPerPod(ctx, logr.Discard(), endpointsFn, "testns", "testsvc", adminPort)
+	_, err = fetchCountsPerPod(ctx, logr.Discard(), testHTTPClient(), endpointsFn, "testns", "testsvc", adminPort)
 	r.Error(err, "should fail when all pods are unreachable")
 	r.Contains(err.Error(), "all 2 interceptor pods were unreachable")
+}
+
+// newHangingServer returns a server that accepts connections and never
+// answers. This is the "black hole" interceptor that used to block the
+// scaler's fetch forever. The handler unblocks once the client gives up, so
+// the test server can shut down cleanly.
+func newHangingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestFetchCountsPerPod_UnresponsivePod(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+	const (
+		adminPort    = "8081"
+		fetchTimeout = 200 * time.Millisecond
+	)
+
+	podA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(queue.Counts{
+			"host1": {Concurrency: 5, RequestCount: 100},
+		})
+	}))
+	defer podA.Close()
+
+	podB := newHangingServer(t)
+
+	withPatchedDefaultTransport(t, map[string]string{
+		"pod-a:" + adminPort: podA.Listener.Addr().String(),
+		"pod-b:" + adminPort: podB.Listener.Addr().String(),
+	})
+
+	endpointsFn := func(context.Context, string, string) (k8s.Endpoints, error) {
+		return k8s.Endpoints{
+			ReadyAddresses: []string{"pod-a", "pod-b"},
+		}, nil
+	}
+
+	start := time.Now()
+	result, err := fetchCountsPerPod(
+		ctx,
+		logr.Discard(),
+		&http.Client{Timeout: fetchTimeout},
+		endpointsFn,
+		"testns",
+		"testsvc",
+		adminPort,
+	)
+	elapsed := time.Since(start)
+
+	r.NoError(err, "one unresponsive pod should not fail the entire fetch")
+	r.Less(elapsed, 10*fetchTimeout,
+		"fetch must be bounded by the client timeout, not by the slowest pod")
+	r.Len(result.perPod, 1, "only the responsive pod should report counts")
+	r.Equal(2, result.endpointCount, "endpointCount should reflect all endpoints")
+	r.Contains(result.perPod, "pod-a:"+adminPort)
+	r.NotContains(result.perPod, "pod-b:"+adminPort)
+}
+
+func TestFetchCountsPerPod_AllPodsUnresponsive(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+	const (
+		adminPort    = "8081"
+		fetchTimeout = 200 * time.Millisecond
+	)
+
+	podA := newHangingServer(t)
+	podB := newHangingServer(t)
+
+	withPatchedDefaultTransport(t, map[string]string{
+		"pod-a:" + adminPort: podA.Listener.Addr().String(),
+		"pod-b:" + adminPort: podB.Listener.Addr().String(),
+	})
+
+	endpointsFn := func(context.Context, string, string) (k8s.Endpoints, error) {
+		return k8s.Endpoints{
+			ReadyAddresses: []string{"pod-a", "pod-b"},
+		}, nil
+	}
+
+	start := time.Now()
+	_, err := fetchCountsPerPod(
+		ctx,
+		logr.Discard(),
+		&http.Client{Timeout: fetchTimeout},
+		endpointsFn,
+		"testns",
+		"testsvc",
+		adminPort,
+	)
+
+	r.Error(err, "should fail when no pod answers")
+	r.Contains(err.Error(), "all 2 interceptor pods were unreachable")
+	r.Less(time.Since(start), 10*fetchTimeout, "fetch must still be bounded")
+}
+
+// TestFetchAndSaveCounts_UnresponsivePodKeepsPingerFresh covers the reason the
+// timeout matters: a stalled tick stops lastPingTime from advancing, which
+// makes the health check in main.go report NOT_SERVING and gets the scaler
+// restarted — taking metrics for every HTTP-autoscaled app down with it.
+func TestFetchAndSaveCounts_UnresponsivePodKeepsPingerFresh(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+	const (
+		ns        = "testns"
+		svcName   = "testsvc"
+		deplName  = "testdepl"
+		adminPort = "8081"
+		// At or above minFetchTimeout, so newQueuePinger uses it as given.
+		fetchTimeout = minFetchTimeout
+	)
+
+	podA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(queue.Counts{
+			"host1": {Concurrency: 5, RequestCount: 100},
+		})
+	}))
+	defer podA.Close()
+
+	podB := newHangingServer(t)
+
+	withPatchedDefaultTransport(t, map[string]string{
+		"pod-a:" + adminPort: podA.Listener.Addr().String(),
+		"pod-b:" + adminPort: podB.Listener.Addr().String(),
+	})
+
+	pinger := newQueuePinger(
+		logr.Discard(),
+		func(context.Context, string, string) (k8s.Endpoints, error) {
+			return k8s.Endpoints{ReadyAddresses: []string{"pod-a", "pod-b"}}, nil
+		},
+		ns,
+		svcName,
+		deplName,
+		adminPort,
+		fetchTimeout,
+		metrics.NewNoopInstruments(),
+	)
+
+	r.NoError(pinger.fetchAndSaveCounts(ctx))
+	firstPing := pinger.lastPingTime
+	r.False(firstPing.IsZero(), "a tick with an unresponsive pod must still complete")
+	r.Equal(5, pinger.count("host1").Concurrency,
+		"the responsive pod's counts should still be reported")
+
+	r.NoError(pinger.fetchAndSaveCounts(ctx))
+	r.True(pinger.lastPingTime.After(firstPing),
+		"the pinger must keep making progress while a pod is unresponsive")
 }
 
 func TestFetchAndSaveCounts_CachedUnreachablePod(t *testing.T) {
@@ -491,6 +661,7 @@ func TestFetchAndSaveCounts_CachedUnreachablePod(t *testing.T) {
 			}, nil
 		},
 		ns, svcName, deplName, adminPort,
+		testFetchTimeout,
 		metrics.NewNoopInstruments(),
 	)
 
@@ -523,6 +694,33 @@ func TestFetchAndSaveCounts_CachedUnreachablePod(t *testing.T) {
 		"cached data should be pruned when pod leaves EndpointSlice")
 	r.NotContains(pinger.prevPodCounts, "pod-b:"+adminPort,
 		"prevPodCounts should be pruned when pod leaves EndpointSlice")
+}
+
+func TestNewQueuePingerFetchTimeout(t *testing.T) {
+	endpointsFn := func(context.Context, string, string) (k8s.Endpoints, error) {
+		return k8s.Endpoints{}, nil
+	}
+
+	for name, tc := range map[string]struct {
+		given time.Duration
+		want  time.Duration
+	}{
+		"tracks the tick duration":   {given: 2 * time.Second, want: 2 * time.Second},
+		"clamps a very short tick":   {given: time.Millisecond, want: minFetchTimeout},
+		"clamps an unset duration":   {given: 0, want: minFetchTimeout},
+		"clamps a negative duration": {given: -time.Second, want: minFetchTimeout},
+	} {
+		t.Run(name, func(t *testing.T) {
+			pinger := newQueuePinger(
+				logr.Discard(),
+				endpointsFn,
+				"testns", "testsvc", "testdepl", "8080",
+				tc.given,
+				metrics.NewNoopInstruments(),
+			)
+			require.Equal(t, tc.want, pinger.httpCl.Timeout)
+		})
+	}
 }
 
 func TestUpdateBucketConfig(t *testing.T) {
@@ -583,6 +781,7 @@ func newFakeQueuePinger(lggr logr.Logger, optsFuncs ...optsFunc) (*time.Ticker, 
 		"testsvc",
 		"testdepl",
 		opts.port,
+		testFetchTimeout,
 		metrics.NewNoopInstruments(),
 	)
 	return ticker, pinger, nil


### PR DESCRIPTION
The scaler polls every interceptor pod's `/queue` endpoint on each tick to build the concurrency and request-rate metrics it serves to KEDA. Those requests were issued with `http.DefaultClient`, whose `Timeout` is zero, and no context was attached. `http.DefaultTransport` bounds connection setup (30s dial, 10s TLS handshake) but sets no `ResponseHeaderTimeout`, so once a connection was established nothing bounded the exchange.

An interceptor pod that accepts the connection but never answers — GC pause, deadlock, wedged informer, a node in a degraded network state — therefore parks its fetch goroutine indefinitely. `wg.Wait()` in `fetchCountsPerPod` never returns, the tick never completes, and `lastPingTime` stops advancing. The health loop in `scaler/main.go` then flips **liveness** to `NOT_SERVING` after two ticks and kubelet restarts the scaler. The wedged pod is still wedged, so it repeats. Since the scaler is a cluster-wide singleton, every HTTP-autoscaled app in the cluster loses its metric source while it crash-loops.

#1667 made the scaler tolerate interceptor pods that are unreachable, but a refused connection returns immediately while a black hole never does, so that recovery path was never reached.

### Changes

- `queue.GetCounts` now takes a `context.Context` and uses `http.NewRequestWithContext`, so cancellation propagates and the request can be bounded.
- `queuePinger` uses a dedicated `*http.Client` with an explicit `Timeout`, which covers the whole exchange including the response body read. An unresponsive pod is now treated exactly like an unreachable one: it counts as failed for that tick, and the existing cached-counts path keeps reporting its last known concurrency.
- The bound is `KEDA_HTTP_QUEUE_TICK_DURATION`, clamped up to a 250ms floor. No new setting is introduced: there is no point waiting longer than the interval after which we ask again, since the next tick supersedes the answer. The floor matters because request-rate deltas are deliberately not synthesised for pods we failed to reach, so letting a very short tick mark slow-but-healthy pods unreachable would quietly under-report the rate.
- Non-200 responses are rejected explicitly instead of surfacing as a confusing JSON decode error, and the body is capped before decoding.

The client's `Transport` is deliberately left `nil` so it resolves `http.DefaultTransport` per request, keeping the connection pool shared across ticks.

### Tests

Seven new test functions (ten cases with the table subtests):

- `pkg/queue` pins the RPC contract: an unresponsive interceptor, a cancelled context, and a non-200 response.
- `scaler` covers one unresponsive pod among healthy ones, all pods unresponsive, and the timeout derivation including its clamp at zero, negative, and very short tick durations.
- `TestFetchAndSaveCounts_UnresponsivePodKeepsPingerFresh` is the one that matters most: it asserts `lastPingTime` keeps advancing across consecutive ticks while a pod hangs, which is exactly what the health check depends on and exactly what broke.

The unresponsive-pod tests fail against the current behavior — with the unbounded client they hang and only fail once the Go test timeout expires. With the fix they pass in under a second.

### Follow-up

While tracing this I noticed the health loop is a related hazard worth its own issue: it ties **liveness** rather than readiness to a dependency being reachable, and its staleness threshold of `2 × KEDA_HTTP_QUEUE_TICK_DURATION` gets very tight at small tick values, where a healthy fan-out across many pods can exceed it. A restart cannot fix an unreachable interceptor, and it discards the rate history in `prevPodCounts`/`rateBuckets`. Out of scope here.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

No new configuration is introduced, but `KEDA_HTTP_QUEUE_TICK_DURATION` gains a second effect, so its keda-docs entry deserves a sentence noting it also bounds each request to an interceptor. Happy to open that PR.

Fixes #1730