### PR TITLE
feat(interceptor): retry requests against an alternate endpoint on connect failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This changelog keeps track of work items that have been completed and are ready 
 - **General**: TODO ([#TODO](https://github.com/kedacore/http-add-on/issues/TODO))
 - **Interceptor**: Add `KEDA_HTTP_DIRECT_POD_ROUTING` environment variable (`true` | `false`, default `true`). When enabled, the interceptor routes requests directly to a ready pod IP instead of through the Service ClusterIP, bypassing kube-proxy and other Service-layer features (Service-level NetworkPolicy, session affinity, topology-aware routing). ([#1473](https://github.com/kedacore/http-add-on/issues/1473))
 - **Interceptor**: Add `KEDA_HTTP_TLS_CA_DIRS` environment variable to trust custom CA bundles for outbound backend connections. ([#1728](https://github.com/kedacore/http-add-on/issues/1728))
+- **Interceptor**: Retry requests against an alternate ready endpoint when the picked pod fails at connect time (e.g. it terminated after the endpoint snapshot was taken). Bounded by the new `KEDA_HTTP_RETRY_COUNT` environment variable (default `1`, `0` disables); only requests without a body are retried, and only with direct-pod routing enabled. Adds the `interceptor.request.retries` metric. ([#1734](https://github.com/kedacore/http-add-on/issues/1734))
 
 ### Improvements
 

--- a/interceptor/config/serving.go
+++ b/interceptor/config/serving.go
@@ -54,6 +54,12 @@ type Serving struct {
 	// ClusterIP, bypassing kube-proxy and other Service-layer features
 	// (NetworkPolicy, session affinity, topology-aware routing).
 	DirectPodRouting bool `env:"KEDA_HTTP_DIRECT_POD_ROUTING" envDefault:"true"`
+	// RetryCount is the maximum number of times a request is retried against an
+	// alternate ready endpoint when the picked pod fails at connect time (e.g.
+	// it terminated after the endpoint snapshot was taken). Only requests
+	// without a body are retried. Only applies with DirectPodRouting enabled;
+	// 0 disables retries.
+	RetryCount int `env:"KEDA_HTTP_RETRY_COUNT" envDefault:"1"`
 }
 
 // MustParseServing parses standard configs and returns the

--- a/interceptor/handler/upstream.go
+++ b/interceptor/handler/upstream.go
@@ -35,9 +35,10 @@ type Upstream struct {
 	reader                 client.Reader
 	responseHeaderTimeout  time.Duration
 	tracingCfg             config.Tracing
+	retryCfg               RetryConfig
 }
 
-func NewUpstream(baseTransport *http.Transport, reader client.Reader, tracingCfg config.Tracing, responseHeaderTimeout time.Duration) *Upstream {
+func NewUpstream(baseTransport *http.Transport, reader client.Reader, tracingCfg config.Tracing, responseHeaderTimeout time.Duration, retryCfg RetryConfig) *Upstream {
 	if baseTransport == nil {
 		panic("baseTransport must not be nil")
 	}
@@ -52,6 +53,7 @@ func NewUpstream(baseTransport *http.Transport, reader client.Reader, tracingCfg
 		reader:                 reader,
 		responseHeaderTimeout:  responseHeaderTimeout,
 		tracingCfg:             tracingCfg,
+		retryCfg:               retryCfg,
 	}
 }
 
@@ -94,8 +96,11 @@ func (uh *Upstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	transport := pool.Get(responseHeaderTimeout)
 
 	var rt http.RoundTripper = transport
+	if uh.retryCfg.Count > 0 {
+		rt = newRetryTransport(rt, uh.retryCfg)
+	}
 	if uh.tracingCfg.Enabled {
-		rt = otelhttp.NewTransport(transport)
+		rt = otelhttp.NewTransport(rt)
 	}
 
 	rc := http.NewResponseController(w)

--- a/interceptor/handler/upstream_retry.go
+++ b/interceptor/handler/upstream_retry.go
@@ -1,0 +1,125 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/kedacore/http-add-on/interceptor/metrics"
+	kedanet "github.com/kedacore/http-add-on/pkg/net"
+	"github.com/kedacore/http-add-on/pkg/util"
+)
+
+// maxDialAttemptsPerEndpoint bounds how many times the dialer retries a single
+// endpoint before the request may rotate to an alternate one. Kept small: a
+// ready endpoint that refuses connections is almost always a pod that is
+// terminating, so failing over fast beats waiting. Cold-start resilience for
+// single-endpoint services is unaffected — with no alternate available the
+// first attempt keeps the dialer's legacy context-bounded retry.
+const maxDialAttemptsPerEndpoint = 3
+
+// RetryConfig configures request retries against alternate upstream endpoints.
+type RetryConfig struct {
+	// Count is the maximum number of endpoint rotations per request.
+	// A value <= 0 disables retries entirely.
+	Count int
+	// Instruments records the retry metric; nil disables it.
+	Instruments *metrics.Instruments
+}
+
+// retryTransport retries a request against an alternate ready endpoint when
+// the picked endpoint fails at TCP connect time — the steady-state case during
+// scale-down, where a pod disappears between the endpoint snapshot and the
+// dial. Only requests without a body are retried, and only on dial failure, so
+// a retry can never replay a request the backend has already seen.
+type retryTransport struct {
+	base        http.RoundTripper
+	retries     int
+	instruments *metrics.Instruments
+}
+
+func newRetryTransport(base http.RoundTripper, cfg RetryConfig) *retryTransport {
+	return &retryTransport{base: base, retries: cfg.Count, instruments: cfg.Instruments}
+}
+
+var _ http.RoundTripper = (*retryTransport)(nil)
+
+func (rt *retryTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	picker := util.EndpointPickerFromContext(req.Context())
+	if picker == nil || rt.retries <= 0 || !retryableRequest(req) {
+		return rt.base.RoundTrip(req)
+	}
+
+	tried := map[string]struct{}{req.URL.Host: {}}
+	rotated := false
+	defer func() {
+		if rotated && rt.instruments != nil {
+			routeName, routeNamespace := "", ""
+			if ir := util.InterceptorRouteFromContext(req.Context()); ir != nil {
+				routeName, routeNamespace = ir.Name, ir.Namespace
+			}
+			rt.instruments.RecordRetry(routeName, routeNamespace, err == nil)
+		}
+	}()
+
+	for rotations := 0; ; {
+		attemptReq := req
+		if rotations > 0 || picker(tried) != "" {
+			// Bound this attempt's dials whenever a failover target may exist,
+			// so a dead endpoint fails fast instead of soaking the whole
+			// request budget redialing it. With no alternate in the snapshot,
+			// the first attempt keeps the legacy unbounded dial retry, which
+			// cold starts on single-replica services rely on.
+			attemptReq = req.WithContext(kedanet.ContextWithMaxDialAttempts(req.Context(), maxDialAttemptsPerEndpoint))
+		}
+
+		resp, err := rt.base.RoundTrip(attemptReq)
+
+		var exhausted *kedanet.DialAttemptsExhaustedError
+		if !errors.As(err, &exhausted) {
+			// Success, or a failure retrying cannot fix: the unbounded settle
+			// attempt, a mid-request error, or a spent request budget.
+			return resp, err
+		}
+
+		if rotations >= rt.retries {
+			return nil, err
+		}
+
+		next := picker(tried)
+		if next == "" {
+			// The snapshot changed mid-flight; nothing left to rotate to.
+			return nil, err
+		}
+
+		rotations++
+		rotated = true
+		tried[next] = struct{}{}
+
+		util.LoggerFromContext(req.Context()).V(1).Info(
+			"endpoint unreachable, retrying request against an alternate endpoint",
+			"failedHost", req.URL.Host,
+			"nextHost", next,
+			"rotation", rotations,
+		)
+
+		req = requestWithHost(req, next)
+	}
+}
+
+// retryableRequest reports whether the request can be re-dispatched without
+// replaying a body: retries only trigger on connect failure, where no request
+// byte reached the backend, so any body-less request is safe to resend.
+func retryableRequest(req *http.Request) bool {
+	return req.Body == nil || req.ContentLength == 0
+}
+
+// requestWithHost returns a copy of req with the URL host replaced, keeping
+// everything else — including the context, so TLS SNI still resolves to the
+// original service hostname.
+func requestWithHost(req *http.Request, host string) *http.Request {
+	r2 := req.Clone(req.Context())
+	u := *req.URL
+	u.Host = host
+	r2.URL = &u
+	return r2
+}

--- a/interceptor/handler/upstream_retry_test.go
+++ b/interceptor/handler/upstream_retry_test.go
@@ -1,0 +1,300 @@
+package handler
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kedacore/http-add-on/interceptor/config"
+	"github.com/kedacore/http-add-on/interceptor/metrics"
+	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
+	"github.com/kedacore/http-add-on/pkg/util"
+)
+
+// deadServerURL returns the URL of a server that was closed before serving,
+// so dials to it are refused immediately.
+func deadServerURL(t *testing.T) *url.URL {
+	t.Helper()
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	addr := listener.Addr().String()
+	require.NoError(t, listener.Close())
+	u, err := url.Parse("http://" + addr)
+	require.NoError(t, err)
+	return u
+}
+
+// staticPicker mimics the cache-backed endpoint picker: it returns altHost
+// until altHost has been tried.
+func staticPicker(altHost string) util.EndpointPickerFunc {
+	return func(tried map[string]struct{}) string {
+		if _, ok := tried[altHost]; ok {
+			return ""
+		}
+		return altHost
+	}
+}
+
+func TestUpstreamRetriesAlternateEndpointOnConnectFailure(t *testing.T) {
+	r := require.New(t)
+
+	var alternateHits atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		alternateHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("from alternate"))
+		assert.NoError(t, err)
+	}))
+	defer backend.Close()
+	backendURL, err := url.Parse(backend.URL)
+	r.NoError(err)
+
+	deadURL := deadServerURL(t)
+
+	timeouts := defaultTimeouts()
+	uh := NewUpstream(
+		newTestTransport(retryDialContextFunc(timeouts)),
+		newFakeClient(),
+		config.Tracing{},
+		timeouts.ResponseHeader,
+		RetryConfig{Count: 1, Instruments: metrics.NewNoopInstruments()},
+	)
+
+	res, req, err := reqAndRes("/test")
+	r.NoError(err)
+	ctx := util.ContextWithUpstreamURL(req.Context(), deadURL)
+	ctx = util.ContextWithEndpointPicker(ctx, staticPicker(backendURL.Host))
+	req = req.WithContext(ctx)
+
+	uh.ServeHTTP(res, req)
+
+	r.Equal(http.StatusOK, res.Code, "response body: %s", res.Body.String())
+	r.Equal("from alternate", res.Body.String())
+	r.Equal(int32(1), alternateHits.Load())
+}
+
+func TestUpstreamRetryBudgetExhausted(t *testing.T) {
+	r := require.New(t)
+
+	deadURL1 := deadServerURL(t)
+	deadURL2 := deadServerURL(t)
+
+	timeouts := defaultTimeouts()
+	uh := NewUpstream(
+		newTestTransport(retryDialContextFunc(timeouts)),
+		newFakeClient(),
+		config.Tracing{},
+		timeouts.ResponseHeader,
+		RetryConfig{Count: 1, Instruments: metrics.NewNoopInstruments()},
+	)
+
+	res, req, err := reqAndRes("/test")
+	r.NoError(err)
+	ctx := util.ContextWithUpstreamURL(req.Context(), deadURL1)
+	ctx = util.ContextWithEndpointPicker(ctx, staticPicker(deadURL2.Host))
+	req = req.WithContext(ctx)
+
+	start := time.Now()
+	uh.ServeHTTP(res, req)
+	elapsed := time.Since(start)
+
+	// Connection refused is not a timeout, so the failure maps to 502.
+	r.Equal(http.StatusBadGateway, res.Code, "response body: %s", res.Body.String())
+	// Two bounded attempts (3 dials each at a 50ms interval) must fail far
+	// quicker than the legacy unbounded redial, which would run until the
+	// 10s request timeout of defaultTimeouts.
+	r.Less(elapsed, 5*time.Second)
+}
+
+func TestUpstreamDoesNotRetryRequestWithBody(t *testing.T) {
+	r := require.New(t)
+
+	var alternateHits atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		alternateHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+	backendURL, err := url.Parse(backend.URL)
+	r.NoError(err)
+
+	deadURL := deadServerURL(t)
+
+	timeouts := defaultTimeouts()
+	uh := NewUpstream(
+		newTestTransport(retryDialContextFunc(timeouts)),
+		newFakeClient(),
+		config.Tracing{},
+		timeouts.ResponseHeader,
+		RetryConfig{Count: 1, Instruments: metrics.NewNoopInstruments()},
+	)
+
+	req, err := http.NewRequest("POST", "/test", strings.NewReader("payload"))
+	r.NoError(err)
+	res := httptest.NewRecorder()
+
+	ctx := util.ContextWithUpstreamURL(req.Context(), deadURL)
+	ctx = util.ContextWithEndpointPicker(ctx, staticPicker(backendURL.Host))
+	// Bound the legacy unbounded dial redial for the test.
+	ctx, cancel := context.WithTimeout(ctx, 300*time.Millisecond)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	uh.ServeHTTP(res, req)
+
+	r.Equal(http.StatusGatewayTimeout, res.Code, "response body: %s", res.Body.String())
+	r.Equal(int32(0), alternateHits.Load(), "requests with a body must not be retried")
+}
+
+func TestUpstreamRetryDisabled(t *testing.T) {
+	r := require.New(t)
+
+	var alternateHits atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		alternateHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+	backendURL, err := url.Parse(backend.URL)
+	r.NoError(err)
+
+	deadURL := deadServerURL(t)
+
+	timeouts := defaultTimeouts()
+	uh := NewUpstream(
+		newTestTransport(retryDialContextFunc(timeouts)),
+		newFakeClient(),
+		config.Tracing{},
+		timeouts.ResponseHeader,
+		RetryConfig{Count: 0, Instruments: metrics.NewNoopInstruments()},
+	)
+
+	res, req, err := reqAndRes("/test")
+	r.NoError(err)
+	ctx := util.ContextWithUpstreamURL(req.Context(), deadURL)
+	ctx = util.ContextWithEndpointPicker(ctx, staticPicker(backendURL.Host))
+	ctx, cancel := context.WithTimeout(ctx, 300*time.Millisecond)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	uh.ServeHTTP(res, req)
+
+	r.Equal(http.StatusGatewayTimeout, res.Code, "response body: %s", res.Body.String())
+	r.Equal(int32(0), alternateHits.Load(), "retry count 0 must disable retries")
+}
+
+// TestUpstreamSingleEndpointKeepsLegacyDialRetry verifies that when the
+// snapshot has no alternate endpoint, the first attempt keeps the legacy
+// context-bounded dial retry instead of failing fast — single-replica cold
+// starts rely on it.
+func TestUpstreamSingleEndpointKeepsLegacyDialRetry(t *testing.T) {
+	r := require.New(t)
+
+	deadURL := deadServerURL(t)
+
+	timeouts := defaultTimeouts()
+	uh := NewUpstream(
+		newTestTransport(retryDialContextFunc(timeouts)),
+		newFakeClient(),
+		config.Tracing{},
+		timeouts.ResponseHeader,
+		RetryConfig{Count: 1, Instruments: metrics.NewNoopInstruments()},
+	)
+
+	res, req, err := reqAndRes("/test")
+	r.NoError(err)
+	ctx := util.ContextWithUpstreamURL(req.Context(), deadURL)
+	// No alternate available: the picker returns "".
+	ctx = util.ContextWithEndpointPicker(ctx, func(map[string]struct{}) string { return "" })
+	ctx, cancel := context.WithTimeout(ctx, 400*time.Millisecond)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	start := time.Now()
+	uh.ServeHTTP(res, req)
+	elapsed := time.Since(start)
+
+	r.Equal(http.StatusGatewayTimeout, res.Code, "response body: %s", res.Body.String())
+	// A bounded first attempt would fail after ~150ms; the legacy redial must
+	// run until the request context deadline.
+	r.GreaterOrEqual(elapsed, 350*time.Millisecond)
+}
+
+func TestUpstreamRetryMetric(t *testing.T) {
+	r := require.New(t)
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	instruments, err := metrics.NewInstruments(provider)
+	r.NoError(err)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+	backendURL, err := url.Parse(backend.URL)
+	r.NoError(err)
+
+	deadURL := deadServerURL(t)
+
+	timeouts := defaultTimeouts()
+	uh := NewUpstream(
+		newTestTransport(retryDialContextFunc(timeouts)),
+		newFakeClient(),
+		config.Tracing{},
+		timeouts.ResponseHeader,
+		RetryConfig{Count: 1, Instruments: instruments},
+	)
+
+	ir := &httpv1beta1.InterceptorRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ir", Namespace: "test-ns"},
+	}
+
+	res, req, err := reqAndRes("/test")
+	r.NoError(err)
+	ctx := util.ContextWithUpstreamURL(req.Context(), deadURL)
+	ctx = util.ContextWithEndpointPicker(ctx, staticPicker(backendURL.Host))
+	ctx = util.ContextWithInterceptorRoute(ctx, ir)
+	req = req.WithContext(ctx)
+
+	uh.ServeHTTP(res, req)
+	r.Equal(http.StatusOK, res.Code, "response body: %s", res.Body.String())
+
+	var rm metricdata.ResourceMetrics
+	r.NoError(reader.Collect(context.Background(), &rm))
+
+	var found bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != metrics.MetricRequestRetries {
+				continue
+			}
+			found = true
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			r.True(ok, "retry metric should be a Sum[int64]")
+			r.Len(sum.DataPoints, 1)
+			dp := sum.DataPoints[0]
+			r.Equal(int64(1), dp.Value)
+			outcome, _ := dp.Attributes.Value(attribute.Key(metrics.AttrOutcome))
+			r.Equal(metrics.OutcomeSuccess, outcome.AsString())
+			routeName, _ := dp.Attributes.Value(attribute.Key(metrics.AttrRouteName))
+			r.Equal("test-ir", routeName.AsString())
+			routeNs, _ := dp.Attributes.Value(attribute.Key(metrics.AttrRouteNamespace))
+			r.Equal("test-ns", routeNs.AsString())
+		}
+	}
+	r.True(found, "retry metric %q not found", metrics.MetricRequestRetries)
+}

--- a/interceptor/handler/upstream_test.go
+++ b/interceptor/handler/upstream_test.go
@@ -164,7 +164,7 @@ func TestForwarderSuccess(t *testing.T) {
 	req = util.RequestWithUpstreamURL(req, forwardURL)
 	timeouts := defaultTimeouts()
 	dialCtxFunc := retryDialContextFunc(timeouts)
-	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader)
+	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader, RetryConfig{})
 	uh.ServeHTTP(res, req)
 
 	r.True(
@@ -206,7 +206,7 @@ func TestForwarderHeaderTimeout(t *testing.T) {
 	res, req, err := reqAndRes("/testfwd")
 	r.NoError(err)
 	req = util.RequestWithUpstreamURL(req, originURL)
-	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader)
+	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader, RetryConfig{})
 	uh.ServeHTTP(res, req)
 
 	r.Equal(http.StatusGatewayTimeout, res.Code)
