### PR TITLE
fix: avoid TLS e2e certificate mount collision

### DIFF
--- a/test/helpers/deployment.go
+++ b/test/helpers/deployment.go
@@ -120,7 +120,9 @@ func WithEnvVar(name, value string) PatchDeploymentOption {
 }
 
 // WithTLSCert creates a certificate for the given DNS names using cert-manager
-// and mounts the resulting secret into the deployment at /certs.
+// and mounts the resulting secret into the deployment at /test-certs.
+// KEDA OLM Operator mounts its OpenShift serving certificate at /certs,
+// so test certificates must use another path to avoid conflicts.
 func WithTLSCert(dnsNames []string) PatchDeploymentOption {
 	return func(ctx context.Context, client klient.Client, dep *appsv1.Deployment) error {
 		certName, err := createCertificate(ctx, client, dep.Namespace, caIssuerFromContext(ctx), dnsNames)
@@ -137,12 +139,18 @@ func WithTLSCert(dnsNames []string) PatchDeploymentOption {
 			},
 		)
 		for i := range dep.Spec.Template.Spec.Containers {
-			dep.Spec.Template.Spec.Containers[i].VolumeMounts = append(
-				dep.Spec.Template.Spec.Containers[i].VolumeMounts,
+			container := &dep.Spec.Template.Spec.Containers[i]
+			container.VolumeMounts = append(
+				container.VolumeMounts,
 				corev1.VolumeMount{
 					Name:      tlsCertsVolume,
-					MountPath: "/certs",
+					MountPath: "/test-certs",
+					ReadOnly:  true,
 				},
+			)
+			container.Env = append(container.Env,
+				corev1.EnvVar{Name: "KEDA_HTTP_PROXY_TLS_CERT_PATH", Value: "/test-certs/tls.crt"},
+				corev1.EnvVar{Name: "KEDA_HTTP_PROXY_TLS_KEY_PATH", Value: "/test-certs/tls.key"},
 			)
 		}
 		return nil


### PR DESCRIPTION
The TLS e2e helper mounted its test certificate at /certs, which conflicts with the serving certificate mount added by the KEDA OLM Operator on OpenShift. When running the e2e tests in an OpenShift cluster with TLS enabled, we would get a conflict.

Mount test certificates at a separate path and configure the interceptor to use it.

Related OLM operator code: https://github.com/kedacore/keda-olm-operator/blob/3be7fa342b897ccd5b7c8090e4affbb48456db89/internal/controller/keda/transform/transform.go#L1675

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md
-->



### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

