### PR TITLE
test: harden e2e test pods and helpers for restricted PSS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ e2e-deps-jaeger: $(HELM)
 	$(HELM) repo add jaegertracing https://jaegertracing.github.io/helm-charts --force-update
 	$(call helm-retry,$(HELM) upgrade --install jaeger jaegertracing/jaeger \
 		--namespace jaeger --create-namespace \
+		-f test/fixtures/jaeger-values.yaml \
 		--version $(JAEGER_VERSION) --wait --timeout 5m)
 
 e2e-deps-keda: $(HELM)

--- a/test/fixtures/jaeger-values.yaml
+++ b/test/fixtures/jaeger-values.yaml
@@ -1,0 +1,14 @@
+# Harden for restricted PodSecurity / OpenShift SCC.
+# Null out the chart's pinned UID so OpenShift can assign one from the namespace range.
+jaeger:
+  podSecurityContext:
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/test/fixtures/otel-values.yaml
+++ b/test/fixtures/otel-values.yaml
@@ -1,5 +1,14 @@
 # Chart has no default mode.
 mode: deployment
+# OpenShift enforces the "restricted" SCC — the chart's default empty
+# securityContext fails PodSecurity admission.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 # Prometheus exporter requires the contrib image (not available in core).
 image:
   repository: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib"

--- a/test/helpers/app.go
+++ b/test/helpers/app.go
@@ -156,6 +156,13 @@ func (a *TestApp) Resources() []k8s.Object {
 						VolumeMounts:   volumeMounts,
 						LivenessProbe:  a.probe(5, probeScheme),
 						ReadinessProbe: a.probe(1, probeScheme),
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.To(false),
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+							RunAsNonRoot:             ptr.To(true),
+							RunAsUser:                ptr.To(int64(65532)),
+							SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+						},
 					}},
 				},
 			},

--- a/test/helpers/deployment.go
+++ b/test/helpers/deployment.go
@@ -10,6 +10,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/e2e-framework/klient"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/wait"
@@ -48,7 +50,7 @@ func PatchDeployment(testenv env.Environment, namespace, name string, opts ...Pa
 				return ctx, err
 			}
 		}
-		if err := client.Resources().Update(ctx, patched); err != nil {
+		if err := patchDeployment(ctx, client, original, patched); err != nil {
 			return ctx, fmt.Errorf("failed to patch deployment %s/%s: %w", namespace, name, err)
 		}
 
@@ -72,12 +74,23 @@ func PatchDeployment(testenv env.Environment, namespace, name string, opts ...Pa
 		if err := client.Resources().Get(ctx, name, namespace, current); err != nil {
 			return ctx, fmt.Errorf("failed to get deployment for restore: %w", err)
 		}
-		current.Spec.Template.Spec = *originalSpec
-		if err := client.Resources().Update(ctx, current); err != nil {
+		restored := current.DeepCopy()
+		restored.Spec.Template.Spec = *originalSpec
+		if err := patchDeployment(ctx, client, current, restored); err != nil {
 			return ctx, fmt.Errorf("failed to restore deployment: %w", err)
 		}
 		return ctx, nil
 	})
+}
+
+// patchDeployment applies the diff between original and modified as a merge patch.
+// Avoids resourceVersion conflicts with concurrent reconcilers (e.g. KEDA ScaledObject).
+func patchDeployment(ctx context.Context, client klient.Client, original, modified *appsv1.Deployment) error {
+	data, err := ctrlclient.MergeFrom(original).Data(modified)
+	if err != nil {
+		return fmt.Errorf("failed to compute patch: %w", err)
+	}
+	return client.Resources().Patch(ctx, modified, k8s.Patch{PatchType: types.MergePatchType, Data: data})
 }
 
 // WithContainerPort appends a container port to all containers in the deployment.
@@ -198,17 +211,18 @@ func (f *Framework) RestartInterceptor() error {
 		return fmt.Errorf("getting interceptor deployment: %w", err)
 	}
 
-	if dep.Spec.Template.Annotations == nil {
-		dep.Spec.Template.Annotations = make(map[string]string)
+	restarted := dep.DeepCopy()
+	if restarted.Spec.Template.Annotations == nil {
+		restarted.Spec.Template.Annotations = make(map[string]string)
 	}
-	dep.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+	restarted.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 
-	if err := f.client.Resources().Update(f.ctx, dep); err != nil {
+	if err := patchDeployment(f.ctx, f.client, dep, restarted); err != nil {
 		return fmt.Errorf("updating interceptor deployment: %w", err)
 	}
 
 	if err := wait.For(
-		conditions.New(f.client.Resources()).ResourceMatch(dep, deploymentRolledOut),
+		conditions.New(f.client.Resources()).ResourceMatch(restarted, deploymentRolledOut),
 		wait.WithTimeout(defaultWaitTimeout),
 	); err != nil {
 		return fmt.Errorf("interceptor deployment did not recover: %w", err)

--- a/test/helpers/proxy.go
+++ b/test/helpers/proxy.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/env"
@@ -76,6 +77,13 @@ func registerInterceptorProxy(testenv env.Environment, interceptorPort int) {
 							},
 						},
 						PeriodSeconds: 1,
+					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						RunAsNonRoot:             ptr.To(true),
+						RunAsUser:                ptr.To(int64(65532)),
+						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 					},
 				}},
 			},


### PR DESCRIPTION
Improve the compatibility against clusters using PSS restricted or the OpenShift equivalent, although this requires further modifications.

SecurityContext is set where missing, we also set an explicit RunAsUser in case the image would use root so that everything runs e.g. in kind in CI.
This breaks in OpenShift though so users testing this in OpenShift would need to remove the RunAsUser overwrites so that OpenShift can choose a user id in the namespaces range.

We unset the runAsUser for the podSecurityContext of the jaeger chart to reduce the changes one would have to make to run this on OpenShift.




### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

