### PR TITLE
fix: extend duration buckets and classify cold-start requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Improvements
 
+- **Interceptor**: Extend `interceptor_request_duration_seconds` buckets up to `300s` (was `10s`) and add a `cold_start` label to both `interceptor_request_duration_seconds` and `interceptor_request_count_total`, identifying requests that waited for backend readiness, including waits that ended before the backend became ready ([#1776](https://github.com/kedacore/http-add-on/issues/1776))
 - **Interceptor**: The forwarding transport sets TLS `ServerName` per-dial via `DialTLSContext`, using the original service hostname captured in context, so SNI stays correct when the upstream URL is rewritten to a pod IP. ([#1473](https://github.com/kedacore/http-add-on/issues/1473))
 - **Interceptor**: TLS server name is captured in context by the routing middleware before any URL rewrites, so downstream transports always use the original service hostname for SNI. The routing middleware also resolves the upstream named port into context to drive direct-pod target selection. ([#1473](https://github.com/kedacore/http-add-on/issues/1473))
 - **Interceptor**: Use certwatcher for the default serving certificate, enabling automatic reload on certificate rotation without restarts. ([#1715](https://github.com/kedacore/http-add-on/issues/1715))

--- a/interceptor/metrics/instruments.go
+++ b/interceptor/metrics/instruments.go
@@ -21,6 +21,7 @@ const (
 	MetricColdStartRejections = "interceptor.cold_start.rejections"
 
 	AttrCode           = "code"
+	AttrColdStart      = "cold_start"
 	AttrMethod         = "method"
 	AttrRouteName      = "route_name"
 	AttrRouteNamespace = "route_namespace"
@@ -29,6 +30,14 @@ const (
 	// following the OTel semantic convention prefix for synthetic values.
 	MethodOther = "_OTHER"
 )
+
+// RequestDurationBucketBoundaries are the bucket boundaries (seconds) for MetricRequestDuration.
+// Below 10s: OTel HTTP semconv defaults, see https://opentelemetry.io/docs/specs/semconv/http/http-metrics/ .
+// Above 10s: extended to make longer cold-start request durations visible.
+var RequestDurationBucketBoundaries = []float64{
+	0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
+	15, 30, 60, 120, 300,
+}
 
 // standardMethods is the set of HTTP methods that pass through normalization.
 // Non-standard methods are mapped to MethodOther to bound cardinality.
@@ -77,10 +86,7 @@ func NewInstruments(provider *sdkmetric.MeterProvider) (*Instruments, error) {
 		MetricRequestDuration,
 		api.WithDescription("Time from request received to response written"),
 		api.WithUnit("s"),
-		// Bucket boundaries from OTel HTTP semconv: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/
-		api.WithExplicitBucketBoundaries(
-			0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
-		),
+		api.WithExplicitBucketBoundaries(RequestDurationBucketBoundaries...),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating request duration histogram: %w", err)
@@ -118,9 +124,10 @@ func normalizeMethod(method string) string {
 }
 
 // RecordRequest records a completed request with bounded labels.
-func (i *Instruments) RecordRequest(method string, code int, routeName, routeNamespace string, duration time.Duration) {
+func (i *Instruments) RecordRequest(method string, code int, routeName, routeNamespace string, isColdStart bool, duration time.Duration) {
 	attrs := api.WithAttributeSet(attribute.NewSet(
 		attribute.Int(AttrCode, code),
+		attribute.Bool(AttrColdStart, isColdStart),
 		attribute.String(AttrMethod, normalizeMethod(method)),
 		attribute.String(AttrRouteName, routeName),
 		attribute.String(AttrRouteNamespace, routeNamespace),

--- a/interceptor/metrics/prometheus_test.go
+++ b/interceptor/metrics/prometheus_test.go
@@ -47,14 +47,14 @@ func testRegistry(t *testing.T) (*prometheus.Registry, *Instruments) {
 func TestPrometheus_RequestMetrics(t *testing.T) {
 	registry, instruments := testRegistry(t)
 
-	instruments.RecordRequest("GET", 200, "my-route", "my-ns", 100*time.Millisecond)
-	instruments.RecordRequest("POST", 500, "my-route", "my-ns", 200*time.Millisecond)
+	instruments.RecordRequest("GET", 200, "my-route", "my-ns", false, 100*time.Millisecond)
+	instruments.RecordRequest("POST", 500, "my-route", "my-ns", false, 200*time.Millisecond)
 
 	expected := `
 		# HELP interceptor_request_count_total Total requests processed by the interceptor proxy
 		# TYPE interceptor_request_count_total counter
-		interceptor_request_count_total{code="200",method="GET",route_name="my-route",route_namespace="my-ns"} 1
-		interceptor_request_count_total{code="500",method="POST",route_name="my-route",route_namespace="my-ns"} 1
+		interceptor_request_count_total{code="200",cold_start="false",method="GET",route_name="my-route",route_namespace="my-ns"} 1
+		interceptor_request_count_total{code="500",cold_start="false",method="POST",route_name="my-route",route_namespace="my-ns"} 1
 	`
 	if err := testutil.CollectAndCompare(registry, strings.NewReader(expected), "interceptor_request_count_total"); err != nil {
 		t.Fatalf("unexpected metrics output:\n%v", err)
@@ -64,47 +64,57 @@ func TestPrometheus_RequestMetrics(t *testing.T) {
 func TestPrometheus_DurationMetrics(t *testing.T) {
 	registry, instruments := testRegistry(t)
 
-	instruments.RecordRequest("GET", 200, "app-alpha", "production", 30*time.Millisecond)
-	instruments.RecordRequest("GET", 200, "app-alpha", "production", 3*time.Second)
-	instruments.RecordRequest("POST", 503, "app-beta", "staging", 12*time.Second)
+	instruments.RecordRequest("GET", 200, "app-alpha", "production", false, 30*time.Millisecond)
+	instruments.RecordRequest("GET", 200, "app-alpha", "production", false, 3*time.Second)
+	instruments.RecordRequest("POST", 503, "app-beta", "staging", true, 12*time.Second)
 
 	expected := `
 		# HELP interceptor_request_duration_seconds Time from request received to response written
 		# TYPE interceptor_request_duration_seconds histogram
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="0.005"} 0
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="0.01"} 0
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="0.025"} 0
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="0.05"} 1
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="0.075"} 1
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="0.1"} 1
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="0.25"} 1
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="0.5"} 1
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="0.75"} 1
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="1"} 1
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="2.5"} 1
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="5"} 2
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="7.5"} 2
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="10"} 2
-		interceptor_request_duration_seconds_bucket{code="200",method="GET",route_name="app-alpha",route_namespace="production",le="+Inf"} 2
-		interceptor_request_duration_seconds_sum{code="200",method="GET",route_name="app-alpha",route_namespace="production"} 3.03
-		interceptor_request_duration_seconds_count{code="200",method="GET",route_name="app-alpha",route_namespace="production"} 2
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="0.005"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="0.01"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="0.025"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="0.05"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="0.075"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="0.1"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="0.25"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="0.5"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="0.75"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="1"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="2.5"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="5"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="7.5"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="10"} 0
-		interceptor_request_duration_seconds_bucket{code="503",method="POST",route_name="app-beta",route_namespace="staging",le="+Inf"} 1
-		interceptor_request_duration_seconds_sum{code="503",method="POST",route_name="app-beta",route_namespace="staging"} 12
-		interceptor_request_duration_seconds_count{code="503",method="POST",route_name="app-beta",route_namespace="staging"} 1
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="0.005"} 0
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="0.01"} 0
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="0.025"} 0
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="0.05"} 1
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="0.075"} 1
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="0.1"} 1
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="0.25"} 1
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="0.5"} 1
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="0.75"} 1
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="1"} 1
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="2.5"} 1
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="5"} 2
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="7.5"} 2
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="10"} 2
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="15"} 2
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="30"} 2
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="60"} 2
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="120"} 2
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="300"} 2
+		interceptor_request_duration_seconds_bucket{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production",le="+Inf"} 2
+		interceptor_request_duration_seconds_sum{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production"} 3.03
+		interceptor_request_duration_seconds_count{code="200",cold_start="false",method="GET",route_name="app-alpha",route_namespace="production"} 2
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="0.005"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="0.01"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="0.025"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="0.05"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="0.075"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="0.1"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="0.25"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="0.5"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="0.75"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="1"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="2.5"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="5"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="7.5"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="10"} 0
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="15"} 1
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="30"} 1
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="60"} 1
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="120"} 1
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="300"} 1
+		interceptor_request_duration_seconds_bucket{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging",le="+Inf"} 1
+		interceptor_request_duration_seconds_sum{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging"} 12
+		interceptor_request_duration_seconds_count{code="503",cold_start="true",method="POST",route_name="app-beta",route_namespace="staging"} 1
 	`
 	if err := testutil.CollectAndCompare(registry, strings.NewReader(expected), "interceptor_request_duration_seconds"); err != nil {
 		t.Fatalf("unexpected metrics output:\n%v", err)

--- a/interceptor/middleware/endpoint_resolver.go
+++ b/interceptor/middleware/endpoint_resolver.go
@@ -66,6 +66,11 @@ func (er *EndpointResolver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	serviceKey := ir.Namespace + "/" + ir.Spec.Target.Service
 	isColdStart, podHost, err := er.readyCache.WaitForReady(waitCtx, serviceKey, util.UpstreamPortNameFromContext(ctx))
+	if info := routeInfoFromContext(ctx); info != nil {
+		// An error means the request waited for readiness but the backend did
+		// not become ready before the wait ended.
+		info.IsColdStart = isColdStart || err != nil
+	}
 	if err != nil {
 		// No fallback, return an error
 		if !hasFallback {

--- a/interceptor/middleware/endpoint_resolver_test.go
+++ b/interceptor/middleware/endpoint_resolver_test.go
@@ -455,6 +455,8 @@ func TestEndpointResolver_RouteSpecReadinessOverride(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := newRequest(t, ir)
+	info := &routeInfo{}
+	req = req.WithContext(contextWithRouteInfo(req.Context(), info))
 	mw.ServeHTTP(rec, req)
 
 	if nextCalled {
@@ -462,6 +464,9 @@ func TestEndpointResolver_RouteSpecReadinessOverride(t *testing.T) {
 	}
 	if got, want := rec.Code, http.StatusGatewayTimeout; got != want {
 		t.Fatalf("status code = %d, want %d", got, want)
+	}
+	if !info.IsColdStart {
+		t.Fatal("expected timed-out readiness wait to be marked as cold start")
 	}
 }
 

--- a/interceptor/middleware/metrics.go
+++ b/interceptor/middleware/metrics.go
@@ -36,7 +36,7 @@ func (m *Metrics) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 
 	defer func() {
-		m.instruments.RecordRequest(r.Method, rw.statusCode, info.Name, info.Namespace, time.Since(start))
+		m.instruments.RecordRequest(r.Method, rw.statusCode, info.Name, info.Namespace, info.IsColdStart, time.Since(start))
 	}()
 
 	m.next.ServeHTTP(rw, r)

--- a/interceptor/middleware/metrics_test.go
+++ b/interceptor/middleware/metrics_test.go
@@ -48,8 +48,38 @@ func TestMetrics_RecordsRequestWithRouteInfo(t *testing.T) {
 	assertIntAttr(t, dp.Attributes, metrics.AttrCode, int64(http.StatusOK))
 	assertStringAttr(t, dp.Attributes, metrics.AttrRouteName, "test-route")
 	assertStringAttr(t, dp.Attributes, metrics.AttrRouteNamespace, "test-ns")
+	assertBoolAttr(t, dp.Attributes, metrics.AttrColdStart, false)
 
 	requireMetric(t, rm, metrics.MetricRequestDuration)
+}
+
+func TestMetrics_RecordsColdStart(t *testing.T) {
+	instruments, reader := testInstruments(t)
+
+	// Simulate EndpointResolver marking the request as a cold start.
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ri := routeInfoFromContext(r.Context()); ri != nil {
+			ri.Name = "test-route"
+			ri.Namespace = "test-ns"
+			ri.IsColdStart = true
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := NewMetrics(next, instruments)
+
+	req := httptest.NewRequest("GET", "/some/path", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+
+	m := requireMetric(t, rm, metrics.MetricRequestCount)
+	dp := m.Data.(metricdata.Sum[int64]).DataPoints[0]
+	assertBoolAttr(t, dp.Attributes, metrics.AttrColdStart, true)
 }
 
 func TestMetrics_UnmatchedRoute(t *testing.T) {
@@ -75,6 +105,7 @@ func TestMetrics_UnmatchedRoute(t *testing.T) {
 
 	dp := m.Data.(metricdata.Sum[int64]).DataPoints[0]
 	assertStringAttr(t, dp.Attributes, metrics.AttrRouteName, "")
+	assertBoolAttr(t, dp.Attributes, metrics.AttrColdStart, false)
 }
 
 func testInstruments(t *testing.T) (*metrics.Instruments, sdkmetric.Reader) {
@@ -105,5 +136,13 @@ func assertIntAttr(t *testing.T, attrs attribute.Set, key string, want int64) {
 	v, _ := attrs.Value(attribute.Key(key))
 	if got := v.AsInt64(); got != want {
 		t.Fatalf("attribute %s: got %d, want %d", key, got, want)
+	}
+}
+
+func assertBoolAttr(t *testing.T, attrs attribute.Set, key string, want bool) {
+	t.Helper()
+	v, _ := attrs.Value(attribute.Key(key))
+	if got := v.AsBool(); got != want {
+		t.Fatalf("attribute %s: got %t, want %t", key, got, want)
 	}
 }

--- a/interceptor/middleware/routeinfo.go
+++ b/interceptor/middleware/routeinfo.go
@@ -12,6 +12,9 @@ const routeInfoKey contextKeyType = iota
 type routeInfo struct {
 	Name      string
 	Namespace string
+	// IsColdStart is true when the request waited for backend readiness,
+	// including waits that ended before the backend became ready.
+	IsColdStart bool
 }
 
 func contextWithRouteInfo(ctx context.Context, info *routeInfo) context.Context {


### PR DESCRIPTION
interceptor_request_duration_seconds topped out at a 10s bucket, so any request held while its backend scaled from zero collapsed into +Inf, indistinguishable from a stuck request. Widen the histogram a bit, and add a cold_start label so cold and warm request latency can be queried separately.

**Changes:**
- Extend request duration bucket boundaries from 10s up to 300s
- Add a cold_start label to interceptor_request_duration_seconds, set from the existing EndpointResolver readiness-wait result

**To the reviewers** please challenge the bucket boundaries, not sure what a good default here is but I understand the arguments in #1776 for higher boundaries.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))
	- https://github.com/kedacore/keda-docs/pull/1865

Fixes #1776 