### PR TITLE
chore: auto-install dev tools via Makefile

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,7 +64,7 @@
     {
       matchManagers: ["custom.regex"],
       matchFileNames: ["Makefile", ".github/workflows/e2e-tests.yaml"],
-      groupName: "E2E Dependencies",
+      groupName: "Infra Dependencies",
     },
     {
       matchManagers: ["pre-commit"],

--- a/.github/workflows/benchmark-tests.yaml
+++ b/.github/workflows/benchmark-tests.yaml
@@ -46,7 +46,7 @@ jobs:
           version: ${{ env.KIND_VERSION }}
 
       - name: Setup e2e environment
-        run: make e2e-setup
+        run: make e2e-setup HELM=$(which helm)
         env:
           KO_DEFAULTPLATFORMS: linux/arm64
           KO_DOCKER_REPO: kind.local

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -64,7 +64,7 @@ jobs:
           version: ${{ env.KIND_VERSION }}
 
       - name: Setup e2e environment
-        run: make e2e-setup
+        run: make e2e-setup HELM=$(which helm)
         env:
           KO_DOCKER_REPO: kind.local
           KO_DEFAULTPLATFORMS: ${{ matrix.platform }} # only need target arch

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,19 @@ COSIGN_FLAGS ?= -y -a GIT_HASH=$(GIT_COMMIT) -a GIT_VERSION=$(VERSION) -a BUILD_
 ## Tool Binaries
 CONTROLLER_GEN ?= go tool controller-gen
 
+LOCALBIN ?= $(CURDIR)/bin
+
+# renovate: datasource=github-releases depName=golangci/golangci-lint
+GOLANGCI_LINT_VERSION ?= v2.12.2
+# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize extractVersion=^kustomize\/(?<version>.+)$$
+KUSTOMIZE_VERSION ?= v5.8.1
+# renovate: datasource=github-releases depName=helm/helm
+HELM_VERSION ?= v4.2.3
+
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+KUSTOMIZE     ?= $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
+HELM          ?= $(LOCALBIN)/helm-$(HELM_VERSION)
+
 ##################################################
 # Go build                                       #
 ##################################################
@@ -138,28 +151,28 @@ e2e-test-images: ## Build all test images under test/images/ and push to $KO_DOC
 
 e2e-deps: e2e-deps-cert-manager e2e-deps-jaeger e2e-deps-keda e2e-deps-otel-collector ## Install all e2e dependencies
 
-e2e-deps-cert-manager:
-	helm repo add jetstack https://charts.jetstack.io --force-update
-	$(call helm-retry,helm upgrade --install cert-manager jetstack/cert-manager \
+e2e-deps-cert-manager: $(HELM)
+	$(HELM) repo add jetstack https://charts.jetstack.io --force-update
+	$(call helm-retry,$(HELM) upgrade --install cert-manager jetstack/cert-manager \
 		--namespace cert-manager --create-namespace \
 		-f test/fixtures/cert-manager-values.yaml \
 		--version $(CERT_MANAGER_VERSION) --wait --timeout 5m)
 
-e2e-deps-jaeger:
-	helm repo add jaegertracing https://jaegertracing.github.io/helm-charts --force-update
-	$(call helm-retry,helm upgrade --install jaeger jaegertracing/jaeger \
+e2e-deps-jaeger: $(HELM)
+	$(HELM) repo add jaegertracing https://jaegertracing.github.io/helm-charts --force-update
+	$(call helm-retry,$(HELM) upgrade --install jaeger jaegertracing/jaeger \
 		--namespace jaeger --create-namespace \
 		--version $(JAEGER_VERSION) --wait --timeout 5m)
 
-e2e-deps-keda:
-	helm repo add kedacore https://kedacore.github.io/charts --force-update
-	$(call helm-retry,helm upgrade --install keda kedacore/keda \
+e2e-deps-keda: $(HELM)
+	$(HELM) repo add kedacore https://kedacore.github.io/charts --force-update
+	$(call helm-retry,$(HELM) upgrade --install keda kedacore/keda \
 		--namespace keda --create-namespace \
 		--version $(KEDA_VERSION) --wait --timeout 5m)
 
-e2e-deps-otel-collector:
-	helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts --force-update
-	$(call helm-retry,helm upgrade --install opentelemetry-collector open-telemetry/opentelemetry-collector \
+e2e-deps-otel-collector: $(HELM)
+	$(HELM) repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts --force-update
+	$(call helm-retry,$(HELM) upgrade --install opentelemetry-collector open-telemetry/opentelemetry-collector \
 		--namespace open-telemetry-system --create-namespace \
 		-f test/fixtures/otel-values.yaml \
 		--version $(OTEL_COLLECTOR_VERSION) --wait --timeout 5m)
@@ -196,14 +209,14 @@ verify-manifests: ## Verify manifests are up to date.
 # Linting & static checks                        #
 ##################################################
 
-fmt:
-	golangci-lint fmt
+fmt: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) fmt
 
-lint:
-	golangci-lint run
+lint: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) run
 
-lint-fix:
-	golangci-lint run --fix
+lint-fix: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) run --fix
 
 check-links:
 	lychee "./**/*.md"
@@ -215,23 +228,23 @@ pre-commit: ## Run static-checks.
 # Deployment (local cluster)                     #
 ##################################################
 
-install:
-	kustomize build config/crd | kubectl apply -f -
+install: $(KUSTOMIZE)
+	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 
-deploy:
-	kustomize build config/default | ko apply -f -
+deploy: $(KUSTOMIZE)
+	$(KUSTOMIZE) build config/default | ko apply -f -
 
-deploy-operator:
-	kustomize build config/operator | ko apply -f -
+deploy-operator: $(KUSTOMIZE)
+	$(KUSTOMIZE) build config/operator | ko apply -f -
 
-deploy-interceptor:
-	kustomize build config/interceptor | ko apply -f -
+deploy-interceptor: $(KUSTOMIZE)
+	$(KUSTOMIZE) build config/interceptor | ko apply -f -
 
-deploy-scaler:
-	kustomize build config/scaler | ko apply -f -
+deploy-scaler: $(KUSTOMIZE)
+	$(KUSTOMIZE) build config/scaler | ko apply -f -
 
-undeploy:
-	kustomize build config/default | ko delete -f - || true
+undeploy: $(KUSTOMIZE)
+	$(KUSTOMIZE) build config/default | ko delete -f - || true
 
 ##################################################
 # Publish, release & signing                     #
@@ -249,15 +262,15 @@ publish-scaler:
 
 publish: publish-operator publish-interceptor publish-scaler
 
-release: manifests ## Produce new KEDA Http Add-on release in keda-add-ons-http-$(VERSION).yaml file.
-	kustomize build config/crd > keda-add-ons-http-$(VERSION).yaml
+release: manifests $(KUSTOMIZE) ## Produce new KEDA Http Add-on release in keda-add-ons-http-$(VERSION).yaml file.
+	$(KUSTOMIZE) build config/crd > keda-add-ons-http-$(VERSION).yaml
 	echo '---' >> keda-add-ons-http-$(VERSION).yaml
-	kustomize build config/operator | KO_DOCKER_REPO=$(IMAGE_OPERATOR) ko resolve --bare --platform=$(KO_RELEASE_PLATFORMS) --tags=$(VERSION) -f - >> keda-add-ons-http-$(VERSION).yaml
+	$(KUSTOMIZE) build config/operator | KO_DOCKER_REPO=$(IMAGE_OPERATOR) ko resolve --bare --platform=$(KO_RELEASE_PLATFORMS) --tags=$(VERSION) -f - >> keda-add-ons-http-$(VERSION).yaml
 	echo '---' >> keda-add-ons-http-$(VERSION).yaml
-	kustomize build config/interceptor | KO_DOCKER_REPO=$(IMAGE_INTERCEPTOR) ko resolve --bare --platform=$(KO_RELEASE_PLATFORMS) --tags=$(VERSION) -f - >> keda-add-ons-http-$(VERSION).yaml
+	$(KUSTOMIZE) build config/interceptor | KO_DOCKER_REPO=$(IMAGE_INTERCEPTOR) ko resolve --bare --platform=$(KO_RELEASE_PLATFORMS) --tags=$(VERSION) -f - >> keda-add-ons-http-$(VERSION).yaml
 	echo '---' >> keda-add-ons-http-$(VERSION).yaml
-	kustomize build config/scaler | KO_DOCKER_REPO=$(IMAGE_SCALER) ko resolve --bare --platform=$(KO_RELEASE_PLATFORMS) --tags=$(VERSION) -f - >> keda-add-ons-http-$(VERSION).yaml
-	kustomize build config/crd > keda-add-ons-http-$(VERSION)-crds.yaml
+	$(KUSTOMIZE) build config/scaler | KO_DOCKER_REPO=$(IMAGE_SCALER) ko resolve --bare --platform=$(KO_RELEASE_PLATFORMS) --tags=$(VERSION) -f - >> keda-add-ons-http-$(VERSION).yaml
+	$(KUSTOMIZE) build config/crd > keda-add-ons-http-$(VERSION)-crds.yaml
 
 sign-images: ## Sign KEDA images published on GitHub Container Registry
 	cosign sign $(COSIGN_FLAGS) $(IMAGE_OPERATOR_VERSIONED_TAG)
@@ -266,3 +279,27 @@ sign-images: ## Sign KEDA images published on GitHub Container Registry
 	cosign sign $(COSIGN_FLAGS) $(IMAGE_INTERCEPTOR_SHA_TAG)
 	cosign sign $(COSIGN_FLAGS) $(IMAGE_SCALER_VERSIONED_TAG)
 	cosign sign $(COSIGN_FLAGS) $(IMAGE_SCALER_SHA_TAG)
+
+##################################################
+# Tool installation                              #
+##################################################
+
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+$(GOLANGCI_LINT): | $(LOCALBIN)
+	$(call go-install-tool,golangci-lint,github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+$(KUSTOMIZE): | $(LOCALBIN)
+	$(call go-install-tool,kustomize,sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
+
+$(HELM): | $(LOCALBIN)
+	$(call go-install-tool,helm,helm.sh/helm/v4/cmd/helm,$(HELM_VERSION))
+
+define go-install-tool
+@echo "Installing $(2)@$(3)"
+@rm -f $(LOCALBIN)/$(1)
+@GOBIN=$(LOCALBIN) go install $(2)@$(3)
+@mv $(LOCALBIN)/$(1) $(LOCALBIN)/$(1)-$(3)
+@ln -sf $(1)-$(3) $(LOCALBIN)/$(1)
+endef


### PR DESCRIPTION
`make lint`, `make deploy`, and other targets now auto-install golangci-lint, kustomize, and helm via `go install` when missing. Binaries land in bin/ with a version suffix (bin/helm-v4.2.3) so Make skips the download when the file already exists. A symlink (bin/helm -> bin/helm-v4.2.3) is created for convenience.
I did not include everything but only tools used during normal development that could cause problems, e.g. `kind` is still in the hand of the user as they might also use another k8s distribution.

I was quite split on this as package managers exist for a reason:
- installing packages from scripts seems less safe, reliable and convenient
- custom installs can overlap with github actions installing the same tools
- forcing specific tool versions on users is not what I personally prefer

But the reasons for this approach are:
- go install is a reliable way to install packages also cross plattform
	- installing tools via go install seems to be a common way in the k8s ecosystem though
	- the arguments against go install e.g. from [golangci-lint](https://golangci-lint.run/docs/welcome/install/local/#install-from-sources) don't really apply (no tools, no dep update, ...)
	- this approach is somewhat similar to what [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder/blob/0ae27c357390c35c4710b3e610cf891ce556cdb9/Makefile#L284-L308) does (but a bit simpler)
- we already saw that different helm and golangci-lint versions caused errors
	- make it easy to avoid such mistakes by using pinned tool versions
	- "experts" can easily override the version if they want to e.g. via `make lint GOLANGCI_LINT=$(which golangci-lint)`
- the proposed approach is still fast
	- CI can still run fast and save 45s build time of helm by using the cached binary from the action
	- local dependencies are cached and only downloaded once

Alternative approaches considered:
- installing tools via their installer scripts
	- go install is simpler with the draw back of building the binary but only when needed
	- go install is the approach chosen by projects like kubebuilder or controller-runtime
	- go install luckily works for all of our required tools
	- downloading binaries/installer scripts might be faster for the first time only but piping online scripts to bash has a taste


### Changes
- Add go-install-tool macro and version-pinned targets for golangci-lint, kustomize, and helm
- Replace bare tool references with Makefile variables
- Create convenience symlinks (bin/helm -> bin/helm-v4.2.3) for direct use
- CI passes HELM=$(which helm) to reuse the faster action-installed binary instead of compiling from source
- Add renovate comments for version bumps
- Rename renovate group from "E2E Dependencies" to "Infra Dependencies" to reflect broader scope


 


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))