### PR TITLE
feat: add SLSA Build L2 provenance attestations for release images

### DIFF
--- a/.github/workflows/build_canary.yml
+++ b/.github/workflows/build_canary.yml
@@ -15,6 +15,7 @@ jobs:
       contents: read
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
+      attestations: write # needed for SLSA Build L2 provenance attestations
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -37,6 +38,36 @@ jobs:
         run: make publish
         env:
           VERSION: canary
+
+      - name: Parse image digests
+        id: digests
+        run: |
+          for component in operator interceptor scaler; do
+            ref=$(cat "${component}.digest")
+            echo "${component}_name=${ref%%@*}" >> "$GITHUB_OUTPUT"
+            echo "${component}_digest=${ref##*@}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Attest operator image provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ steps.digests.outputs.operator_name }}
+          subject-digest: ${{ steps.digests.outputs.operator_digest }}
+          push-to-registry: true
+
+      - name: Attest interceptor image provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ steps.digests.outputs.interceptor_name }}
+          subject-digest: ${{ steps.digests.outputs.interceptor_digest }}
+          push-to-registry: true
+
+      - name: Attest scaler image provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ steps.digests.outputs.scaler_name }}
+          subject-digest: ${{ steps.digests.outputs.scaler_digest }}
+          push-to-registry: true
 
       # https://github.com/sigstore/cosign-installer
       - name: Install Cosign

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -14,6 +14,7 @@ jobs:
       contents: write
       packages: write
       id-token: write # needed for signing images and release manifests with GitHub OIDC Token
+      attestations: write # needed for SLSA Build L2 provenance attestations
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -41,6 +42,36 @@ jobs:
         run: make publish
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
+
+      - name: Parse image digests
+        id: digests
+        run: |
+          for component in operator interceptor scaler; do
+            ref=$(cat "${component}.digest")
+            echo "${component}_name=${ref%%@*}" >> "$GITHUB_OUTPUT"
+            echo "${component}_digest=${ref##*@}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Attest operator image provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ steps.digests.outputs.operator_name }}
+          subject-digest: ${{ steps.digests.outputs.operator_digest }}
+          push-to-registry: true
+
+      - name: Attest interceptor image provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ steps.digests.outputs.interceptor_name }}
+          subject-digest: ${{ steps.digests.outputs.interceptor_digest }}
+          push-to-registry: true
+
+      - name: Attest scaler image provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ steps.digests.outputs.scaler_name }}
+          subject-digest: ${{ steps.digests.outputs.scaler_digest }}
+          push-to-registry: true
 
       - name: Release Deployment YAML file
         run: make release

--- a/.gitignore
+++ b/.gitignore
@@ -359,3 +359,6 @@ admin/Cargo.lock
 *.test
 
 .lycheecache
+
+# ko publish digest refs written by Makefile publish-* targets (CI artifacts)
+*.digest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### New
 