@@ -250,7 +250,7 @@ func TestForwarderWaitsForSlowOrigin(t *testing.T) {
 	res, req, err := reqAndRes(path)
 	r.NoError(err)
 	req = util.RequestWithUpstreamURL(req, originURL)
-	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader)
+	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader, RetryConfig{})
 	uh.ServeHTTP(res, req)
 	// wait for the goroutine above to finish, with a little cusion
 	ensureSignalBeforeTimeout(originWaitCh, originDelay*2)
@@ -266,7 +266,7 @@ func TestForwarderConnectionRetryAndTimeout(t *testing.T) {
 	const requestTimeout = 500 * time.Millisecond
 	timeouts := defaultTimeouts()
 	dialCtxFunc := retryDialContextFunc(timeouts)
-	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader)
+	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader, RetryConfig{})
 
 	res, req, err := reqAndRes("/test")
 	r.NoError(err)
@@ -324,7 +324,7 @@ func TestForwardRequestRedirectAndHeaders(t *testing.T) {
 	res, req, err := reqAndRes("/testfwd")
 	r.NoError(err)
 	req = util.RequestWithUpstreamURL(req, srvURL)
-	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader)
+	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader, RetryConfig{})
 	uh.ServeHTTP(res, req)
 	r.Equal(301, res.Code)
 	r.Equal("abc123.com", res.Header().Get("Location"))
