### PR TITLE
fix(ci): track kind version in the HTTPSO e2e job

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -117,10 +117,13 @@ jobs:
 
       - name: Create Kind Cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        env:
+          # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+          KIND_VERSION: "v0.32.0"
         with:
           node_image: kindest/node:${{ matrix.kindVersion }}
           cluster_name: kind
-          version: v0.31.0
+          version: ${{ env.KIND_VERSION }}
 
       - name: Show Kubernetes version
         run: kubectl version


### PR DESCRIPTION
The HTTPSO e2e job hardcodes the kind binary version with no Renovate annotation, while the other e2e job tracks it through an annotated `KIND_VERSION` env var:

```yaml
# e2e_tests (tracked)
        env:
          # renovate: datasource=github-releases depName=kubernetes-sigs/kind
          KIND_VERSION: "v0.32.0"
        with:
          version: ${{ env.KIND_VERSION }}

# e2e_tests_legacy (not tracked)
        with:
          version: v0.31.0
```

Both matrices list the same `kindest/node` images and both are Renovate-annotated, so Renovate bumps the node images in lockstep but the kind binary in only one job. The HTTPSO job then drifts further behind on every Kubernetes bump until it can no longer create a cluster for the node image it is handed.

That is the current failure on #1771. kind v0.31.0 emits a `kubeadm.k8s.io/v1beta3` `ClusterConfiguration`, which Kubernetes v1.37 rejects outright:

```
ERROR: failed to create cluster: failed to init node with kubeadm
error: your configuration file uses an old API spec: "kubeadm.k8s.io/v1beta3" (kind: "ClusterConfiguration")
```

The regular e2e jobs pass on v1.37 in that same run because they are on kind v0.32.0 — only the HTTPSO variants fail, which is what makes it look like an add-on bug rather than a CI config drift.

This aligns the HTTPSO job with the existing pattern so Renovate keeps both in sync from here on. Set to v0.32.0 to match the other job's current pinned version; #1771 can then move both to v0.33.0 together.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

<!-- CI-only change, no user-facing behavior to document in the changelog. -->