### PR TITLE
chore: configure Renovate groups and monthly schedule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,7 @@
     "config:best-practices",
     "customManagers:githubActionsVersions",
     "customManagers:makefileVersions",
-    "schedule:weekly",
+    "schedule:monthly",
     ":gitSignOff",
     ":prHourlyLimitNone",
   ],
@@ -65,8 +65,19 @@
     },
     {
       matchManagers: ["custom.regex"],
-      matchFileNames: ["Makefile", ".github/workflows/e2e-tests.yaml"],
+      matchFileNames: [
+        ".github/workflows/benchmark-tests.yaml",
+        ".github/workflows/e2e-tests.yaml",
+        ".github/workflows/tests.yaml",
+        "Makefile",
+      ],
       groupName: "Infra Dependencies",
+    },
+    {
+      matchManagers: ["custom.regex"],
+      matchDatasources: ["docker"],
+      matchFileNames: ["test/helpers/*.go"],
+      groupName: "E2E Test Images",
     },
     {
       matchManagers: ["pre-commit"],
@@ -81,7 +92,10 @@
     // Disable digest pinning for kindest/node as we don't need it and as it causes renovate update failures when not captured.
     {
       matchManagers: ["custom.regex"],
-      matchFileNames: [".github/workflows/e2e-tests.yaml"],
+      matchFileNames: [
+        ".github/workflows/benchmark-tests.yaml",
+        ".github/workflows/e2e-tests.yaml",
+      ],
       matchDepNames: ["/kindest\\/node/"],
       pinDigests: false,
     },


### PR DESCRIPTION
Run routine dependency updates monthly and group related changes by where they are used, reducing separate Renovate pull requests while keeping production and example images independent.

benchmark-tests.yaml pins helm/helm and kindest/node the same way e2e-tests.yaml does, but was added after the corresponding renovate rules and never got included in them.
Makefile and CI files contained 


Changing the renovate schedule to monthly makes IMO sense as security updates are not affected and as 52 update cycles per year with way fewer releases is IMO too much.


### Changes
- Group infrastructure dependencies from build and test configuration
- Group Docker images used by end-to-end test helpers
- Disable kindest/node digest pinning in benchmark tests
- Change the Renovate schedule from weekly to monthly


### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