@@ -381,7 +381,7 @@ func TestUpstreamPreservesXForwardedHeaders(t *testing.T) {
 			}
 
 			// Configure the Upstream and send a dummy request
-			upstream := NewUpstream(http.DefaultTransport.(*http.Transport), newFakeClient(), config.Tracing{}, 500*time.Millisecond)
+			upstream := NewUpstream(http.DefaultTransport.(*http.Transport), newFakeClient(), config.Tracing{}, 500*time.Millisecond, RetryConfig{})
 
 			req := httptest.NewRequest("GET", "/test", nil)
 			if tt.forwardedFor != "" {
@@ -470,7 +470,7 @@ func TestUpstream_RouteSpecResponseHeaderOverride(t *testing.T) {
 	ctx := util.ContextWithInterceptorRoute(req.Context(), ir)
 	req = req.WithContext(ctx)
 
-	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader)
+	uh := NewUpstream(newTestTransport(dialCtxFunc), newFakeClient(), config.Tracing{}, timeouts.ResponseHeader, RetryConfig{})
 	uh.ServeHTTP(res, req)
 
 	r.Equal(http.StatusGatewayTimeout, res.Code)
@@ -489,7 +489,7 @@ func TestFullDuplexBodyPanic(t *testing.T) {
 		},
 	}
 
