### PR TITLE
ci: add artifact-metadata:write permission

### DIFF
--- a/.github/workflows/build_canary.yml
+++ b/.github/workflows/build_canary.yml
@@ -16,6 +16,7 @@ jobs:
       packages: write
       id-token: write # needed for signing the images with GitHub OIDC Token
       attestations: write # needed for SLSA Build L2 provenance attestations
+      artifact-metadata: write # needed for org-level linked artifacts dashboard
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -15,6 +15,7 @@ jobs:
       packages: write
       id-token: write # needed for signing images and release manifests with GitHub OIDC Token
       attestations: write # needed for SLSA Build L2 provenance attestations
+      artifact-metadata: write # needed for org-level linked artifacts dashboard
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
The `actions/attest-build-provenance` action warns about a missing storage record when this permission is absent. Adding it populates the org-level linked artifacts dashboard and silences the warning.

Related to #1743 
Relevant CI log https://github.com/kedacore/http-add-on/actions/runs/31171566158/job/92844303912#step:8:28 

Seems like artifacts will then appear in this dashboard: https://github.com/orgs/kedacore/artifacts

### Changes
- Add `artifact-metadata: write` to build_release.yml
- Add `artifact-metadata: write` to build_canary.yml


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

