### PR TITLE
feat: add cold-start duration metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This changelog keeps track of work items that have been completed and are ready 
 
 ### Improvements
 
+- **Interceptor**: Add `interceptor_cold_start_duration_seconds` histogram with `ready`, `timeout`, and `cancelled` outcomes to expose time spent waiting for scaled-from-zero backends to become ready ([#1721](https://github.com/kedacore/http-add-on/issues/1721))
 - **Interceptor**: Extend `interceptor_request_duration_seconds` buckets up to `300s` (was `10s`) and add a `cold_start` label to both `interceptor_request_duration_seconds` and `interceptor_request_count_total`, identifying requests that waited for backend readiness, including waits that ended before the backend became ready ([#1776](https://github.com/kedacore/http-add-on/issues/1776))
 - **Interceptor**: The forwarding transport sets TLS `ServerName` per-dial via `DialTLSContext`, using the original service hostname captured in context, so SNI stays correct when the upstream URL is rewritten to a pod IP. ([#1473](https://github.com/kedacore/http-add-on/issues/1473))
 - **Interceptor**: TLS server name is captured in context by the routing middleware before any URL rewrites, so downstream transports always use the original service hostname for SNI. The routing middleware also resolves the upstream named port into context to drive direct-pod target selection. ([#1473](https://github.com/kedacore/http-add-on/issues/1473))

--- a/interceptor/metrics/instruments.go
+++ b/interceptor/metrics/instruments.go
@@ -18,23 +18,29 @@ const (
 	MetricRequestConcurrency  = "interceptor.request.concurrency"
 	MetricRequestCount        = "interceptor.request.count"
 	MetricRequestDuration     = "interceptor.request.duration"
+	MetricColdStartDuration   = "interceptor.cold_start.duration"
 	MetricColdStartRejections = "interceptor.cold_start.rejections"
 
 	AttrCode           = "code"
 	AttrColdStart      = "cold_start"
 	AttrMethod         = "method"
+	AttrOutcome        = "outcome"
 	AttrRouteName      = "route_name"
 	AttrRouteNamespace = "route_namespace"
+
+	ColdStartOutcomeReady     = "ready"
+	ColdStartOutcomeTimeout   = "timeout"
+	ColdStartOutcomeCancelled = "cancelled"
 
 	// MethodOther is the normalized value for non-standard HTTP methods,
 	// following the OTel semantic convention prefix for synthetic values.
 	MethodOther = "_OTHER"
 )
 
-// RequestDurationBucketBoundaries are the bucket boundaries (seconds) for MetricRequestDuration.
+// durationBucketBoundaries are the bucket boundaries (seconds) for duration histograms.
 // Below 10s: OTel HTTP semconv defaults, see https://opentelemetry.io/docs/specs/semconv/http/http-metrics/ .
-// Above 10s: extended to make longer cold-start request durations visible.
-var RequestDurationBucketBoundaries = []float64{
+// Above 10s: extended to make longer cold-start durations visible.
+var durationBucketBoundaries = []float64{
 	0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
 	15, 30, 60, 120, 300,
 }
@@ -58,6 +64,7 @@ type Instruments struct {
 	pendingRequests     api.Int64UpDownCounter
 	requestCounter      api.Int64Counter
 	requestDuration     api.Float64Histogram
+	coldStartDuration   api.Float64Histogram
 	coldStartRejections api.Int64Counter
 }
 
@@ -86,10 +93,20 @@ func NewInstruments(provider *sdkmetric.MeterProvider) (*Instruments, error) {
 		MetricRequestDuration,
 		api.WithDescription("Time from request received to response written"),
 		api.WithUnit("s"),
-		api.WithExplicitBucketBoundaries(RequestDurationBucketBoundaries...),
+		api.WithExplicitBucketBoundaries(durationBucketBoundaries...),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating request duration histogram: %w", err)
+	}
+
+	coldStartDuration, err := meter.Float64Histogram(
+		MetricColdStartDuration,
+		api.WithDescription("Time spent waiting for a cold-start backend to become ready"),
+		api.WithUnit("s"),
+		api.WithExplicitBucketBoundaries(durationBucketBoundaries...),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating cold-start duration histogram: %w", err)
 	}
 
 	pendingRequests, err := meter.Int64UpDownCounter(
@@ -112,6 +129,7 @@ func NewInstruments(provider *sdkmetric.MeterProvider) (*Instruments, error) {
 		requestCounter:      requestCounter,
 		requestDuration:     requestDuration,
 		pendingRequests:     pendingRequests,
+		coldStartDuration:   coldStartDuration,
 		coldStartRejections: coldStartRejections,
 	}, nil
 }
@@ -134,6 +152,16 @@ func (i *Instruments) RecordRequest(method string, code int, routeName, routeNam
 	))
 	i.requestCounter.Add(context.Background(), 1, attrs)
 	i.requestDuration.Record(context.Background(), duration.Seconds(), attrs)
+}
+
+// RecordColdStartDuration records the time spent waiting for backend readiness.
+func (i *Instruments) RecordColdStartDuration(routeName, routeNamespace, outcome string, duration time.Duration) {
+	attrs := api.WithAttributeSet(attribute.NewSet(
+		attribute.String(AttrOutcome, outcome),
+		attribute.String(AttrRouteName, routeName),
+		attribute.String(AttrRouteNamespace, routeNamespace),
+	))
+	i.coldStartDuration.Record(context.Background(), duration.Seconds(), attrs)
 }
 
 // RecordPendingRequest increments or decrements the pending request gauge.

--- a/interceptor/metrics/prometheus_test.go
+++ b/interceptor/metrics/prometheus_test.go
@@ -121,6 +121,42 @@ func TestPrometheus_DurationMetrics(t *testing.T) {
 	}
 }
 
+func TestPrometheus_ColdStartDurationMetrics(t *testing.T) {
+	registry, instruments := testRegistry(t)
+
+	instruments.RecordColdStartDuration("my-route", "my-ns", "ready", 12*time.Second)
+
+	expected := `
+		# HELP interceptor_cold_start_duration_seconds Time spent waiting for a cold-start backend to become ready
+		# TYPE interceptor_cold_start_duration_seconds histogram
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="0.005"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="0.01"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="0.025"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="0.05"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="0.075"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="0.1"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="0.25"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="0.5"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="0.75"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="1"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="2.5"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="5"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="7.5"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="10"} 0
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="15"} 1
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="30"} 1
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="60"} 1
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="120"} 1
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="300"} 1
+		interceptor_cold_start_duration_seconds_bucket{outcome="ready",route_name="my-route",route_namespace="my-ns",le="+Inf"} 1
+		interceptor_cold_start_duration_seconds_sum{outcome="ready",route_name="my-route",route_namespace="my-ns"} 12
+		interceptor_cold_start_duration_seconds_count{outcome="ready",route_name="my-route",route_namespace="my-ns"} 1
+	`
+	if err := testutil.CollectAndCompare(registry, strings.NewReader(expected), "interceptor_cold_start_duration_seconds"); err != nil {
+		t.Fatalf("unexpected metrics output:\n%v", err)
+	}
+}
+
 func TestPrometheus_ConcurrencyMetrics(t *testing.T) {
 	registry, instruments := testRegistry(t)
 

--- a/interceptor/middleware/endpoint_resolver.go
+++ b/interceptor/middleware/endpoint_resolver.go
@@ -2,12 +2,14 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/kedacore/http-add-on/interceptor/handler"
+	"github.com/kedacore/http-add-on/interceptor/metrics"
 	kedahttp "github.com/kedacore/http-add-on/pkg/http"
 	"github.com/kedacore/http-add-on/pkg/k8s"
 	"github.com/kedacore/http-add-on/pkg/util"
@@ -19,6 +21,7 @@ type EndpointResolverConfig struct {
 	ReadinessTimeout      time.Duration
 	EnableColdStartHeader bool
 	DirectPodRouting      bool // route every request to a pod IP instead of the ClusterIP service
+	Instruments           *metrics.Instruments
 }
 
 type EndpointResolver struct {
@@ -65,11 +68,23 @@ func (er *EndpointResolver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	serviceKey := ir.Namespace + "/" + ir.Spec.Target.Service
+	waitStart := time.Now()
 	isColdStart, podHost, err := er.readyCache.WaitForReady(waitCtx, serviceKey, util.UpstreamPortNameFromContext(ctx))
 	if info := routeInfoFromContext(ctx); info != nil {
 		// An error means the request waited for readiness but the backend did
 		// not become ready before the wait ended.
 		info.IsColdStart = isColdStart || err != nil
+	}
+
+	if er.cfg.Instruments != nil && (isColdStart || err != nil) {
+		outcome := metrics.ColdStartOutcomeReady
+		switch {
+		case errors.Is(err, context.Canceled):
+			outcome = metrics.ColdStartOutcomeCancelled
+		case err != nil:
+			outcome = metrics.ColdStartOutcomeTimeout
+		}
+		er.cfg.Instruments.RecordColdStartDuration(ir.Name, ir.Namespace, outcome, time.Since(waitStart))
 	}
 	if err != nil {
 		// No fallback, return an error

--- a/interceptor/middleware/endpoint_resolver_test.go
+++ b/interceptor/middleware/endpoint_resolver_test.go
@@ -10,9 +10,12 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	discov1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	interceptormetrics "github.com/kedacore/http-add-on/interceptor/metrics"
 	httpv1beta1 "github.com/kedacore/http-add-on/operator/apis/http/v1beta1"
 	kedahttp "github.com/kedacore/http-add-on/pkg/http"
 	"github.com/kedacore/http-add-on/pkg/k8s"
@@ -317,6 +320,111 @@ func TestEndpointResolver_ColdStart(t *testing.T) {
 			if got, want := rec.Header().Get(kedahttp.HeaderColdStart), tt.wantColdStartHeader; got != want {
 				t.Fatalf("cold-start header = %q, want %q", got, want)
 			}
+		})
+	}
+}
+
+func TestEndpointResolver_RecordsColdStartDuration(t *testing.T) {
+	tests := map[string]struct {
+		readyBefore  bool
+		readyAfter   bool
+		cancelBefore bool
+		wantOutcome  string
+	}{
+		"warm request is not recorded": {
+			readyBefore: true,
+		},
+		"backend becomes ready": {
+			readyAfter:  true,
+			wantOutcome: interceptormetrics.ColdStartOutcomeReady,
+		},
+		"backend does not become ready": {
+			wantOutcome: interceptormetrics.ColdStartOutcomeTimeout,
+		},
+		"client cancels request": {
+			cancelBefore: true,
+			wantOutcome:  interceptormetrics.ColdStartOutcomeCancelled,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				reader := metric.NewManualReader()
+				provider := metric.NewMeterProvider(metric.WithReader(reader))
+				t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+				instruments, err := interceptormetrics.NewInstruments(provider)
+				if err != nil {
+					t.Fatalf("NewInstruments() error: %v", err)
+				}
+
+				cache := k8s.NewReadyEndpointsCache(logr.Discard())
+				if tt.readyBefore {
+					addReadyEndpoint(cache)
+				}
+				if tt.readyAfter {
+					go func() {
+						time.Sleep(10 * time.Millisecond)
+						addReadyEndpoint(cache)
+					}()
+				}
+
+				next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				})
+				ir := defaultIR()
+				ir.Name = "test-route"
+				mw := NewEndpointResolver(next, cache, EndpointResolverConfig{
+					ReadinessTimeout: 50 * time.Millisecond,
+					Instruments:      instruments,
+				})
+
+				req := newRequest(t, ir)
+				if tt.cancelBefore {
+					ctx, cancel := context.WithCancel(req.Context())
+					cancel()
+					req = req.WithContext(ctx)
+				}
+				mw.ServeHTTP(httptest.NewRecorder(), req)
+
+				var rm metricdata.ResourceMetrics
+				if err := reader.Collect(context.Background(), &rm); err != nil {
+					t.Fatalf("Collect() error: %v", err)
+				}
+
+				var coldStartMetric *metricdata.Metrics
+			findMetric:
+				for _, scope := range rm.ScopeMetrics {
+					for i := range scope.Metrics {
+						if scope.Metrics[i].Name == interceptormetrics.MetricColdStartDuration {
+							coldStartMetric = &scope.Metrics[i]
+							break findMetric
+						}
+					}
+				}
+				if tt.wantOutcome == "" {
+					if coldStartMetric != nil {
+						t.Fatal("warm request should not record cold-start duration")
+					}
+					return
+				}
+				if coldStartMetric == nil {
+					t.Fatal("cold-start duration metric was not recorded")
+				}
+
+				histogram, ok := coldStartMetric.Data.(metricdata.Histogram[float64])
+				if !ok || len(histogram.DataPoints) != 1 {
+					t.Fatalf("unexpected histogram data: %#v", coldStartMetric.Data)
+				}
+				dp := histogram.DataPoints[0]
+				assertStringAttr(t, dp.Attributes, interceptormetrics.AttrOutcome, tt.wantOutcome)
+				assertStringAttr(t, dp.Attributes, interceptormetrics.AttrRouteName, "test-route")
+				assertStringAttr(t, dp.Attributes, interceptormetrics.AttrRouteNamespace, testNamespace)
+				if dp.Count != 1 {
+					t.Fatalf("cold-start duration count = %d, want 1", dp.Count)
+				}
+			})
 		})
 	}
 }

--- a/interceptor/proxy.go
+++ b/interceptor/proxy.go
@@ -72,6 +72,7 @@ func BuildProxyHandler(cfg *ProxyHandlerConfig) http.Handler {
 		ReadinessTimeout:      cfg.Timeouts.Readiness,
 		EnableColdStartHeader: cfg.Serving.EnableColdStartHeader,
 		DirectPodRouting:      cfg.Serving.DirectPodRouting,
+		Instruments:           cfg.Instruments,
 	})
 
 	h = middleware.NewColdStart(h, cfg.ReadyCache, cfg.Reader, cfg.Queue, cfg.Instruments, middleware.ColdStartConfig{


### PR DESCRIPTION
Add a new histogram to allow admins to see how long cold-starts take and for which reason (normal wait, error, request cancellation).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin ([DCO](https://developercertificate.org/))
- [x] Changelog is updated per our [changelog requirements](https://github.com/kedacore/http-add-on/blob/main/CONTRIBUTING.md#updating-the-changelog)
- [x] Documentation is updated if needed ([`README.md`](../README.md), [keda-docs](https://github.com/kedacore/keda-docs/tree/main/content/http-add-on))
	- https://github.com/kedacore/keda-docs/pull/1865

Fixes #1721 