-	upstream := NewUpstream(failingTransport, newFakeClient(), config.Tracing{}, 1*time.Second)
+	upstream := NewUpstream(failingTransport, newFakeClient(), config.Tracing{}, 1*time.Second, RetryConfig{})
 
 	targetURL, _ := url.Parse("http://fake-backend:8080")
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -602,7 +602,7 @@ func TestUpstream_AppProtocolTransportSelection(t *testing.T) {
 				},
 			}
 
-			upstream := NewUpstream(http.DefaultTransport.(*http.Transport), fakeClient, config.Tracing{}, 5*time.Second)
+			upstream := NewUpstream(http.DefaultTransport.(*http.Transport), fakeClient, config.Tracing{}, 5*time.Second, RetryConfig{})
 
 			req := httptest.NewRequest(http.MethodGet, "/test", nil)
 			req.ProtoMajor = tc.incomingProtoMajor
@@ -651,7 +651,7 @@ func TestUpstream_AppProtocolFallbackOnMissingService(t *testing.T) {
 		},
 	}
 
-	upstream := NewUpstream(http.DefaultTransport.(*http.Transport), fakeClient, config.Tracing{}, 5*time.Second)
+	upstream := NewUpstream(http.DefaultTransport.(*http.Transport), fakeClient, config.Tracing{}, 5*time.Second, RetryConfig{})
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	ctx := util.ContextWithUpstreamURL(req.Context(), backendURL)
@@ -722,7 +722,7 @@ func serveHTTP(w http.ResponseWriter, r *http.Request) {
 	timeouts := defaultTimeouts()
 	dialCtxFunc := retryDialContextFunc(timeouts)
 	transport := newTestTransport(dialCtxFunc)
-	upstream := NewUpstream(transport, newFakeClient(), config.Tracing{Enabled: true}, timeouts.ResponseHeader)
+	upstream := NewUpstream(transport, newFakeClient(), config.Tracing{Enabled: true}, timeouts.ResponseHeader, RetryConfig{})
 
 	upstream.ServeHTTP(w, r)
 }

--- a/interceptor/metrics/instruments.go
+++ b/interceptor/metrics/instruments.go
@@ -18,11 +18,19 @@ const (
 	MetricRequestConcurrency = "interceptor.request.concurrency"
 	MetricRequestCount       = "interceptor.request.count"
 	MetricRequestDuration    = "interceptor.request.duration"
+	MetricRequestRetries     = "interceptor.request.retries"
 
 	AttrCode           = "code"
 	AttrMethod         = "method"
+	AttrOutcome        = "outcome"
 	AttrRouteName      = "route_name"
 	AttrRouteNamespace = "route_namespace"
+
+	// OutcomeSuccess / OutcomeFailure are the values of AttrOutcome for
+	// MetricRequestRetries: whether the retried request eventually got an
+	// upstream response.
+	OutcomeSuccess = "success"
+	OutcomeFailure = "failure"
 
 	// MethodOther is the normalized value for non-standard HTTP methods,
 	// following the OTel semantic convention prefix for synthetic values.
@@ -48,6 +56,7 @@ type Instruments struct {
 	pendingRequests api.Int64UpDownCounter
 	requestCounter  api.Int64Counter
 	requestDuration api.Float64Histogram
+	retryCounter    api.Int64Counter
 }
 
 // NewNoopInstruments returns Instruments backed by a no-op provider, for use in tests.
@@ -92,10 +101,19 @@ func NewInstruments(provider *sdkmetric.MeterProvider) (*Instruments, error) {
 		return nil, fmt.Errorf("creating pending requests counter: %w", err)
 	}
 
+	retryCounter, err := meter.Int64Counter(
+		MetricRequestRetries,
+		api.WithDescription("Requests retried against an alternate upstream endpoint after a connect failure"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating retry counter: %w", err)
+	}
+
 	return &Instruments{
 		requestCounter:  requestCounter,
 		requestDuration: requestDuration,
 		pendingRequests: pendingRequests,
+		retryCounter:    retryCounter,
 	}, nil
 }
 
@@ -125,4 +143,20 @@ func (i *Instruments) RecordPendingRequest(routeName, routeNamespace string, del
 		attribute.String(AttrRouteNamespace, routeNamespace),
 	))
 	i.pendingRequests.Add(context.Background(), delta, attrs)
+}
+
+// RecordRetry records a request that was retried against an alternate upstream
+// endpoint, with success reporting whether the retried request eventually got
+// an upstream response.
+func (i *Instruments) RecordRetry(routeName, routeNamespace string, success bool) {
+	outcome := OutcomeSuccess
+	if !success {
+		outcome = OutcomeFailure
+	}
+	attrs := api.WithAttributeSet(attribute.NewSet(
+		attribute.String(AttrOutcome, outcome),
+		attribute.String(AttrRouteName, routeName),
+		attribute.String(AttrRouteNamespace, routeNamespace),
+	))
+	i.retryCounter.Add(context.Background(), 1, attrs)
 }

