### PR TITLE
refactor: extract e2e-deps-external make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,9 @@ e2e-test-images: ## Build all test images under test/images/ and push to $KO_DOC
 	# --base-import-paths prevents the hash suffix in image names
 	ko build --base-import-paths ./test/images/*/
 
-e2e-deps: e2e-deps-cert-manager e2e-deps-jaeger e2e-deps-keda e2e-deps-otel-collector ## Install all e2e dependencies
+e2e-deps-external: e2e-deps-cert-manager e2e-deps-jaeger e2e-deps-otel-collector ## Install non-KEDA e2e deps
+
+e2e-deps: e2e-deps-external e2e-deps-keda ## Install all e2e dependencies
 
 e2e-deps-cert-manager: $(HELM)
 	$(HELM) repo add jetstack https://charts.jetstack.io --force-update


### PR DESCRIPTION
Groups the e2e dependencies unrelated to KEDA/HTTP Add-on installation into a single target so simplify e2e tests with existing KEDA installations.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))
