### PR TITLE
ci: track patch updates for older Kubernetes versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -84,6 +84,12 @@
       groupName: "Pre-commit Hooks",
     },
     {
+      // Split patch and minor updates for dependencies pinned to older versions.
+      matchManagers: ["custom.regex"],
+      matchDepNames: ["/@only-patch/"],
+      separateMinorPatch: true,
+    },
+    {
       matchManagers: ["custom.regex"],
       matchDepNames: ["/@only-patch/"],
       matchUpdateTypes: ["minor", "major"],

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -26,9 +26,9 @@ jobs:
           # renovate: datasource=docker depName=kindest/node
           - v1.37.0
           # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node
-          - v1.35.1
+          - v1.36.1
           # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node
-          - v1.34.3
+          - v1.35.1
         include:
           - arch: AMD64
             runner: ubuntu-latest
@@ -88,9 +88,9 @@ jobs:
           # renovate: datasource=docker depName=kindest/node
           - v1.37.0
           # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node
-          - v1.35.1
+          - v1.36.1
           # renovate: datasource=docker depName=kindest/node@only-patch packageName=kindest/node
-          - v1.34.3
+          - v1.35.1
         include:
           - arch: AMD64
             runner: ubuntu-latest


### PR DESCRIPTION
Renovate did not produce patch candidates for older Kubernetes node image tracks because minor and patch updates were not separated for custom regex dependencies.
Verified by running renovate locally.

**Changes:**
- Split minor and patch updates for @only-patch dependencies.
- Keep the e2e matrix on Kubernetes v1.37.0, v1.36.1, and v1.35.1.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))