--- a/interceptor/middleware/endpoint_resolver.go
+++ b/interceptor/middleware/endpoint_resolver.go
@@ -65,7 +65,8 @@ func (er *EndpointResolver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	serviceKey := ir.Namespace + "/" + ir.Spec.Target.Service
-	isColdStart, podHost, err := er.readyCache.WaitForReady(waitCtx, serviceKey, util.UpstreamPortNameFromContext(ctx))
+	portName := util.UpstreamPortNameFromContext(ctx)
+	isColdStart, podHost, err := er.readyCache.WaitForReady(waitCtx, serviceKey, portName)
 	if err != nil {
 		// No fallback, return an error
 		if !hasFallback {
@@ -109,6 +110,12 @@ func (er *EndpointResolver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				podURL := *upstreamURL
 				podURL.Host = podHost
 				ctx = util.ContextWithUpstreamURL(ctx, &podURL)
+				// Expose the remaining ready endpoints so the upstream handler
+				// can retry against an alternate pod when the picked one is
+				// unreachable (e.g. it terminated after the snapshot was taken).
+				ctx = util.ContextWithEndpointPicker(ctx, func(tried map[string]struct{}) string {
+					return er.readyCache.PickEndpoint(serviceKey, portName, tried)
+				})
 				r = r.WithContext(ctx)
 			}
 		}

--- a/interceptor/middleware/endpoint_resolver_test.go
+++ b/interceptor/middleware/endpoint_resolver_test.go
@@ -1014,3 +1014,70 @@ func TestEndpointResolver_DirectPodRouting_UsedOnWarmPath(t *testing.T) {
 		t.Fatalf("upstream host = %q, want pod IP (should be rewritten on warm path too)", capturedUpstream.Host)
 	}
 }
+
+// TestEndpointResolver_DirectPodRouting_SetsEndpointPicker verifies that the
+// direct-pod rewrite also exposes an endpoint picker so the upstream handler
+// can retry against an alternate pod.
+func TestEndpointResolver_DirectPodRouting_SetsEndpointPicker(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+	addReadyEndpointWithPort(cache, 8080)
+
+	var capturedPicker util.EndpointPickerFunc
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPicker = util.EndpointPickerFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 200 * time.Millisecond,
+		DirectPodRouting: true,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, defaultIR())
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedPicker == nil {
+		t.Fatal("expected an endpoint picker in context when direct-pod routing rewrites the URL")
+	}
+	if got := capturedPicker(map[string]struct{}{}); got != "1.2.3.4:8080" {
+		t.Fatalf("picker = %q, want %q", got, "1.2.3.4:8080")
+	}
+	// With the only endpoint already tried, nothing remains.
+	if got := capturedPicker(map[string]struct{}{"1.2.3.4:8080": {}}); got != "" {
+		t.Fatalf("picker = %q, want empty when the only endpoint was tried", got)
+	}
+}
+
+// TestEndpointResolver_NoEndpointPickerWithoutDirectPodRouting verifies that
+// no picker is exposed when the request goes through the Service ClusterIP:
+// there is no single pod to fail over from, kube-proxy re-selects on redial.
+func TestEndpointResolver_NoEndpointPickerWithoutDirectPodRouting(t *testing.T) {
+	cache := k8s.NewReadyEndpointsCache(logr.Discard())
+	addReadyEndpointWithPort(cache, 8080)
+
+	var capturedPicker util.EndpointPickerFunc
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPicker = util.EndpointPickerFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+		ReadinessTimeout: 200 * time.Millisecond,
+		DirectPodRouting: false,
+	})
+
+	rec := httptest.NewRecorder()
+	req := newRequest(t, defaultIR())
+	mw.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if capturedPicker != nil {
+		t.Fatal("endpoint picker must not be set when direct-pod routing is disabled")
+	}
+}

--- a/interceptor/proxy.go
+++ b/interceptor/proxy.go
@@ -38,11 +38,17 @@ type ProxyHandlerConfig struct {
 	// dialAddressOverride redirects all dial attempts to this address (for testing).
 	// If empty, dials to the original target address.
 	dialAddressOverride string
+	// dialFuncOverride replaces the dial function entirely (for testing).
+	// If nil, DialContextWithRetry(Timeouts.Connect) is used.
+	dialFuncOverride kedanet.DialContextFunc
 }
 
 // BuildProxyHandler constructs the proxy handler chain.
 func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
-	dialFunc := kedanet.DialContextWithRetry(cfg.Timeouts.Connect)
+	dialFunc := cfg.dialFuncOverride
+	if dialFunc == nil {
+		dialFunc = kedanet.DialContextWithRetry(cfg.Timeouts.Connect)
+	}
 
 	// Wrap dialer to redirect if override is set (for testing)
 	if cfg.dialAddressOverride != "" {
@@ -66,7 +72,10 @@ func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
 	}
 
 	// Build handler chain (innermost to outermost)
