### PR TITLE
chore: exclude slack link from link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -7,4 +7,5 @@ retry_wait_time = 10 # default: 1s; survive transient network failures
 exclude = [
   '^http://opentelemetry-collector\.open-telemetry-system:4318',
   '^https://www\.gnu\.org/software/make/',                       # often returns 429
+  '^https://kubernetes\.slack\.com/archives/CKZJ36A5D',
 ]


### PR DESCRIPTION
Often fails in CI with 403 despite being valid.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))