+- **General**: Add SLSA Build Level 2 provenance attestations for release and canary container images via `actions/attest-build-provenance`. Attestations are pushed to GHCR alongside images and can be verified with `gh attestation verify oci://ghcr.io/kedacore/http-add-on-operator:<version> --owner kedacore` ([#1604](https://github.com/kedacore/http-add-on/issues/1604))
 - **General**: Add `staticRoutes` to InterceptorRoute for defining routes that should not trigger autoscaling, such as health checks, redirects, and maintenance pages. Supports `responseMode: WhenUnavailable` (forward to backend when ready, static response otherwise) and `responseMode: Always` (always serve static response) ([#1622](https://github.com/kedacore/http-add-on/issues/1622))
 - **Interceptor**: Add `KEDA_HTTP_DIRECT_POD_ROUTING` environment variable (`true` | `false`, default `true`). When enabled, the interceptor routes requests directly to a ready pod IP instead of through the Service ClusterIP, bypassing kube-proxy and other Service-layer features (Service-level NetworkPolicy, session affinity, topology-aware routing). ([#1473](https://github.com/kedacore/http-add-on/issues/1473))
 - **Interceptor**: Add `KEDA_HTTP_TLS_CA_DIRS` environment variable to trust custom CA bundles for outbound backend connections. ([#1728](https://github.com/kedacore/http-add-on/issues/1728))

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # Variables                                      #
 ##################################################
 SHELL          = /bin/bash
+.SHELLFLAGS    = -eo pipefail -c # fail on error and pipeline failures
 .DEFAULT_GOAL := ko-build
 
 IMAGE_REGISTRY ?= ghcr.io
@@ -252,13 +253,13 @@ undeploy: $(KUSTOMIZE)
 
 publish-operator:
 	# --bare preserves image names like ghcr.io/kedacore/http-add-on-operator
-	KO_DOCKER_REPO=$(IMAGE_OPERATOR) ko build --bare --platform=$(KO_RELEASE_PLATFORMS) --tags=$(VERSION),$(GIT_COMMIT_SHORT) ./operator
+	KO_DOCKER_REPO=$(IMAGE_OPERATOR) ko build --bare --platform=$(KO_RELEASE_PLATFORMS) --tags=$(VERSION),$(GIT_COMMIT_SHORT) ./operator | tee operator.digest
 
 publish-interceptor:
-	KO_DOCKER_REPO=$(IMAGE_INTERCEPTOR) ko build --bare --platform=$(KO_RELEASE_PLATFORMS) --tags=$(VERSION),$(GIT_COMMIT_SHORT) ./interceptor
+	KO_DOCKER_REPO=$(IMAGE_INTERCEPTOR) ko build --bare --platform=$(KO_RELEASE_PLATFORMS) --tags=$(VERSION),$(GIT_COMMIT_SHORT) ./interceptor | tee interceptor.digest
 
 publish-scaler:
-	KO_DOCKER_REPO=$(IMAGE_SCALER) ko build --bare --platform=$(KO_RELEASE_PLATFORMS) --tags=$(VERSION),$(GIT_COMMIT_SHORT) ./scaler
+	KO_DOCKER_REPO=$(IMAGE_SCALER) ko build --bare --platform=$(KO_RELEASE_PLATFORMS) --tags=$(VERSION),$(GIT_COMMIT_SHORT) ./scaler | tee scaler.digest
 
 publish: publish-operator publish-interceptor publish-scaler
 


### PR DESCRIPTION
Adds `actions/attest-build-provenance` after each `ko build` in the release and canary workflows, generating signed provenance for the three container images (operator, interceptor, scaler).

### Changes
- Makefile: pipe each `publish-*` ko build through `tee *.digest` to capture image digest refs; add `.SHELLFLAGS = -eo pipefail -c` to catch pipeline failures
- build_release.yml: add `attestations: write` permission, parse digest files, attest each image
- build_canary.yml: same attestation steps as release workflow
- .gitignore: exclude `*.digest` build artifacts



### Why L2 and not L3

L3 (PR #1649) requires splitting the workflow into isolated reusable workflows — much higher complexity. L2 is achieved here by running `actions/attest-build-provenance` in the same hosted runner job, which satisfies:
- **L1**: provenance document exists and is distributed
- **L2**: build runs on a hosted platform (GitHub Actions) and provenance is cryptographically signed via GitHub's OIDC/Sigstore

We can add L3 when the other PR is ready but this is a quick win.

### Verification

After a release:

```bash
gh attestation verify oci://ghcr.io/kedacore/http-add-on-operator:0.16.0 --owner kedacore
gh attestation verify oci://ghcr.io/kedacore/http-add-on-interceptor:0.16.0 --owner kedacore
gh attestation verify oci://ghcr.io/kedacore/http-add-on-scaler:0.16.0 --owner kedacore
```

After a push to main (canary):

```bash
gh attestation verify oci://ghcr.io/kedacore/http-add-on-operator:canary --owner kedacore
gh attestation verify oci://ghcr.io/kedacore/http-add-on-interceptor:canary --owner kedacore
gh attestation verify oci://ghcr.io/kedacore/http-add-on-scaler:canary --owner kedacore
```

### Test plan

1. Verify attestations are visible in GHCR package UI under "Attestations" after a tagged release
2. Run `gh attestation verify` for each image post-release
3. Verify canary attestations after a push to main


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed (`README.md`, [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))
	- not needed IMO.

Fixes #1604