-	upstream := handler.NewUpstream(baseTransport, cfg.Reader, cfg.Tracing, cfg.Timeouts.ResponseHeader)
+	upstream := handler.NewUpstream(baseTransport, cfg.Reader, cfg.Tracing, cfg.Timeouts.ResponseHeader, handler.RetryConfig{
+		Count:       cfg.Serving.RetryCount,
+		Instruments: cfg.Instruments,
+	})
 
 	var h http.Handler = middleware.NewEndpointResolver(upstream, cfg.ReadyCache, middleware.EndpointResolverConfig{
 		ReadinessTimeout:      cfg.Timeouts.Readiness,

--- a/interceptor/proxy_test.go
+++ b/interceptor/proxy_test.go
@@ -7,7 +7,9 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +28,7 @@ import (
 	kedacache "github.com/kedacore/http-add-on/pkg/cache"
 	kedahttp "github.com/kedacore/http-add-on/pkg/http"
 	"github.com/kedacore/http-add-on/pkg/k8s"
+	kedanet "github.com/kedacore/http-add-on/pkg/net"
 	"github.com/kedacore/http-add-on/pkg/queue"
 	routingtest "github.com/kedacore/http-add-on/pkg/routing/test"
 	"github.com/kedacore/http-add-on/pkg/testutil"
@@ -275,6 +278,170 @@ func TestProxyHandler_TLSBackend(t *testing.T) {
 	}
 }
 
+// closedPort returns a 127.0.0.1 port that nothing listens on, emulating a pod
+// that is gone while its endpoint is still in the EndpointSlices.
+func closedPort(t *testing.T) int32 {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate port: %v", err)
+	}
+	_, portStr, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to parse listener address: %v", err)
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("failed to close listener: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("failed to parse port: %v", err)
+	}
+	return int32(port)
+}
+
+// endpointSliceForPorts builds an EndpointSlice for test-service with the given
+// pods on 127.0.0.1 and the given (unnamed) ports. Direct-pod routing pairs
+// every ready IP with every port, so one IP with two ports yields two
+// candidates.
+func endpointSliceForPorts(ip string, ports ...int32) *discov1.EndpointSlice {
+	slicePorts := make([]discov1.EndpointPort, 0, len(ports))
+	for i := range ports {
+		slicePorts = append(slicePorts, discov1.EndpointPort{Port: &ports[i]})
+	}
+	return &discov1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-service-slice",
+			Namespace: "test-namespace",
+			Labels:    map[string]string{discov1.LabelServiceName: "test-service"},
+		},
+		AddressType: discov1.AddressTypeIPv4,
+		Ports:       slicePorts,
+		Endpoints:   []discov1.Endpoint{{Addresses: []string{ip}}},
+	}
+}
+
+// countingDial counts dial-function calls per target address while delegating
+// to the real retrying dialer, so tests observe both rotation (one call per
+// endpoint tried) and real retry behavior inside each call.
+type countingDial struct {
+	real  kedanet.DialContextFunc
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func newCountingDial(connectTimeout time.Duration) *countingDial {
+	return &countingDial{
+		real:  kedanet.DialContextWithRetry(connectTimeout),
+		calls: map[string]int{},
+	}
+}
+
+func (d *countingDial) dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	d.mu.Lock()
+	d.calls[addr]++
+	d.mu.Unlock()
+	return d.real(ctx, network, addr)
+}
+
+func (d *countingDial) callsTo(addr string) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.calls[addr]
+}
+
+// TestProxyHandler_StaleEndpointRedialsUntilRequestTimeout emulates a pod that
+// is gone while its endpoint is still in the EndpointSlices, with no alternate
+// available: the interceptor redials the same dead pod for the whole request
+// budget and then gives up with 504. The redialing happens inside a single
+// dial call — every 50ms, i.e. ~8 attempts in this test's 400ms budget and
+// ~1200 at the default 60s (the exact count is verified in pkg/net tests).
+func TestProxyHandler_StaleEndpointRedialsUntilRequestTimeout(t *testing.T) {
+	dial := newCountingDial(500 * time.Millisecond)
+	h := newProxyTestHarness(t, harnessConfig{
+		directPodRouting: true,
+		retryCount:       1,
+		requestTimeout:   400 * time.Millisecond,
+		noDialOverride:   true,
+		dialFunc:         dial.dial,
+	})
+
+	deadPort := closedPort(t)
+	deadHost := net.JoinHostPort("127.0.0.1", strconv.Itoa(int(deadPort)))
+	// The stale snapshot: the dead pod is the only ready endpoint.
+	h.ReadyCache.Update(testServiceKey, []*discov1.EndpointSlice{
+		endpointSliceForPorts("127.0.0.1", deadPort),
+	})
+
+	start := time.Now()
+	resp := h.doRequest(t, http.MethodGet, "/", testHost)
+	defer resp.Body.Close()
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusGatewayTimeout {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusGatewayTimeout)
+	}
+	// With no alternate endpoint there is nothing to rotate to, so the legacy
+	// unbounded redial runs until the request timeout — it must not fail fast.
+	if elapsed < 350*time.Millisecond {
+		t.Errorf("elapsed %v; expected redialing until the 400ms request timeout", elapsed)
+	}
+	if got := dial.callsTo(deadHost); got != 1 {
+		t.Errorf("dial calls to dead pod = %d, want 1 (redialing happens inside the call)", got)
+	}
+}
+
+// TestProxyHandler_StaleEndpointRotatesToAlternate emulates the scale-down
+// race through the full handler chain: the snapshot still contains the dead
+// pod, the request picks it, the bounded dial fails fast, and the request is
+// retried against the live alternate endpoint — the client sees a 200 instead
+// of a 502/504.
+func TestProxyHandler_StaleEndpointRotatesToAlternate(t *testing.T) {
+	dial := newCountingDial(500 * time.Millisecond)
+	h := newProxyTestHarness(t, harnessConfig{
+		directPodRouting: true,
+		retryCount:       1,
+		requestTimeout:   5 * time.Second,
+		noDialOverride:   true,
+		dialFunc:         dial.dial,
+	})
+
+	deadPort := closedPort(t)
+	deadHost := net.JoinHostPort("127.0.0.1", strconv.Itoa(int(deadPort)))
+	_, livePortStr, err := net.SplitHostPort(h.Backend.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to parse backend address: %v", err)
+	}
+	livePort, err := strconv.Atoi(livePortStr)
+	if err != nil {
+		t.Fatalf("failed to parse backend port: %v", err)
+	}
+	liveHost := h.Backend.Listener.Addr().String()
+
+	// The stale snapshot contains both the dead pod and the live one. Which
+	// one is picked first is random, so send several requests: every response
+	// must be 200, including from requests that started on the dead pod (the
+	// dead pod cannot serve, so those 200s prove the rotation).
+	h.ReadyCache.Update(testServiceKey, []*discov1.EndpointSlice{
+		endpointSliceForPorts("127.0.0.1", deadPort, int32(livePort)),
+	})
+
+	for range 30 {
+		resp := h.doRequest(t, http.MethodGet, "/", testHost)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d — a request that picked the dead pod must fail over", resp.StatusCode, http.StatusOK)
+		}
+		_ = resp.Body.Close()
+	}
+
+	if got := dial.callsTo(deadHost); got < 1 {
+		t.Error("the dead pod was never picked first in 30 requests; cannot prove rotation")
+	}
+	if got := dial.callsTo(liveHost); got < 1 {
+		t.Error("the live alternate was never dialed")
+	}
+}
+
 // proxyTestHarness provides a configured proxy handler for testing.
 type proxyTestHarness struct {
 	Handler    http.Handler
@@ -290,6 +457,11 @@ type harnessConfig struct {
 	tlsEnabled            bool
 	tracingEnabled        bool
 	useBlockingQueue      bool
+	directPodRouting      bool
+	retryCount            int
+	requestTimeout        time.Duration
+	noDialOverride        bool
+	dialFunc              kedanet.DialContextFunc
 }
 
 // newProxyTestHarness creates a test harness with the full handler chain.
@@ -368,6 +540,14 @@ func newProxyTestHarness(t *testing.T, cfg harnessConfig) *proxyTestHarness {
 	if cfg.tlsEnabled {
 		tlsCfg = &tls.Config{InsecureSkipVerify: true}
 	}
+	requestTimeout := cfg.requestTimeout
+	if requestTimeout == 0 {
+		requestTimeout = 60 * time.Second
+	}
+	dialAddressOverride := backend.Listener.Addr().String()
+	if cfg.noDialOverride {
+		dialAddressOverride = ""
+	}
 	handler := BuildProxyHandler(&ProxyHandlerConfig{
 		Logger:       logr.Discard(),
 		Queue:        fakeQueue,
@@ -377,15 +557,20 @@ func newProxyTestHarness(t *testing.T, cfg harnessConfig) *proxyTestHarness {
 		Timeouts: config.Timeouts{
 			Connect:        500 * time.Millisecond,
 			Readiness:      5 * time.Second,
-			Request:        60 * time.Second,
+			Request:        requestTimeout,
 			ResponseHeader: 5 * time.Second,
 		},
-		Serving:             config.Serving{EnableColdStartHeader: cfg.enableColdStartHeader},
+		Serving: config.Serving{
+			EnableColdStartHeader: cfg.enableColdStartHeader,
+			DirectPodRouting:      cfg.directPodRouting,
+			RetryCount:            cfg.retryCount,
+		},
 		ServingTLS:          tlsCfg,
 		OutboundTLS:         tlsCfg,
 		Tracing:             config.Tracing{Enabled: cfg.tracingEnabled},
 		Instruments:         metrics.NewNoopInstruments(),
-		dialAddressOverride: backend.Listener.Addr().String(),
+		dialAddressOverride: dialAddressOverride,
+		dialFuncOverride:    cfg.dialFunc,
 	})
 
 	return &proxyTestHarness{

--- a/pkg/k8s/ready_endpoints_cache.go
+++ b/pkg/k8s/ready_endpoints_cache.go
@@ -129,10 +129,35 @@ func (c *ReadyEndpointsCache) WaitForReady(ctx context.Context, serviceKey, port
 	}
 }
 
+// PickEndpoint returns a random ready endpoint host ("ip:port") for portName,
+// excluding any hosts in exclude. It returns "" when no untried candidate
+// remains or the service has no ready endpoints.
+func (c *ReadyEndpointsCache) PickEndpoint(serviceKey, portName string, exclude map[string]struct{}) string {
+	if v, ok := c.states.Load(serviceKey); ok {
+		return pickHostExcluding(v.(*serviceState), portName, exclude)
+	}
+	return ""
+}
+
 // pickHost selects a random ready pod for portName from state and returns its
 // "ip:port" host string. Returns "" if portName has no candidates.
 func pickHost(state *serviceState, portName string) string {
+	return pickHostExcluding(state, portName, nil)
+}
+
+// pickHostExcluding is pickHost with an exclusion set, used to select an
+// alternate endpoint for retries.
+func pickHostExcluding(state *serviceState, portName string, exclude map[string]struct{}) string {
 	eps := state.candidates[portName]
+	if len(exclude) > 0 {
+		filtered := make([]endpoint, 0, len(eps))
+		for _, ep := range eps {
+			if _, skip := exclude[net.JoinHostPort(ep.ip, strconv.Itoa(int(ep.port)))]; !skip {
+				filtered = append(filtered, ep)
+			}
+		}
+		eps = filtered
+	}
 	if len(eps) == 0 {
 		return ""
 	}

--- a/pkg/k8s/ready_endpoints_cache_test.go
+++ b/pkg/k8s/ready_endpoints_cache_test.go
@@ -572,3 +572,65 @@ func newReadySlice(namespace, service string, addresses ...string) *discov1.Endp
 		Endpoints:   endpoints,
 	}
 }
+
+// --- PickEndpoint tests ---
+
+func TestPickEndpoint(t *testing.T) {
+	const key = "testns/testsvc"
+	port := int32(8080)
+
+	newCache := func() *ReadyEndpointsCache {
+		cache := NewReadyEndpointsCache(logr.Discard())
+		cache.Update(key, []*discov1.EndpointSlice{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testsvc-slice",
+					Namespace: "testns",
+					Labels:    map[string]string{discov1.LabelServiceName: "testsvc"},
+				},
+				AddressType: discov1.AddressTypeIPv4,
+				Ports:       []discov1.EndpointPort{{Port: &port}},
+				Endpoints: []discov1.Endpoint{
+					{Addresses: []string{"1.2.3.4"}},
+					{Addresses: []string{"5.6.7.8"}},
+				},
+			},
+		})
+		return cache
+	}
+
+	t.Run("picks a ready endpoint", func(t *testing.T) {
+		r := require.New(t)
+		host := newCache().PickEndpoint(key, "", nil)
+		r.Contains([]string{"1.2.3.4:8080", "5.6.7.8:8080"}, host)
+	})
+
+	t.Run("excludes tried hosts", func(t *testing.T) {
+		r := require.New(t)
+		cache := newCache()
+		// With one endpoint excluded, every pick must return the other one.
+		for range 20 {
+			host := cache.PickEndpoint(key, "", map[string]struct{}{"1.2.3.4:8080": {}})
+			r.Equal("5.6.7.8:8080", host)
+		}
+	})
+
+	t.Run("returns empty when all endpoints are excluded", func(t *testing.T) {
+		r := require.New(t)
+		host := newCache().PickEndpoint(key, "", map[string]struct{}{
+			"1.2.3.4:8080": {},
+			"5.6.7.8:8080": {},
+		})
+		r.Empty(host)
+	})
+
+	t.Run("returns empty for unknown service", func(t *testing.T) {
+		r := require.New(t)
+		r.Empty(newCache().PickEndpoint("testns/unknown", "", nil))
+	})
+
+	t.Run("returns empty for unknown port name", func(t *testing.T) {
+		r := require.New(t)
+		r.Empty(newCache().PickEndpoint(key, "no-such-port", nil))
+	})
+}

