### PR TITLE
chore: scan test dependencies with Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,10 +9,12 @@
     ":gitSignOff",
     ":prHourlyLimitNone",
   ],
+  ignorePresets: [":ignoreModulesAndTests"],
   commitBodyTable: true,
   kubernetes: {
     managerFilePatterns: ["/(config|examples)/.+\\.ya?ml$/"],
   },
+  ignorePaths: ["**/vendor/**"],
   labels: ["dependencies"],
   // Experimental: OSV-based vulnerability alerts for direct dependencies
   osvVulnerabilityAlerts: true,


### PR DESCRIPTION
Renovate's recommended preset ignores test directories, hiding dependencies declared in test helpers. Keep vendor paths ignored while allowing Renovate to discover test dependencies, even if we dont need vendor right now.

Same as in https://github.com/kedacore/keda/pull/8096

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))