--- a/pkg/net/dial_context.go
+++ b/pkg/net/dial_context.go
@@ -20,12 +20,53 @@ const (
 	maxRetryDuration = 1 * time.Minute
 )
 
+// DialAttemptsExhaustedError is returned when a dial bounded by
+// ContextWithMaxDialAttempts spends its per-endpoint attempt budget before the
+// context deadline. It signals that failing over to another endpoint may
+// succeed where redialing this one did not.
+type DialAttemptsExhaustedError struct {
+	Addr     string
+	Attempts int
+	Err      error
+}
+
+func (e *DialAttemptsExhaustedError) Error() string {
+	return fmt.Sprintf("dial %s: %d attempt(s) exhausted: %v", e.Addr, e.Attempts, e.Err)
+}
+
+func (e *DialAttemptsExhaustedError) Unwrap() error { return e.Err }
+
+type dialContextKey int
+
+const ckMaxDialAttempts dialContextKey = iota
+
+// ContextWithMaxDialAttempts bounds how many attempts DialContextWithRetry
+// makes for a single endpoint before giving up with a
+// *DialAttemptsExhaustedError. A value <= 0 (or no value at all) keeps the
+// default behavior: retry until the context is cancelled or its deadline
+// expires.
+func ContextWithMaxDialAttempts(ctx context.Context, maxAttempts int) context.Context {
+	return context.WithValue(ctx, ckMaxDialAttempts, maxAttempts)
+}
+
+func maxDialAttemptsFromContext(ctx context.Context) int {
+	cv, _ := ctx.Value(ckMaxDialAttempts).(int)
+	return cv
+}
+
 // DialContextWithRetry returns a DialContextFunc that retries failed dials at a
 // fixed interval until the parent context is cancelled or its deadline expires.
 // When the parent context has no deadline, retries are bounded by maxRetryDuration.
+// When the context carries a max-attempts bound (see ContextWithMaxDialAttempts),
+// the dial gives up after that many failed attempts instead.
 func DialContextWithRetry(connectTimeout time.Duration) DialContextFunc {
 	dialer := net.Dialer{Timeout: connectTimeout}
+	return dialContextWithRetry(dialer.DialContext)
+}
 
+// dialContextWithRetry is DialContextWithRetry with the underlying dial
+// function injected, so tests can count attempts and control failures.
+func dialContextWithRetry(dial DialContextFunc) DialContextFunc {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		// Safety net: prevent infinite retries when no request deadline is set.
 		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
@@ -34,25 +75,31 @@ func DialContextWithRetry(connectTimeout time.Duration) DialContextFunc {
 			defer cancel()
 		}
 
+		maxAttempts := maxDialAttemptsFromContext(ctx)
 		start := time.Now()
 
-		conn, lastErr := dialer.DialContext(ctx, network, addr)
+		conn, lastErr := dial(ctx, network, addr)
 		if lastErr == nil {
 			return conn, nil
 		}
 
+		attempts := 1
 		ticker := time.NewTicker(retryInterval)
 		defer ticker.Stop()
 
 		for {
+			if maxAttempts > 0 && attempts >= maxAttempts {
+				return nil, &DialAttemptsExhaustedError{Addr: addr, Attempts: attempts, Err: lastErr}
+			}
 			select {
 			case <-ctx.Done():
 				return nil, fmt.Errorf("retry dial %s after %.2fs: %w", addr, time.Since(start).Seconds(), errors.Join(ctx.Err(), lastErr))
 			case <-ticker.C:
-				conn, lastErr = dialer.DialContext(ctx, network, addr)
+				conn, lastErr = dial(ctx, network, addr)
 				if lastErr == nil {
 					return conn, nil
 				}
+				attempts++
 			}
 		}
 	}

--- a/pkg/net/dial_context_test.go
+++ b/pkg/net/dial_context_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -150,4 +151,147 @@ func TestDialContextWithRetry_WrapsError(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("expected context.DeadlineExceeded in error chain, got: %v", err)
 	}
+}
+
+func TestDialContextWithRetry_StopsAtMaxAttempts(t *testing.T) {
+	dialRetry := DialContextWithRetry(10 * time.Millisecond)
+
+	// The parent context has no deadline: without the attempt bound the dial
+	// would retry for maxRetryDuration.
+	ctx := ContextWithMaxDialAttempts(t.Context(), 3)
+
+	start := time.Now()
+	_, err := dialRetry(ctx, "tcp", getUnreachableAddr(t))
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var exhausted *DialAttemptsExhaustedError
+	if !errors.As(err, &exhausted) {
+		t.Fatalf("expected *DialAttemptsExhaustedError, got %T: %v", err, err)
+	}
+	if exhausted.Attempts != 3 {
+		t.Errorf("attempts = %d, want 3", exhausted.Attempts)
+	}
+	// The underlying dial error should stay unwrappable.
+	var opErr *net.OpError
+	if !errors.As(err, &opErr) {
+		t.Errorf("expected wrapped *net.OpError, got %T: %v", err, err)
+	}
+	// 3 attempts at a 50ms interval take ~100ms, far under the 1-minute cap.
+	if elapsed > 10*time.Second {
+		t.Errorf("elapsed %v; bounded dial should give up quickly", elapsed)
+	}
+}
+
+func TestDialContextWithRetry_MaxAttemptsOneFailsImmediately(t *testing.T) {
+	dialRetry := DialContextWithRetry(10 * time.Millisecond)
+	ctx := ContextWithMaxDialAttempts(t.Context(), 1)
+
+	start := time.Now()
+	_, err := dialRetry(ctx, "tcp", getUnreachableAddr(t))
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var exhausted *DialAttemptsExhaustedError
+	if !errors.As(err, &exhausted) {
+		t.Fatalf("expected *DialAttemptsExhaustedError, got %T: %v", err, err)
+	}
+	if exhausted.Attempts != 1 {
+		t.Errorf("attempts = %d, want 1", exhausted.Attempts)
+	}
+	if elapsed >= 50*time.Millisecond {
+		t.Errorf("elapsed %v; should fail before the first retry interval", elapsed)
+	}
+}
+
+func TestDialContextWithRetry_BoundedDialSucceedsWithinBudget(t *testing.T) {
+	// A bounded dial keeps retrying within its budget when the target comes up.
+	addr := getUnreachableAddr(t)
+
+	ready := make(chan struct{})
+	go func() {
+		time.Sleep(120 * time.Millisecond)
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			return
+		}
+		close(ready)
+		conn, err := ln.Accept()
+		if err != nil {
+			_ = ln.Close()
+			return
+		}
+		_ = conn.Close()
+		_ = ln.Close()
+	}()
+
+	dialRetry := DialContextWithRetry(50 * time.Millisecond)
+	ctx := ContextWithMaxDialAttempts(t.Context(), 10)
+
+	conn, err := dialRetry(ctx, "tcp", addr)
+	if err != nil {
+		t.Fatalf("expected success within attempt budget: %v", err)
+	}
+	_ = conn.Close()
+	<-ready
+}
+
+// TestDialContextWithRetry_AttemptCountUntilCap verifies the legacy unbounded
+// behavior precisely: with no request deadline, a dead endpoint is redialed
+// every 50ms until the 1-minute safety cap — i.e. ~1200 attempts before giving
+// up. synctest's fake clock runs the full minute instantly.
+func TestDialContextWithRetry_AttemptCountUntilCap(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		attempts := 0
+		countingDial := func(context.Context, string, string) (net.Conn, error) {
+			attempts++
+			return nil, errors.New("connection refused")
+		}
+		dialRetry := dialContextWithRetry(countingDial)
+
+		// No deadline on the parent context: retries are bounded only by
+		// maxRetryDuration (1 minute).
+		_, err := dialRetry(context.Background(), "tcp", "10.0.0.1:8080")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("expected context.DeadlineExceeded in error chain, got: %v", err)
+		}
+
+		// 1 initial attempt + one per 50ms tick over 60s = ~1200. The final
+		// tick races the deadline timer, so allow an off-by-one.
+		if attempts < 1199 || attempts > 1201 {
+			t.Errorf("attempts = %d, want ~1200 (20/s for 60s)", attempts)
+		}
+	})
+}
+
+// TestDialContextWithRetry_BoundedAttemptCount verifies the per-endpoint bound
+// used for endpoint failover: exactly maxAttempts dials, then
+// DialAttemptsExhaustedError.
+func TestDialContextWithRetry_BoundedAttemptCount(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		attempts := 0
+		countingDial := func(context.Context, string, string) (net.Conn, error) {
+			attempts++
+			return nil, errors.New("connection refused")
+		}
+		dialRetry := dialContextWithRetry(countingDial)
+
+		ctx := ContextWithMaxDialAttempts(context.Background(), 3)
+		_, err := dialRetry(ctx, "tcp", "10.0.0.1:8080")
+
+		var exhausted *DialAttemptsExhaustedError
+		if !errors.As(err, &exhausted) {
+			t.Fatalf("expected *DialAttemptsExhaustedError, got %T: %v", err, err)
+		}
+		if attempts != 3 {
+			t.Errorf("attempts = %d, want exactly 3", attempts)
+		}
+	})
 }

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -18,6 +18,7 @@ const (
 	ckIR
 	ckUpstreamServerName
 	ckUpstreamPortName
+	ckEndpointPicker
 )
 
 func ContextWithLogger(ctx context.Context, logger logr.Logger) context.Context {
@@ -75,5 +76,23 @@ func ContextWithUpstreamPortName(ctx context.Context, portName string) context.C
 
 func UpstreamPortNameFromContext(ctx context.Context) string {
 	cv, _ := ctx.Value(ckUpstreamPortName).(string)
+	return cv
+}
+
+// EndpointPickerFunc returns the host ("ip:port") of a ready endpoint to try,
+// excluding any hosts in tried. It returns "" when no untried endpoint remains.
+// Implementations read the live endpoint snapshot at call time, so a pod that
+// disappeared since the request started is never returned.
+type EndpointPickerFunc func(tried map[string]struct{}) string
+
+// ContextWithEndpointPicker stores an EndpointPickerFunc so the upstream
+// handler can retry a request against an alternate endpoint when the picked
+// one fails at connect time.
+func ContextWithEndpointPicker(ctx context.Context, picker EndpointPickerFunc) context.Context {
+	return context.WithValue(ctx, ckEndpointPicker, picker)
+}
+
+func EndpointPickerFromContext(ctx context.Context) EndpointPickerFunc {
+	cv, _ := ctx.Value(ckEndpointPicker).(EndpointPickerFunc)
 	return cv
 }


### PR DESCRIPTION
With direct-pod routing, the interceptor commits to a single pod IP per request. When that pod disappears between the EndpointSlice snapshot and the dial (the steady state of scale-down) the dial retry loop redialed the same dead address until the request budget expired (up to 1 minute at defaults, ~1200 attempts). Under ClusterIP routing each redial was re-NATed to a possibly live endpoint, so the loop was effective; with pod IPs it is a no-op for dead pods.

On connect failure the request now fails over to an alternate ready endpoint from the live snapshot:

- Per-endpoint dial attempts are bounded (3) so a dead endpoint fails fast instead of soaking the whole request budget. When the snapshot has no alternate, the first attempt keeps the legacy context-bounded redial, preserving single-replica cold-start behavior.
- Retries are limited to connect failures and to requests without a body, so a retry can never replay a request the backend has seen.
- Bounded by KEDA_HTTP_RETRY_COUNT (default 1, 0 disables).
- Adds the interceptor.request.retries metric (route_name, route_namespace, outcome).

Refs #1734

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [ ] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

Fixes #
